### PR TITLE
17 Enemy Editor Continued: Enemy Weapon Sprites, and Size Panel

### DIFF
--- a/src/guys.cpp
+++ b/src/guys.cpp
@@ -373,15 +373,15 @@ enemy::enemy(fix X,fix Y,int Id,int Clk) : sprite()
     //al_trace("->txsz:%i\n", d->txsz); Verified that this is setting the value. -Z
    // al_trace("Enemy txsz:%i\n", txsz);
     if ( d->tysz > 0 ) { tysz = d->tysz; if ( tysz > 1 ) extend = 3; }
-    if ( d->hxsz > 0 ) hxsz = d->hxsz;
-    if ( d->hysz > 0 ) hysz = d->hysz;
-    if ( d->hzsz > 0 ) hzsz = d->hzsz;
-    if ( d->hxofs != 0 ) hxofs = d->hxofs;
-    if ( d->hyofs != 0 ) hyofs = d->hyofs;
-   
-    if ( d->xofs != 0 ) xofs = (int)d->xofs;
-    if ( d->yofs != 0 ) yofs = (int)d->yofs;
-    if ( d->zofs != 0 ) zofs = (int)d->zofs;
+    if ( ((d->SIZEflags&guyflagOVERRIDEXOFFSET) != 0) && d->hxsz > 0 ) hxsz = d->hxsz;
+    if ( ((d->SIZEflags&guyflagOVERRIDEYOFFSET) != 0) && d->hysz > 0 ) hysz = d->hysz;
+    if ( ((d->SIZEflags&guyflagOVERRIDEHITZOFFSET) != 0) && d->hzsz > 0  ) hzsz = d->hzsz;
+    if ( (d->SIZEflags&guyflagOVERRIDEHITXOFFSET) != 0) hxofs = d->hxofs;
+    if (  (d->SIZEflags&guyflagOVERRIDEHITYOFFSET) != 0 ) hyofs = d->hyofs;
+//    if ( (d->SIZEflags&guyflagOVERRIDEHITZOFFSET) != 0 ) hzofs = d->hzofs;
+    if (  (d->SIZEflags&guyflagOVERRIDEDRAWXOFFSET) != 0 ) xofs = (int)d->xofs;
+    if ( (d->SIZEflags&guyflagOVERRIDEDRAWYOFFSET) != 0 ) yofs = (int)d->yofs;
+    if (  (d->SIZEflags&guyflagOVERRIDEDRAWXZOFFSET) != 0 ) zofs = (int)d->zofs;
     
     if((wpn==ewBomb || wpn==ewSBomb) && family!=eeOTHER && family!=eeFIRE && (family!=eeWALK || dmisc2 != e2tBOMBCHU))
         wpn = 0;
@@ -6018,6 +6018,14 @@ eRock::eRock(fix X,fix Y,int Id,int Clk) : enemy(X,Y,Id,Clk)
     clk=0;
     mainguy=false;
     clk2=-14;
+	/*
+    if ( (SIZEflags&guyflagOVERRIDEHITXOFFSET) != 0) hxofs = d->hxofs;
+    if (  (SIZEflags&guyflagOVERRIDEHITYOFFSET) != 0 ) hyofs = d->hyofs;
+    if ( (SIZEflags&guyflagOVERRIDEHITZOFFSET) != 0 ) hzofs = d->hzofs;
+    if (  (SIZEflags&guyflagOVERRIDEDRAWXOFFSET) != 0 ) xofs = (int)d->xofs;
+    if ( (SIZEflags&guyflagOVERRIDEDRAWYOFFSET) != 0 ) yofs = (int)d->yofs;
+    if (  (SIZEflags&guyflagOVERRIDEDRAWXZOFFSET) != 0 ) zofs = (int)d->zofs;
+	*/
     hxofs=hyofs=-2;
     hxsz=hysz=20;
     //nets+1640;
@@ -7561,9 +7569,11 @@ eKeese::eKeese(fix X,fix Y,int Id,int Clk) : enemy(X,Y,Id,Clk)
     step=0;
     movestatus=1;
     c=0;
