### PR TITLE
Array sizes can be constant expressions.

### DIFF
--- a/src/parser/AST.cpp
+++ b/src/parser/AST.cpp
@@ -19,11 +19,11 @@ ASTProgram* ASTProgram::clone() const
 ASTFloat::ASTFloat(char *Value, int Type, LocationData Loc)
 		: AST(Loc), type(Type), negative(false), val((string)Value)
 {}
-    
+
 ASTFloat::ASTFloat(const char *Value, int Type, LocationData Loc)
 		: AST(Loc), type(Type), negative(false), val((string)Value)
 {}
-    
+
 ASTFloat::ASTFloat(string Value, int Type, LocationData Loc)
 		: AST(Loc), type(Type), negative(false), val(Value)
 {}
@@ -157,12 +157,12 @@ ASTString* ASTString::clone() const
 ASTBlock::~ASTBlock()
 {
     list<ASTStmt *>::iterator it;
-    
+
     for (it = statements.begin(); it != statements.end(); it++)
     {
         delete *it;
     }
-    
+
     statements.clear();
 }
 
@@ -212,9 +212,9 @@ ASTStmtIf* ASTStmtIf::clone() const
 			stmt != NULL ? stmt->clone() : NULL,
 			getLocation());
 }
-    
+
 // ASTStmtIfElse
-    
+
 ASTStmtIfElse::ASTStmtIfElse(ASTExpr *Cond, ASTStmt *Ifstmt, ASTStmt *Elsestmt, LocationData Loc)
 		: ASTStmtIf(Cond, Ifstmt, Loc), elsestmt(Elsestmt)
 {}
@@ -440,8 +440,8 @@ void ASTFuncDecl::addParam(ASTVarDecl *param)
 
 // ASTArrayDecl
 
-ASTArrayDecl::ASTArrayDecl(ASTType *Type, string Name, AST *Size, bool isReg, ASTArrayList *List, LocationData Loc)
-		: ASTDecl(Loc), name(Name), list(List), size(Size), type(Type), reg(isReg)
+ASTArrayDecl::ASTArrayDecl(ASTType *Type, string Name, ASTExpr *Size, ASTArrayList *List, LocationData Loc)
+		: ASTDecl(Loc), name(Name), list(List), size(Size), type(Type)
 {}
 
 ASTArrayDecl::~ASTArrayDecl()
@@ -455,7 +455,7 @@ ASTArrayDecl* ASTArrayDecl::clone() const
 {
 	ASTArrayList* c_list = NULL;
 	if (list != NULL) c_list = list->clone();
-	return new ASTArrayDecl(type->clone(), name, size->clone(), reg, c_list, getLocation());
+	return new ASTArrayDecl(type->clone(), name, size->clone(), c_list, getLocation());
 }
 
 // ASTArrayList
@@ -519,6 +519,14 @@ ASTVarDeclInitializer* ASTVarDeclInitializer::clone() const
 
 // ASTExpr
 
+void ASTExpr::setIntValue(long val)
+{
+	hasval = true;
+	intval=val;
+}
+
+// ASTExprConst
+
 // ASTNumConstant
 
 ASTNumConstant* ASTNumConstant::clone() const
@@ -546,6 +554,7 @@ ASTExprDot* ASTExprDot::clone() const
 	ASTExprDot* c = new ASTExprDot(nspace, name, getLocation());
 	if (hasIntValue()) c->setIntValue(getIntValue());
 	c->setType(getType());
+	if (isConstant()) {c->markConstant();}
 	return c;
 }
 
@@ -861,7 +870,7 @@ ASTExprTimes* ASTExprTimes::clone() const
 }
 
 // ASTExprDivide
