### PR TITLE
Minmap Fix

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -10976,7 +10976,6 @@ bool LinkClass::dowarp(int type, int index)
         {
             currdmap = wdmap;
             dlevel = DMaps[currdmap].level;
-		//This seems to not work as intended, according to Lut. -Z
             homescr = currscr = wscr + DMaps[wdmap].xoff;
             init_dmap();
             

--- a/src/subscr.cpp
+++ b/src/subscr.cpp
@@ -2563,7 +2563,7 @@ void drawdmap(BITMAP *dest, miscQdata *misc, int x, int y, bool showmap, int sho
         case dmCAVE:
             int maptile=has_item(itype_map, get_dlevel())?DMaps[get_currdmap()].minimap_2_tile:DMaps[get_currdmap()].minimap_1_tile;
             int mapcset=has_item(itype_map, get_dlevel())?DMaps[get_currdmap()].minimap_2_cset:DMaps[get_currdmap()].minimap_1_cset;
-            
+            //What a mess. The map drawing is based on a variable that can change states during a scrolling transition when warping. -Z
             if(maptile)
             {
                 draw_block(dest,x,y,maptile,mapcset,5,3);
@@ -2576,7 +2576,7 @@ void drawdmap(BITMAP *dest, miscQdata *misc, int x, int y, bool showmap, int sho
             {
                 rectfill(dest,x+8,y+8,x+71,y+39,c.dngn_bg);
             }
-            
+            //Marking this as a possible area for the scrolling warp map bug reported by Lut. -Z
             if(!DMaps[get_currdmap()].minimap_2_tile && has_item(itype_map, get_dlevel()))
             {
                 if((DMaps[get_currdmap()].flags&dmfMINIMAPCOLORFIX) != 0)

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -96,9 +96,9 @@
 
 #define ZELDA_VERSION       0x0250                          //version of the program
 #define VERSION_BUILD       31                              //build number of this version
-#define ZELDA_VERSION_STR   "2.53 Beta 8"                    //version of the program as presented in text
+#define ZELDA_VERSION_STR   "2.53 Beta 10"                    //version of the program as presented in text
 #define IS_BETA             1                               //is this a beta? (1: beta, -1: alpha)
-#define DATE_STR            "1st September, 2017"
+#define DATE_STR            "22nd September, 2017"
 #define COPYRIGHT_YEAR      "2017"                          //shown on title screen and in ending
 
 #define MIN_VERSION         0x0184


### PR DESCRIPTION
What a mess. The passive subscreen map is drawn from a variable that is not properly linked to whether Link is warping. I will address this fully in 2.60, as I need to address warping in general, there; but without some major changes to scrolling behaviour that I simply do not want to implement in 2.53, this is going to have to make the cut. 

I also marked some places for future reference that may be related to the reported issue on exiting water with diagonal movement, and I marked the locations that cause the map issue as well.