-    hxofs=2;
+	
+
+    if ( !(SIZEflags&guyflagOVERRIDEHITXOFFSET) ) hxofs=2;
     hxsz=12;
-    hyofs=4;
+    if ( !(SIZEflags&guyflagOVERRIDEHITYOFFSET) ) hxofs=2; hyofs=4;
     hysz=8;
     clk4=0;
     //nets;

--- a/src/guys.h
+++ b/src/guys.h
@@ -112,6 +112,8 @@ public:
         return false;
     }
     int wpnsprite; //wpnsprite is new for 2.6 -Z
+    int SIZEflags; //Flags for size panel offsets. The user must enable these to override defaults. 
+
 protected:
     int  clk2,sclk;
     int  starting_hp;

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -9046,6 +9046,12 @@ int readguys(PACKFILE *f, zquestheader *Header, bool keepdata)
                         return qe_invalid;
                     }
 	    }
+	    
+	    if(guyversion <= 27) // Port over generic script settings from old quests in the new editor. 
+            {
+		tempguy.wpnsprite = 0;
+            }
+	    
 	    if(guyversion > 27)
 	    {
 	        if(!p_igetl(&(tempguy.wpnsprite),f,keepdata))
@@ -9053,11 +9059,10 @@ int readguys(PACKFILE *f, zquestheader *Header, bool keepdata)
                         return qe_invalid;
                     }
 	    }
-	    if(guyversion <= 27) // Port over generic script settings from old quests in the new editor. 
+	    if(guyversion <= 28) // Port over generic script settings from old quests in the new editor. 
             {
-		tempguy.wpnsprite = 0;
+		tempguy.SIZEflags = 0;
             }
-	    
 	    if(guyversion > 28)
 	    {
 		if(!p_igetl(&(tempguy.SIZEflags),f,keepdata))
@@ -9066,10 +9071,7 @@ int readguys(PACKFILE *f, zquestheader *Header, bool keepdata)
 		    }
 		
 	    }
-	    if(guyversion <= 28) // Port over generic script settings from old quests in the new editor. 
-            {
-		tempguy.SIZEflags = 0;
-            }
+	    
 	    
             //miscellaneous other corrections
             //fix the mirror wizzrobe -DD

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -9058,6 +9058,19 @@ int readguys(PACKFILE *f, zquestheader *Header, bool keepdata)
 		tempguy.wpnsprite = 0;
             }
 	    
+	    if(guyversion > 28)
+	    {
+		if(!p_igetl(&(tempguy.SIZEflags),f,keepdata))
+		    {
+			return qe_invalid;
+		    }
+		
+	    }
+	    if(guyversion <= 28) // Port over generic script settings from old quests in the new editor. 
+            {
+		tempguy.SIZEflags = 0;
+            }
+	    
             //miscellaneous other corrections
             //fix the mirror wizzrobe -DD
             if(guyversion < 7)

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -191,7 +191,7 @@ weapon::weapon(weapon const & other):
     misc2(other.misc2),			//int
     ignorecombo(other.ignorecombo),	//int
     isLit(other.isLit),			//bool		Does it light the screen?
-    parentid(other.parentid),		//int		Enemy that created it. -1 for none. 
+    parentid(other.parentid),		//int		Enemy that created it. -1 for none. This is the Enemy POINTER, not the Enemy ID. 
     parentitem(other.parentitem),	//int		Item that created it. -1 for none. 
     dragging(other.dragging),		//int draggong		?
     step(other.step),			//fix		Speed of movement
@@ -288,9 +288,9 @@ weapon::weapon(weapon const & other):
     }*/
     
     //Enemy Editor Weapon Sprite
-    
-    if ( parentid > 0 ) wpnsprite = guysbuf[parentid].wpnsprite;
-    else wpnsprite  = -1;
+    wpnsprite = other.wpnsprite;
+    //if ( parentid > 0 ) wpnsprite = guysbuf[parentid].wpnsprite;
+    //else wpnsprite  = -1;
 }
 
 // Let's dispose of some sound effects!