-    
+
 ASTExprDivide* ASTExprDivide::clone() const
 {
 	ASTExprDivide* c = new ASTExprDivide(getLocation());
@@ -1008,30 +1017,30 @@ ASTTypeItem* ASTTypeItem::clone() const
 {
 	return new ASTTypeItem(getLocation());
 }
-            
+
 // ASTTypeItemclass
-        
+
 ASTTypeItemclass* ASTTypeItemclass::clone() const
 {
 	return new ASTTypeItemclass(getLocation());
 }
-        
+
 // ASTTypeNPC
-    
+
 ASTTypeNPC* ASTTypeNPC::clone() const
 {
 	return new ASTTypeNPC(getLocation());
 }
-        
+
 // ASTTypeLWpn
-        
+
 ASTTypeLWpn* ASTTypeLWpn::clone() const
 {
 	return new ASTTypeLWpn(getLocation());
 }
-        
+
 // ASTTypeEWpn
-    
+
 ASTTypeEWpn* ASTTypeEWpn::clone() const
 {
 	return new ASTTypeEWpn(getLocation());

--- a/src/parser/AST.h
+++ b/src/parser/AST.h
@@ -61,6 +61,7 @@ class ASTVarDecl;
 class ASTVarDeclInitializer;
 // Expressions
 class ASTExpr; // virtual
+class ASTExprConst;
 class ASTNumConstant;
 class ASTBoolConstant;
 class ASTExprDot;
@@ -147,6 +148,7 @@ public:
     virtual void caseVarDecl(ASTVarDecl &, void *param) {caseDefault(param);}
     virtual void caseVarDeclInitializer(ASTVarDeclInitializer &, void *param) {caseDefault(param);}
 	// Expressions
+    virtual void caseExprConst(ASTExprConst &, void *param) {caseDefault(param);}
     virtual void caseNumConstant(ASTNumConstant &, void *param) {caseDefault(param);}
     virtual void caseBoolConstant(ASTBoolConstant &, void *param) {caseDefault(param);}
     virtual void caseExprDot(ASTExprDot &, void *param) {caseDefault(param);}
@@ -591,24 +593,21 @@ private:
 class ASTArrayDecl : public ASTDecl
 {
 public:
-    ASTArrayDecl(ASTType *Type, string Name, AST *Size, bool isReg, ASTArrayList *List, LocationData Loc);
+    ASTArrayDecl(ASTType *Type, string Name, ASTExpr *Size, ASTArrayList *List, LocationData Loc);
     ~ASTArrayDecl();
 	ASTArrayDecl* clone() const;
 
     ASTType *getType() const {return type;}
     string getName() const {return name;}
 
-    // If reg, size is an ASTExpr. If not, it's an ASTFloat
-    AST *getSize() const {return size;}
-    bool isRegister() const {return reg;}
+    ASTExpr *getSize() const {return size;}
     ASTArrayList *getList() const {return list;}
     void execute(ASTVisitor &visitor, void *param) {visitor.caseArrayDecl(*this, param);}
 private:
     string name;
     ASTArrayList *list;
-    AST *size;
+    ASTExpr *size;
     ASTType *type;
-    bool reg;
     //NOT IMPLEMENTED; DO NOT USE
     ASTArrayDecl(ASTArrayDecl &);
     ASTArrayDecl &operator=(ASTArrayDecl &);
@@ -678,27 +677,13 @@ public:
     ASTExpr(LocationData Loc) : ASTStmt(Loc), hasval(false), intval(0), type(-1) {}
     virtual ~ASTExpr() {}
 	virtual ASTExpr* clone() const = 0;
-    long getIntValue() const
-    {
-        return intval;
-    }
-    bool hasIntValue() const
-    {
-        return hasval;
-    }
-    int getType() const
-    {
-        return type;
-    }
-    void setIntValue(long val)
-    {
-        hasval = true;
-        intval=val;
-    }
-    void setType(int t)
-    {
-        type=t;
-    }
+
+    long getIntValue() const {return intval;}
+    bool hasIntValue() const {return hasval;}
+    int getType() const {return type;}
+    void setIntValue(long val);
+    void setType(int t) {type = t;}
+	virtual bool isConstant() const = 0;
 private:
     bool hasval;
     long intval;
@@ -706,6 +691,22 @@ private:
     //NOT IMPLEMENTED; DO NOT USE
     ASTExpr(ASTExpr &);
     ASTExpr &operator=(ASTExpr &);
+};
+
+// Wrap around an expression to type it as constant.
+class ASTExprConst : public ASTExpr
+{
+public:
+    ASTExprConst(ASTExpr *Content) : ASTExpr(Content->getLocation()), content(Content) {}
+	ASTExprConst(ASTExpr *Content, LocationData Loc) : ASTExpr(Loc), content(Content) {}
+	~ASTExprConst() {delete content;}
+	ASTExprConst* clone() const {return new ASTExprConst(content->clone(), getLocation());}
+
+	ASTExpr* getContent() const {return content;}
+	bool isConstant() const {return true;}
+    void execute(ASTVisitor &visitor, void *param) {visitor.caseExprConst(*this, param);}
+private:
+	ASTExpr *content;
 };
 
 class ASTNumConstant : public ASTExpr
@@ -716,6 +717,7 @@ public:
 	ASTNumConstant* clone() const;
     
     ASTFloat *getValue() const {return val;}
+	bool isConstant() const {return true;}
     void execute(ASTVisitor &visitor, void *param) {visitor.caseNumConstant(*this, param);}
 private:
     ASTFloat *val;
@@ -728,6 +730,7 @@ public:
 	ASTBoolConstant* clone() const;
 
     bool getValue() const {return value;}
+	bool isConstant() const {return true;}
     void execute(ASTVisitor &visitor, void *param) {visitor.caseBoolConstant(*this, param);}
 private:
     bool value;
@@ -736,15 +739,18 @@ private:
 class ASTExprDot : public ASTExpr
 {
 public:
-    ASTExprDot(string Nspace, string Name, LocationData Loc) : ASTExpr(Loc), name(Name), nspace(Nspace) {}
+    ASTExprDot(string Nspace, string Name, LocationData Loc) : ASTExpr(Loc), name(Name), nspace(Nspace), _isConstant(false) {}
 	ASTExprDot* clone() const;
 
     string getName() const {return name;}
     string getNamespace() const {return nspace;}
+	bool isConstant() const {return _isConstant;}
+	void markConstant() {_isConstant = true;}
     void execute(ASTVisitor &visitor, void *param) {visitor.caseExprDot(*this, param);}
 private:
     string name;
     string nspace;
+	bool _isConstant;
 };
 
 class ASTExprArrow : public ASTExpr
@@ -758,6 +764,7 @@ public:
     ASTExpr *getLVal() const {return lval;}
     ASTExpr *getIndex() const {return index;}
     void setIndex(ASTExpr *e) {index = e;}
+	bool isConstant() const {return false;}
 
     void execute(ASTVisitor &visitor, void *param) {visitor.caseExprArrow(*this, param);}
 private:
@@ -777,6 +784,7 @@ public:
     string getNamespace() const {return nspace;}
     ASTExpr *getIndex() const {return index;}
     void setIndex(ASTExpr *e) {index = e;}
+	bool isConstant() const {return false;}
 
     void execute(ASTVisitor &visitor, void *param) {visitor.caseExprArray(*this, param);}
 private:
@@ -798,6 +806,7 @@ public:
     void setName(ASTExpr *n) {name = n;}
     ASTExpr * getName() const {return name;}
     void addParam(ASTExpr *param) {params.push_front(param);}
+	bool isConstant() const {return false;}
 
     void execute(ASTVisitor &visitor, void *param) {visitor.caseFuncCall(*this, param);}
 private:
@@ -814,6 +823,7 @@ public:
 
     ASTExpr *getOperand() const {return operand;}
     void setOperand(ASTExpr *e) {operand = e;}
+	virtual bool isConstant() const {return operand->isConstant();}
 private:
     ASTExpr *operand;
     //NOT IMPLEMENTED; DO NOT USE
@@ -855,6 +865,7 @@ public:
 	ASTExprIncrement* clone() const;
 
     void execute(ASTVisitor &visitor, void *param) {visitor.caseExprIncrement(*this, param);}
+	bool isConstant() const {return false;}
 };
 
 class ASTExprPreIncrement : public ASTUnaryExpr
@@ -864,6 +875,7 @@ public:
 	ASTExprPreIncrement* clone() const;
 
     void execute(ASTVisitor &visitor, void *param) {visitor.caseExprPreIncrement(*this, param);}
+	bool isConstant() const {return false;}
 };
 
 class ASTExprDecrement : public ASTUnaryExpr
