### PR TITLE
Fixed alleg_compat methods to cleanup the packfile password. Closes #121

### DIFF
--- a/src/alleg_compat.cpp
+++ b/src/alleg_compat.cpp
@@ -11,10 +11,14 @@
 
 PACKFILE *pack_fopen_password(const char *filename, const char *mode, const char *password) {
 	packfile_password(password);
-	return pack_fopen(filename, mode);
+	PACKFILE *result = pack_fopen(filename, mode);
+	packfile_password(NULL);
+	return result;
 }
 
 uint64_t file_size_ex_password(const char *filename, const char *password) {
 	packfile_password(password);
-	return file_size_ex(filename);
+	uint64_t result = file_size_ex(filename);
+	packfile_password(NULL);
+	return result;
 }


### PR DESCRIPTION
This should restore the old behavior, allowing samplesoundset/patches.dat to load