@@ -1297,9 +1297,13 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         break;
         
     case ewRock:
-	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	    
+	if ( parentid > -1 )
 	{
-		LOADGFX(guysbuf[parentid].wpnsprite);
+		Z_message("wpnsprite is: %d\n", guysbuf[parentid].wpnsprite);
+		Z_message("parentid is: %d\n", parentid);
+		if ( guysbuf[parentid].wpnsprite > 0 ) LOADGFX(guysbuf[parentid].wpnsprite);
+		else LOADGFX(ewROCK);
 	}
 	else LOADGFX(ewROCK);
   

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -1170,10 +1170,13 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
     
     case ewLitBomb:
     case ewBomb:
-	    if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 )) 
-	    {
-		    LOADGFX(guysbuf[parentid].wpnsprite);
-	    }
+	if ( parentid > -1 )
+	{
+		sprite *e = guys.getByUID(parentid);
+		if ( guysbuf[e->id].wpnsprite > 0 ) LOADGFX(guysbuf[e->id].wpnsprite);
+		else LOADGFX(ewBOMB);
+	}
+	
 	else LOADGFX(ewBOMB);
 
         hxofs=0;
@@ -1210,9 +1213,11 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         
     case ewLitSBomb:
     case ewSBomb:
-	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 )) 
+	if ( parentid > -1 )
 	{
-		LOADGFX(guysbuf[parentid].wpnsprite);
+		sprite *e = guys.getByUID(parentid);
+		if ( guysbuf[e->id].wpnsprite > 0 ) LOADGFX(guysbuf[e->id].wpnsprite);
+		else LOADGFX(ewSBOMB);
 	}
 	else LOADGFX(ewSBOMB);
         hxofs=0;
@@ -1262,9 +1267,11 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         
         wid = zc_min(zc_max(current_item(itype_brang),1),3)-1+wBRANG;
         
-	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	if ( parentid > -1 )
 	{
-		LOADGFX(guysbuf[parentid].wpnsprite);
+		sprite *e = guys.getByUID(parentid);
+		if ( guysbuf[e->id].wpnsprite > 0 ) LOADGFX(guysbuf[e->id].wpnsprite);
+		else LOADGFX(wid);
 	}
 	else LOADGFX(wid);
         break;
@@ -1280,9 +1287,11 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         //fallthrough
     case ewFireball:
     case wRefFireball:
-	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	if ( parentid > -1 )
 	{
-		LOADGFX(guysbuf[parentid].wpnsprite);
+		sprite *e = guys.getByUID(parentid);
+		if ( guysbuf[e->id].wpnsprite > 0 ) LOADGFX(guysbuf[e->id].wpnsprite);
+		else LOADGFX(ewFIREBALL);
 	}
 	else LOADGFX(ewFIREBALL);
  
@@ -1300,9 +1309,8 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
 	    
 	if ( parentid > -1 )
 	{
-		Z_message("wpnsprite is: %d\n", guysbuf[parentid].wpnsprite);
-		Z_message("parentid is: %d\n", parentid);
-		if ( guysbuf[parentid].wpnsprite > 0 ) LOADGFX(guysbuf[parentid].wpnsprite);
+		sprite *e = guys.getByUID(parentid);
+		if ( guysbuf[e->id].wpnsprite > 0 ) LOADGFX(guysbuf[e->id].wpnsprite);
 		else LOADGFX(ewROCK);
 	}
 	else LOADGFX(ewROCK);
@@ -1325,9 +1333,12 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         break;
         
     case ewArrow:
-	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	    
+	if ( parentid > -1 )
 	{
-		LOADGFX(guysbuf[parentid].wpnsprite);
+		sprite *e = guys.getByUID(parentid);
+		if ( guysbuf[e->id].wpnsprite > 0 ) LOADGFX(guysbuf[e->id].wpnsprite);
+		else LOADGFX(ewARROW);
 	}
 	else LOADGFX(ewARROW);
         