@@ -873,6 +885,7 @@ public:
 	ASTExprDecrement* clone() const;
 
     void execute(ASTVisitor &visitor, void *param) {visitor.caseExprDecrement(*this, param);}
+	bool isConstant() const {return false;}
 };
 
 class ASTExprPreDecrement : public ASTUnaryExpr
@@ -882,6 +895,7 @@ public:
 	ASTExprPreDecrement* clone() const;
 
     void execute(ASTVisitor &visitor, void *param) {visitor.caseExprPreDecrement(*this, param);}
+	bool isConstant() const {return false;}
 };
 
 class ASTBinaryExpr : public ASTExpr
@@ -895,6 +909,7 @@ public:
     void setFirstOperand(ASTExpr *e) {first = e;}
     ASTExpr *getSecondOperand() const {return second;}
     void setSecondOperand(ASTExpr *e) {second = e;}
+	bool isConstant() const {return first->isConstant() && second->isConstant();}
 private:
     ASTExpr *first;
     ASTExpr *second;
@@ -1120,6 +1135,8 @@ public:
         visitor.caseExprBitXor(*this,param);
     }
 };
+
+// Types
 
 class ASTType : public AST
 {

--- a/src/parser/BuildVisitors.h
+++ b/src/parser/BuildVisitors.h
@@ -32,6 +32,7 @@ public:
     virtual void caseVarDecl(ASTVarDecl &host, void *param);
     virtual void caseVarDeclInitializer(ASTVarDeclInitializer &host, void *param);
 	// Expressions
+    virtual void caseExprConst(ASTExprConst &host, void *param);
     virtual void caseNumConstant(ASTNumConstant &host, void *param);
     virtual void caseBoolConstant(ASTBoolConstant &host, void *param);
     virtual void caseExprDot(ASTExprDot &host, void *param);

--- a/src/parser/ParseError.cpp
+++ b/src/parser/ParseError.cpp
@@ -202,6 +202,9 @@ void printErrorMsg(AST *offender, int errorID, string param)
         
     case NONINTEGERARRAYSIZE:
         oss << "Error T38: Arrays can only be initialized to numerical values" ;
+
+    case EXPRNOTCONSTANT:
+        oss << "Error T45: Expression not constant." ;
         
     default:
         oss << "FATAL FATAL ERROR I0: bad internal error code" ;

--- a/src/parser/ParseError.h
+++ b/src/parser/ParseError.h
@@ -54,5 +54,6 @@ void printErrorMsg(AST *offender, int errorID, string param=string());
 #define ARRAYLISTTOOLARGE 43
 #define ARRAYLISTSTRINGTOOLARGE 44
 #define NONINTEGERARRAYSIZE 45
+#define EXPRNOTCONSTANT 46
 #endif
 

--- a/src/parser/SymbolVisitors.cpp
+++ b/src/parser/SymbolVisitors.cpp
@@ -69,13 +69,13 @@ void BuildScriptSymbols::caseArrayDecl(ASTArrayDecl &host, void *param)
     int type;
     ExtractType temp;
     host.getType()->execute(temp, &type);
-    
+
     if(type == ScriptParser::TYPE_VOID)
     {
         failure = true;
         printErrorMsg(&host, VOIDARR, name);
     }
-    
+
     if(type == ScriptParser::TYPE_FFC || type == ScriptParser::TYPE_ITEM
             || type == ScriptParser::TYPE_ITEMCLASS || type == ScriptParser::TYPE_NPC
             || type == ScriptParser::TYPE_LWPN || type == ScriptParser::TYPE_EWPN)
@@ -83,28 +83,27 @@ void BuildScriptSymbols::caseArrayDecl(ASTArrayDecl &host, void *param)
         failure = true;
         printErrorMsg(&host, REFARR, name);
     }
