### PR TITLE
Fix: Item Script Usage Bug

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -5519,9 +5519,9 @@ void do_lens()
         
         paymagiccost(itemid);
         
-        if(dowpn>=0 && itemsbuf[dowpn].script != 0 && !did_scriptl)
+        if(itemid>=0 && itemsbuf[itemid].script != 0 && !did_scriptl)
         {
-            ZScriptVersion::RunScript(SCRIPT_ITEM, itemsbuf[dowpn].script, dowpn & 0xFFF);
+            ZScriptVersion::RunScript(SCRIPT_ITEM, itemsbuf[itemid].script, itemid & 0xFFF);
             did_scriptl=true;
         }
         


### PR DESCRIPTION
Changelog: Fixed a bug where the Lens of Truth item steals its script ID from the last item used,
and runs that script every frame unti the lens is disabled.