@@ -1355,9 +1366,11 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         break;
         
     case ewSword:
-	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	if ( parentid > -1 )
 	{
-		LOADGFX(guysbuf[parentid].wpnsprite);
+		sprite *e = guys.getByUID(parentid);
+		if ( guysbuf[e->id].wpnsprite > 0 ) LOADGFX(guysbuf[e->id].wpnsprite);
+		else LOADGFX(ewSWORD);
 	}
 	else LOADGFX(ewSWORD);
         
@@ -1398,9 +1411,11 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         
     case wRefMagic:
     case ewMagic:
-	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	if ( parentid > -1 )
 	{
-		LOADGFX(guysbuf[parentid].wpnsprite);
+		sprite *e = guys.getByUID(parentid);
+		if ( guysbuf[e->id].wpnsprite > 0 ) LOADGFX(guysbuf[e->id].wpnsprite);
+		else LOADGFX(ewMAGIC);
 	}
 	else LOADGFX(ewMAGIC);
         
@@ -1447,17 +1462,21 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
     case ewFlame2:
         if(id==ewFlame)
 	{
-		if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+		if ( parentid > -1 )
 		{
-			LOADGFX(guysbuf[parentid].wpnsprite);
+			sprite *e = guys.getByUID(parentid);
+			if ( guysbuf[e->id].wpnsprite > 0 ) LOADGFX(guysbuf[e->id].wpnsprite);
+			else LOADGFX(ewFLAME);
 		}
 		else LOADGFX(ewFLAME);
 	}
         else
 	{
-		if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+		if ( parentid > -1 )
 		{
-			LOADGFX(guysbuf[parentid].wpnsprite);
+			sprite *e = guys.getByUID(parentid);
+			if ( guysbuf[e->id].wpnsprite > 0 ) LOADGFX(guysbuf[e->id].wpnsprite);
+			else LOADGFX(ewFLAME2);
 		}
 		else LOADGFX(ewFLAME2);
 	}
@@ -1500,9 +1519,11 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         break;
         
     case ewFireTrail:
-	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	if ( parentid > -1 )
 	{
-		LOADGFX(guysbuf[parentid].wpnsprite);
+		sprite *e = guys.getByUID(parentid);
+		if ( guysbuf[e->id].wpnsprite > 0 ) LOADGFX(guysbuf[e->id].wpnsprite);
+		else LOADGFX(ewFIRETRAIL);
 	}
 	else LOADGFX(ewFIRETRAIL);
 
@@ -1531,9 +1552,11 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
 			hxofs=hyofs=0;
 			hxsz=hysz=16;
 		}
-	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	if ( parentid > -1 )
 	{
-		LOADGFX(guysbuf[parentid].wpnsprite);
+		sprite *e = guys.getByUID(parentid);
+		if ( guysbuf[e->id].wpnsprite > 0 ) LOADGFX(guysbuf[e->id].wpnsprite);
+		else LOADGFX(ewWIND);
 	}
 	else LOADGFX(ewWIND);
 

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -286,6 +286,11 @@ weapon::weapon(weapon const & other):
     {
       a[i]=other.a[i];
     }*/
+    
+    //Enemy Editor Weapon Sprite
+    
+    if ( parentid > 0 ) wpnsprite = guysbuf[parentid].wpnsprite;
+    else wpnsprite  = -1;
 }
 
 // Let's dispose of some sound effects!
@@ -1165,7 +1170,12 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
     
     case ewLitBomb:
     case ewBomb:
-        LOADGFX(ewBOMB);
+	    if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 )) 
+	    {
+		    LOADGFX(guysbuf[parentid].wpnsprite);
+	    }
+	else LOADGFX(ewBOMB);
+
         hxofs=0;
         hxsz=16;
         
@@ -1200,7 +1210,11 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         
     case ewLitSBomb:
     case ewSBomb:
-        LOADGFX(ewSBOMB);
+	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 )) 
+	{
+		LOADGFX(guysbuf[parentid].wpnsprite);
+	}
+	else LOADGFX(ewSBOMB);
         hxofs=0;
         hxsz=16;
 		if(get_bit(quest_rules, qr_OFFSETEWPNCOLLISIONFIX))