-    
-    //var is always visible
+
+    // var is always visible
     int id = p->first->getVarSymbols().addVariable(name, type);
-    
+
     if(id == -1)
     {
         failure = true;
         printErrorMsg(&host, ARRREDEF, name);
         return;
     }
-    
+
     p->second->putAST(&host, id);
     p->second->putVar(id, type);
-    
+
     if(this->deprecateGlobals)
     {
         printErrorMsg(&host, DEPRECATEDGLOBAL, name);
     }
-    
-    if(host.isRegister())
-        ((ASTExpr *) host.getSize())->execute(*this, param);
-        
+
+	((ASTExpr *) host.getSize())->execute(*this, param);
+
     if(host.getList() != NULL)
     {
         for(list<ASTExpr *>::iterator it = host.getList()->getList().begin(); it != host.getList()->getList().end(); it++)
@@ -302,20 +301,19 @@ void BuildFunctionSymbols::caseArrayDecl(ASTArrayDecl &host, void *param)
     ExtractType temp;
     host.getType()->execute(temp, &type);
     int id = p->scope->getVarSymbols().addVariable(name, type);
-    
+
     if(id == -1)
     {
         printErrorMsg(&host, ARRREDEF, name);
         failure = true;
         return;
     }
-    
+
     p->table->putAST(&host, id);
     p->table->putVar(id, type);
-    
-    if(host.isRegister())
-        ((ASTExpr *) host.getSize())->execute(*this, param);
-        
+
+	((ASTExpr *) host.getSize())->execute(*this, param);
+
     if(host.getList() != NULL)
     {
         for(list<ASTExpr *>::iterator it = host.getList()->getList().begin(); it != host.getList()->getList().end(); it++)

--- a/src/parser/TypeChecker.h
+++ b/src/parser/TypeChecker.h
@@ -21,6 +21,7 @@ public:
     void caseArrayDecl(ASTArrayDecl &host, void *param);
     void caseVarDeclInitializer(ASTVarDeclInitializer &host, void *param);
 	// Expressions
+	void caseExprConst(ASTExprConst &host, void *param);
     void caseNumConstant(ASTNumConstant &host, void *param);
     void caseBoolConstant(ASTBoolConstant &host, void *param);
     void caseExprDot(ASTExprDot &host, void *param);

--- a/src/parser/UtilVisitors.cpp
+++ b/src/parser/UtilVisitors.cpp
@@ -103,12 +103,11 @@ void RecursiveVisitor::caseArrayDecl(ASTArrayDecl &host, void *param)
 {
 	host.getType()->execute(*this, param);
 
-	if(host.isRegister())
-		((ASTExpr *) host.getSize())->execute(*this, param);
+	((ASTExpr *) host.getSize())->execute(*this, param);
 
-	if(host.getList() != NULL)
+	if (host.getList() != NULL)
 	{
-		for(list<ASTExpr *>::iterator it = host.getList()->getList().begin(); it != host.getList()->getList().end(); it++)
+		for (list<ASTExpr *>::iterator it = host.getList()->getList().begin(); it != host.getList()->getList().end(); it++)
 		{
 			(*it)->execute(*this, param);
 		}
@@ -127,6 +126,11 @@ void RecursiveVisitor::caseVarDeclInitializer(ASTVarDeclInitializer &host, void 
 }
 
 // Expressions
+
+void RecursiveVisitor::caseExprConst(ASTExprConst &host, void *param)
+{
+	host.getContent()->execute(*this, param);
+}
 
 void RecursiveVisitor::caseNumConstant(ASTNumConstant &host, void *param)
 {

--- a/src/parser/UtilVisitors.h
+++ b/src/parser/UtilVisitors.h
@@ -25,6 +25,7 @@ public:
     virtual void caseVarDecl(ASTVarDecl &host, void *param);
     virtual void caseVarDeclInitializer(ASTVarDeclInitializer &host, void *param);
 	// Expressions
+	virtual void caseExprConst(ASTExprConst &host, void *param);
     virtual void caseNumConstant(ASTNumConstant &host, void *param);
     virtual void caseExprArrow(ASTExprArrow &host, void *param);
     virtual void caseExprArray(ASTExprArray &host, void *param);

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -133,30 +133,30 @@ ConstDecl : ZCONST ZFLOAT IDENTIFIER ASSIGN NUMBER SEMICOLON {ASTString *name = 
 																  $$ = new ASTConstDecl(name->getValue(), val,@1);
 																  delete name;}
 
-ArrayDecl : Type IDENTIFIER LBRACKET NUMBER RBRACKET {	ASTType *type = (ASTType *)$1;
+ArrayDecl : Type IDENTIFIER LBRACKET ConstExpr RBRACKET {	ASTType *type = (ASTType *)$1;
 														ASTString *name = (ASTString *)$2;
-														ASTExpr *size = (ASTExpr *)$4;
-														$$ = new ASTArrayDecl(type, name->getValue(), size, false, NULL, @1);
+														ASTExprConst *size = (ASTExprConst *)$4;
+														$$ = new ASTArrayDecl(type, name->getValue(), size, NULL, @1);
 														delete name;}
 
-	| Type IDENTIFIER LBRACKET NUMBER RBRACKET ASSIGN LBRACE ArrayList RBRACE {	ASTType *type = (ASTType *)$1;
+	| Type IDENTIFIER LBRACKET ConstExpr RBRACKET ASSIGN LBRACE ArrayList RBRACE {	ASTType *type = (ASTType *)$1;
 																				ASTString *name = (ASTString *)$2;
-																				ASTFloat *size = (ASTFloat *)$4;
+																				ASTExprConst *size = (ASTExprConst *)$4;
 																				ASTArrayList *list = (ASTArrayList *)$8;
-																				$$ = new ASTArrayDecl(type, name->getValue(), size, false, list, @1);
+																				$$ = new ASTArrayDecl(type, name->getValue(), size, list, @1);
 																				delete name;}
  	| Type IDENTIFIER LBRACKET RBRACKET ASSIGN LBRACE ArrayList RBRACE {	ASTType *type = (ASTType *)$1;
 																			ASTString *name = (ASTString *)$2;
 																			ASTArrayList *list = (ASTArrayList *)$7;
 																			char val[15];
 																			sprintf(val, "%d", list->getList().size());
-																			ASTFloat *size = new ASTFloat(val, 0, @1);
-																			$$ = new ASTArrayDecl(type, name->getValue(), size, false, list, @1);
+																			ASTExpr *size = new ASTNumConstant(new ASTFloat(val, 0, @1), @1);
+																			$$ = new ASTArrayDecl(type, name->getValue(), size, list, @1);
 																			delete name;}
 
-	| Type IDENTIFIER LBRACKET NUMBER RBRACKET ASSIGN QUOTEDSTRING {	ASTType *type = (ASTType *)$1;
+	| Type IDENTIFIER LBRACKET ConstExpr RBRACKET ASSIGN QUOTEDSTRING {	ASTType *type = (ASTType *)$1;
 																		ASTString *name = (ASTString *)$2;
-																		ASTFloat *size = (ASTFloat *)$4;
+																		ASTExprConst *size = (ASTExprConst *)$4;
 																		ASTArrayList *list = new ASTArrayList(@1);
 																		list->makeString();
 																		ASTString *string = (ASTString *)$7;
@@ -165,7 +165,7 @@ ArrayDecl : Type IDENTIFIER LBRACKET NUMBER RBRACKET {	ASTType *type = (ASTType 
 																			list->addParam(new ASTNumConstant(new ASTFloat(long((string->getValue())[i]), 0, @1), @1));
 
 																		list->addParam(new ASTNumConstant(new ASTFloat(0L, 0, @1), @1));
-																		$$ = new ASTArrayDecl(type, name->getValue(), size, false, list, @1);
+																		$$ = new ASTArrayDecl(type, name->getValue(), size, list, @1);
 																		delete name;}
 
  	| Type IDENTIFIER LBRACKET RBRACKET ASSIGN QUOTEDSTRING {	ASTType *type = (ASTType *)$1;
@@ -173,13 +173,13 @@ ArrayDecl : Type IDENTIFIER LBRACKET NUMBER RBRACKET {	ASTType *type = (ASTType 
 																ASTArrayList *list = new ASTArrayList(@1);
 																list->makeString();
 																ASTString *string = (ASTString *)$6;
-																ASTFloat *size = new ASTFloat(string->getValue().length()-1, 0, @1);
+																ASTExpr *size = new ASTNumConstant(new ASTFloat(string->getValue().length()-1, 0, @1), @1);
 
 																for(unsigned int i=1; i < string->getValue().length()-1; i++)
 																	list->addParam(new ASTNumConstant(new ASTFloat(long((string->getValue())[i]), 0, @1), @1));
 
 																list->addParam(new ASTNumConstant(new ASTFloat(0L, 0, @1), @1));
-																$$ = new ASTArrayDecl(type, name->getValue(), size, false, list, @1);
+																$$ = new ASTArrayDecl(type, name->getValue(), size, list, @1);
 																delete name;}
 	;
 
@@ -382,6 +382,11 @@ DotExpr : IDENTIFIER DOT IDENTIFIER {ASTString *lval = (ASTString *)$1;
 													   ASTExprArrow *res = new ASTExprArrow(id, rval->getValue(), @1);
 													   res->setIndex(num);
 													   $$ = res;}
+	;
+
+ConstExpr : Expr {
+		ASTExpr *content = (ASTExpr*)$1;
+		$$ = new ASTExprConst(content, @1);}
 	;
 
 Expr : Expr OR Expr15 {ASTLogExpr *e = new ASTExprOr(@2);


### PR DESCRIPTION
Added ASTExprConst, which wraps an ASTExpr and signals an error during
typechecking if the expression is not constant. Bison uses the
ConstExpr class.