### PR TITLE
Fix: Upward Dungeon Doors

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -8710,9 +8710,22 @@ void LinkClass::checklocked()
     int si = (currmap<<7) + currscr;
     int di = nextscr(dir);
     
+    /*
+	
+	if ( diagonalMovement ) 
+	{
+		if (!( y>32 && (x<=112||x>=128) ))
+		{
+			if ( //Link is pressing UP_LEFT, UP, or UPRIGHT ) 
+	}
+	
+	*/
+	
     switch(dir)
     {
     case up:
+    case r_up:
+    case l_up:
         if(y>32 || (diagonalMovement?(x<=112||x>=128):x!=120)) return;
         
         if(tmpscr->door[dir]==dLOCKED)


### PR DESCRIPTION
Changelog: This should fix issues opening upward-facing dungeon doors
when using diagonal movement. A full rewrite of checklocked is planned
and I left the form of it in there as a placeholder (in a comment block).