@@ -1247,7 +1261,12 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         }
         
         wid = zc_min(zc_max(current_item(itype_brang),1),3)-1+wBRANG;
-        LOADGFX(wid);
+        
+	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	{
+		LOADGFX(guysbuf[parentid].wpnsprite);
+	}
+	else LOADGFX(wid);
         break;
         
     case ewFireball2:
@@ -1261,7 +1280,12 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         //fallthrough
     case ewFireball:
     case wRefFireball:
-        LOADGFX(ewFIREBALL);
+	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	{
+		LOADGFX(guysbuf[parentid].wpnsprite);
+	}
+	else LOADGFX(ewFIREBALL);
+ 
         step=1.75;
         
         if(Type&2)
@@ -1273,7 +1297,12 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         break;
         
     case ewRock:
-        LOADGFX(ewROCK);
+	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	{
+		LOADGFX(guysbuf[parentid].wpnsprite);
+	}
+	else LOADGFX(ewROCK);
+  
         
         if(get_bit(quest_rules, qr_OFFSETEWPNCOLLISIONFIX))
         {
@@ -1292,7 +1321,12 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         break;
         
     case ewArrow:
-        LOADGFX(ewARROW);
+	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	{
+		LOADGFX(guysbuf[parentid].wpnsprite);
+	}
+	else LOADGFX(ewARROW);
+        
         step=2;
         
         switch(dir)
@@ -1317,7 +1351,12 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         break;
         
     case ewSword:
-        LOADGFX(ewSWORD);
+	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	{
+		LOADGFX(guysbuf[parentid].wpnsprite);
+	}
+	else LOADGFX(ewSWORD);
+        
         
         if(get_bit(quest_rules, qr_OFFSETEWPNCOLLISIONFIX))
         {
@@ -1355,7 +1394,11 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         
     case wRefMagic:
     case ewMagic:
-        LOADGFX(ewMAGIC);
+	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	{
+		LOADGFX(guysbuf[parentid].wpnsprite);
+	}
+	else LOADGFX(ewMAGIC);
         
         if(get_bit(quest_rules, qr_OFFSETEWPNCOLLISIONFIX))
         {
@@ -1399,9 +1442,21 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
     case ewFlame:
     case ewFlame2:
         if(id==ewFlame)
-            LOADGFX(ewFLAME);
+	{
+		if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+		{
+			LOADGFX(guysbuf[parentid].wpnsprite);
+		}
+		else LOADGFX(ewFLAME);
+	}
         else
-            LOADGFX(ewFLAME2);
+	{
+		if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+		{
+			LOADGFX(guysbuf[parentid].wpnsprite);
+		}
+		else LOADGFX(ewFLAME2);
+	}
             
         if(dir==255)
         {
@@ -1441,7 +1496,12 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
         break;
         
     case ewFireTrail:
-        LOADGFX(ewFIRETRAIL);
+	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	{
+		LOADGFX(guysbuf[parentid].wpnsprite);
+	}
+	else LOADGFX(ewFIRETRAIL);
+
         step=0;
         dir=-1;
         
@@ -1467,8 +1527,12 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
 			hxofs=hyofs=0;
 			hxsz=hysz=16;
 		}
-		
-        LOADGFX(ewWIND);
+	if ( parentid > -1 && ( guysbuf[parentid].wpnsprite > 0 ))
+	{
+		LOADGFX(guysbuf[parentid].wpnsprite);
+	}
+	else LOADGFX(ewWIND);
+
         clk=0;
 	if (power > 0) step = itemsbuf[parentid].misc2; //!Dimentio: Add a check here.
 		//! ZoriaRPG: Explain why this is here. 

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -86,6 +86,9 @@ public:
     //2.6 ZScript -Z
     int scriptrange,blastsfx;
     
+    //2.6 enemy editor weapon sprite
+    int wpnsprite;
+    
     weapon(weapon const & other);
     weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentid, int prntid, bool isDummy=false);
     virtual ~weapon();

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -1305,6 +1305,8 @@ struct itemdata
     int weap_hxofs, weap_yxofs, weap_hxsz, weap_hysz, weap_hzsz, weap_xofs, weap_yofs; //weapon
     
     word weaponscript; //If only. -Z This would link an item to a weapon script in the item editor.
+    int wpnsprite; //enemy weapon sprite. 
+    
     
 };
 
@@ -1428,13 +1430,15 @@ struct item_drop_object
 #define ffCHANGESPEED   0x04000000 //Change speed to this (default, not implemented yet)
 
 
-#define GUYDATA_FLAGS 20
-//fLAGS TO DEFINE IF VARIOUS ENEMY EDITOR PROPERTIES OVERRIDE SYSTEM DEFAULTS
-enum{
-	guyflagOVERRIDEXOFFSET, guyflagOVERRIDEYOFFSET, guyflagOVERRIDEHITXOFFSET, guyflagOVERRIDEHITYOFFSET,
-	guyflagOVERRIDEHITZOFFSET, guyflagOVERRIDEDRAWXOFFSET, guyflagOVERRIDEDRAWYOFFSET, guyflagOVERRIDEDRAWXZOFFSET,
-	guyflagLAST = 19
-};
+
+#define guyflagOVERRIDEXOFFSET       0x00000001
+#define guyflagOVERRIDEYOFFSET         0x00000002
+#define guyflagOVERRIDEHITXOFFSET         0x00000004
+#define guyflagOVERRIDEHITYOFFSET     0x00000008
+#define guyflagOVERRIDEHITZOFFSET    0x00000010
+#define guyflagOVERRIDEDRAWXOFFSET       0x00000020 
+#define guyflagOVERRIDEDRAWYOFFSET       0x00000040 
+#define guyflagOVERRIDEDRAWXZOFFSET       0x00000080 
 
 struct guydata
 {
@@ -1473,7 +1477,7 @@ struct guydata
     int txsz,tysz;
     byte scriptdefense[scriptDEFLAST]; //old 2.future quest file crossover support. 
     int wpnsprite; //wpnsprite is new for 2.6 -Z
-    bool SIZEflags[GUYDATA_FLAGS]; //Flags for size panel offsets. The user must enable these to override defaults. 
+    int SIZEflags;; //Flags for size panel offsets. The user must enable these to override defaults. 
 };
 
 class refInfo

--- a/src/zq_class.cpp
+++ b/src/zq_class.cpp
@@ -9363,6 +9363,10 @@ int writeguys(PACKFILE *f, zquestheader *Header)
             {
                 new_return(62);
             }
+	    if(!p_iputl(guysbuf[i].SIZEflags,f))
+            {
+                new_return(62);
+            }
 	    
         }
         

