### PR TITLE
Refactor: Link and Doors

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -8710,17 +8710,401 @@ void LinkClass::checklocked()
     int si = (currmap<<7) + currscr;
     int di = nextscr(dir);
     
-    /*
+    
 	
 	if ( diagonalMovement ) 
 	{
-		if (!( y>32 && (x<=112||x>=128) ))
+		//Up door
+		if ( y <= 32 && x >= 112 && x <= 128 )
+			
+		//!( y>32 && (x<=112||x>=128) ))
 		{
-			if ( //Link is pressing UP_LEFT, UP, or UPRIGHT ) 
+			switch ( dir ) 
+			{ //dir needs to be changed with readkey or similar. 
+				case up:
+				case r_up:
+				case l_up:
+				{
+					if(tmpscr->door[0]==dLOCKED)
+					{
+					    if(usekey())
+					    {
+						putdoor(scrollbuf,0,up,dUNLOCKED);
+						tmpscr->door[0]=dUNLOCKED;
+						setmapflag(si, mDOOR_UP);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_DOWN);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					else if(tmpscr->door[0]==dBOSS)
+					{
+					    if(game->lvlitems[dlevel]&liBOSSKEY)
+					    {
+						putdoor(scrollbuf,0,up,dOPENBOSS);
+						tmpscr->door[0]=dOPENBOSS;
+						setmapflag(si, mDOOR_UP);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_DOWN);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					break;
+				}
+				default: break;
+					
+			}
+		}
+		//Down
+		if ( y >= 128 && x >= 112 && x <= 128 )
+
+		//!(y<128 && (x<=112||x>=128) ) )
+		{
+			switch(dir)
+			{
+				case down:
+				case l_down:
+				case r_down:
+				{
+					
+					if(tmpscr->door[1]==dLOCKED)
+					{
+					    if(usekey())
+					    {
+						putdoor(scrollbuf,0,down,dUNLOCKED);
+						tmpscr->door[1]=dUNLOCKED;
+						setmapflag(si, mDOOR_DOWN);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_UP);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					else if(tmpscr->door[1]==dBOSS)
+					{
+					    if(game->lvlitems[dlevel]&liBOSSKEY)
+					    {
+						putdoor(scrollbuf,0,down,dOPENBOSS);
+						tmpscr->door[1]=dOPENBOSS;
+						setmapflag(si, mDOOR_DOWN);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_UP);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					break;
+				}
+				default: break;
+			}
+		}
+		//left
+		if ( y>=72 && y <= 88 && x <= 32 )
+			
+		//!( (y<=72||y>=88) && x>32 ) )
+		{
+			switch(dir)
+			{
+				case left:
+				case l_up:
+				case l_down:
+				{
+					if(tmpscr->door[2]==dLOCKED)
+					{
+					    if(usekey())
+					    {
+						putdoor(scrollbuf,0,left,dUNLOCKED);
+						tmpscr->door[2]=dUNLOCKED;
+						setmapflag(si, mDOOR_LEFT);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_RIGHT);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					else if(tmpscr->door[2]==dBOSS)
+					{
+					    if(game->lvlitems[dlevel]&liBOSSKEY)
+					    {
+						putdoor(scrollbuf,0,left,dOPENBOSS);
+						tmpscr->door[2]=dOPENBOSS;
+						setmapflag(si, mDOOR_LEFT);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_RIGHT);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					
+					break;	
+					
+				}
+				default: break;
+			}
+		}
+		
+		
+		//right
+		if ( ( y >=72 && y <= 88 ) && x > 200 )
+			//!( (y<=72||y>=88) && x<206 ) )
+			//y<=72||y>=88):y!=80) || x<208)
+		{
+			switch(dir)
+			{
+				case right:
+				case r_down:
+				case r_up:
+				
+				{
+					if(tmpscr->door[right]==dLOCKED)
+					{
+					    if(usekey())
+					    {
+						putdoor(scrollbuf,0,right,dUNLOCKED);
+						tmpscr->door[3]=dUNLOCKED;
+						setmapflag(si, mDOOR_RIGHT);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_LEFT);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					else if(tmpscr->door[right]==dBOSS)
+					{
+					    if(game->lvlitems[dlevel]&liBOSSKEY)
+					    {
+						putdoor(scrollbuf,0,right,dOPENBOSS);
+						tmpscr->door[3]=dOPENBOSS;
+						setmapflag(si, mDOOR_RIGHT);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_LEFT);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					
+					break;
+				}
+				default: break;
+				
+			}
+		}
+	}
+	else
+	{
+		//orthogonal movement
+		//Up door
+		if ( y<=32 && x == 120 )
+			//!( y>32 && (x!=120) ))
+		{
+			switch ( dir ) 
+			{
+				case up:
+				case r_up:
+				case l_up:
+				{
+					if(tmpscr->door[0]==dLOCKED)
+					{
+					    if(usekey())
+					    {
+						putdoor(scrollbuf,0,up,dUNLOCKED);
+						tmpscr->door[0]=dUNLOCKED;
+						setmapflag(si, mDOOR_UP);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_DOWN);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					else if(tmpscr->door[0]==dBOSS)
+					{
+					    if(game->lvlitems[dlevel]&liBOSSKEY)
+					    {
+						putdoor(scrollbuf,0,up,dOPENBOSS);
+						tmpscr->door[0]=dOPENBOSS;
+						setmapflag(si, mDOOR_UP);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_DOWN);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					break;
+				}
+				default: break;
+					
+			}
+		}
+		//Down
+		if ( y >= 128 && x == 120 )
+			//!(y<128 && (x!=120) ) )
+		{
+			switch(dir)
+			{
+				case down:
+				case l_down:
+				case r_down:
+				{
+					
+					if(tmpscr->door[1]==dLOCKED)
+					{
+					    if(usekey())
+					    {
+						putdoor(scrollbuf,0,down,dUNLOCKED);
+						tmpscr->door[1]=dUNLOCKED;
+						setmapflag(si, mDOOR_DOWN);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_UP);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					else if(tmpscr->door[1]==dBOSS)
+					{
+					    if(game->lvlitems[dlevel]&liBOSSKEY)
+					    {
+						putdoor(scrollbuf,0,down,dOPENBOSS);
+						tmpscr->door[1]=dOPENBOSS;
+						setmapflag(si, mDOOR_DOWN);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_UP);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					break;
+				}
+				default: break;
+			}
+		}
+		//left
+		if ( y == 80 && x <= 32 )
+			//!( (y!=80) && x>32 ) )
+		{
+			switch(dir)
+			{
+				case left:
+				case l_up:
+				case l_down:
+				{
+					if(tmpscr->door[2]==dLOCKED)
+					{
+					    if(usekey())
+					    {
+						putdoor(scrollbuf,0,left,dUNLOCKED);
+						tmpscr->door[2]=dUNLOCKED;
+						setmapflag(si, mDOOR_LEFT);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_RIGHT);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					else if(tmpscr->door[2]==dBOSS)
+					{
+					    if(game->lvlitems[dlevel]&liBOSSKEY)
+					    {
+						putdoor(scrollbuf,0,left,dOPENBOSS);
+						tmpscr->door[2]=dOPENBOSS;
+						setmapflag(si, mDOOR_LEFT);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_RIGHT);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					
+					break;	
+					
+				}
+				default: break;
+			}
+		}
+		//right
+		if ( y == 80 && x >= 208 )
+			//!((y!=80) && x<208 ) )
+		{
+			switch(dir)
+			{
+				case right:
+				case r_down:
+				case r_up:
+				{
+					if(tmpscr->door[3]==dLOCKED)
+					{
+					    if(usekey())
+					    {
+						putdoor(scrollbuf,0,right,dUNLOCKED);
+						tmpscr->door[3]=dUNLOCKED;
+						setmapflag(si, mDOOR_RIGHT);
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_LEFT);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+					    }
+					    else return;
+					}
+					else if(tmpscr->door[3]==dBOSS)
+					{
+					    if(game->lvlitems[dlevel]&liBOSSKEY)
+					    {
+						putdoor(scrollbuf,0,right,dOPENBOSS);
+						tmpscr->door[3]=dOPENBOSS;
+						setmapflag(si, mDOOR_RIGHT);
+						
+						
+						if(di != 0xFFFF)
+						    setmapflag(di, mDOOR_LEFT);
+						sfx(WAV_DOOR);
+						markBmap(-1);
+
+					    }
+					    else return;
+					}
+					
+					
+					break;
+				}
+				default: break;
+				
+			}
+		}
 	}
 	
-	*/
 	
+		
+	/*
     switch(dir)
     {
     case up:
@@ -8852,8 +9236,10 @@ void LinkClass::checklocked()
         }
     }
     
-    sfx(WAV_DOOR);
-    markBmap(-1);
+    
+    */
+    
+    
 }
 
 void LinkClass::checkswordtap()


### PR DESCRIPTION
Changelog: Refactored Link;s door interactions, to separate diagonal
and orthogonal checks.

Note, my previous fix did not do the trick, nor does this, but it is required, and reasonable, to split these up, 
so that a proper fix is possible. I now see and understand the issue that was reported quite clearly, and the door checking needs to poll input, when in diagonal movement mode, rather than check direction. 

Link's direction and his tile are not always a match, and the doors do not open when you would expect them to open. Link can glide back and forth along walls, and the door will not open until he stops, and presses a direction again. Thus, I have split diagonal and orthogonal checks for doors into their own sections, and I will follow this up with a fix for the actual issue. 