### PR TITLE
Fix: Subscreen Crash

### DIFF
--- a/src/subscr.cpp
+++ b/src/subscr.cpp
@@ -3633,7 +3633,7 @@ void show_custom_subscreen(BITMAP *dest, miscQdata *misc, subscreen_group *css, 
                 switch(itemsbuf[itemid].family)
                 {
                 case itype_arrow:
-                    if(Bitem->dummy_bool[0]==true)  //if we also have a bow
+                    if(if Bitem && Bitem->dummy_bool[0]==true)  //if we also have a bow
                     {
                         if(current_item_id(itype_bow))
                         {
@@ -3853,7 +3853,7 @@ void buttonitem(BITMAP *dest, int button, int x, int y)
             switch(itemsbuf[Bitem->id].family)
             {
             case itype_arrow:
-                if(Bitem->dummy_bool[0]==true)
+                if(Bitem && Bitem->dummy_bool[0]==true)
                 {
                     if(current_item_id(itype_bow)>-1)
                     {

--- a/src/subscr.cpp
+++ b/src/subscr.cpp
@@ -3633,7 +3633,7 @@ void show_custom_subscreen(BITMAP *dest, miscQdata *misc, subscreen_group *css, 
                 switch(itemsbuf[itemid].family)
                 {
                 case itype_arrow:
-                    if(if Bitem && Bitem->dummy_bool[0]==true)  //if we also have a bow
+                    if(Bitem && Bitem->dummy_bool[0]==true)  //if we also have a bow
                     {
                         if(current_item_id(itype_bow))
                         {


### PR DESCRIPTION
Changelog: Fixed an issue where the Bitem set to null, but called for a dereferenced var, on the subscreen can crash ZC.