--- a/src/zq_custom.cpp
+++ b/src/zq_custom.cpp
@@ -2388,7 +2388,7 @@ static int enedata_defense3_list[] =
 
 static int enedata_spritesize_list[] =
 {
-    213,214,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,-1
+    213,214,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,237,238,239,240,241,242,243,244,-1
 };
 
 static TABPANEL enedata_tabs[] =
@@ -3280,8 +3280,23 @@ static DIALOG enedata_dlg[] =
 	{  jwin_text_proc,          8,    193-4+12,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void *) "Weapon Sprite:",                              NULL,   NULL                 },
 	//{  jwin_droplist_proc,      86, 189-4+12,    151,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,       0,           0,    0, (void *) &weapon_list,                            NULL,   NULL                  },
 	{  jwin_edit_proc,         86, 189-4+12,    151,     16,    vc(12),                 vc(1),                   0,    0,           6,    0,  NULL,                                                           NULL,   NULL                 },
-	
-	
+	//237 HitWidth Override
+	 { jwin_check_proc,        94+50,     83,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+	//238 HitHeight override
+	 { jwin_check_proc,        94+50,    99,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+	//239 HitZHeight Override
+	 { jwin_check_proc,        94+50,     115,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+	//240 HitXOffset override
+	 { jwin_check_proc,        94+50,     131,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+	//241 HitYOffset Override
+	 { jwin_check_proc,        94+50,    147,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+	//242 HitZOffset Override
+	 { jwin_check_proc,        94+50,     163,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+	//243 DrawXOffset Override
+	 { jwin_check_proc,        94+50,    179,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+	//244 DrawYOffset Overrife
+	 { jwin_check_proc,        94+50,     195,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+  
     {  NULL,                     0,      0,      0,      0,    0,                      0,                       0,    0,           0,    0,  NULL,                                                           NULL,   NULL                 }
 };
 
@@ -3649,6 +3664,17 @@ void edit_enemydata(int index)
     enedata_dlg[230].dp = drawofsx;
     enedata_dlg[232].dp = drawofsy;
     
+    //Override flags
+    enedata_dlg[237].flags = (guysbuf[index].SIZEflags&guyflagOVERRIDEXOFFSET) ? D_SELECTED : 0;
+    enedata_dlg[238].flags = (guysbuf[index].SIZEflags&guyflagOVERRIDEYOFFSET) ? D_SELECTED : 0;
+    enedata_dlg[239].flags = (guysbuf[index].SIZEflags&guyflagOVERRIDEHITXOFFSET) ? D_SELECTED : 0;
+    enedata_dlg[240].flags = (guysbuf[index].SIZEflags&guyflagOVERRIDEHITYOFFSET) ? D_SELECTED : 0;
+    enedata_dlg[241].flags = (guysbuf[index].SIZEflags&guyflagOVERRIDEHITZOFFSET) ? D_SELECTED : 0;
+    enedata_dlg[242].flags = (guysbuf[index].SIZEflags&guyflagOVERRIDEDRAWXOFFSET) ? D_SELECTED : 0;
+    enedata_dlg[243].flags = (guysbuf[index].SIZEflags&guyflagOVERRIDEDRAWYOFFSET) ? D_SELECTED : 0;
+    enedata_dlg[244].flags = (guysbuf[index].SIZEflags&guyflagOVERRIDEDRAWXZOFFSET) ? D_SELECTED : 0;
+    
+    
     sprintf(frt,"%d",guysbuf[index].frate);
     sprintf(efr,"%d",guysbuf[index].e_frate);
     enedata_dlg[140].dp = frt;
@@ -3988,6 +4014,29 @@ void edit_enemydata(int index)
 	test.xofs = atoi(drawofsx);
 	test.yofs = atoi(drawofsy);
 	
+	//override flags
+	if(enedata_cpy[237].flags & D_SELECTED)
+            test.SIZEflags |= guyflagOVERRIDEXOFFSET;
+            
+        if(enedata_cpy[238].flags & D_SELECTED)
+            test.SIZEflags |= guyflagOVERRIDEYOFFSET;
+            
+        if(enedata_cpy[239].flags & D_SELECTED)
+            test.SIZEflags |= guyflagOVERRIDEHITXOFFSET;
+            
+        if(enedata_cpy[240].flags & D_SELECTED)
+            test.SIZEflags |= guyflagOVERRIDEHITYOFFSET;
+            
+        if(enedata_cpy[241].flags & D_SELECTED)
+            test.SIZEflags |= guyflagOVERRIDEHITZOFFSET;
+            
+        if(enedata_cpy[242].flags & D_SELECTED)
+            test.SIZEflags |= guyflagOVERRIDEDRAWXOFFSET;
+	if(enedata_cpy[243].flags & D_SELECTED)
+            test.SIZEflags |= guyflagOVERRIDEDRAWYOFFSET;
+            
+        if(enedata_cpy[244].flags & D_SELECTED)
+            test.SIZEflags |= guyflagOVERRIDEDRAWXZOFFSET;
 
 	    
 	    


### PR DESCRIPTION
The 'Weapon Sprite' field in the enemy editor 'Data 2; tab now works as intended, and I did further work on the Size tab elements. 