### PR TITLE
Add Debug Console Warning

### DIFF
--- a/src/zc_sys.cpp
+++ b/src/zc_sys.cpp
@@ -3429,6 +3429,20 @@ void updatescr(bool allowwavy)
         masked_blit(msgdisplaybuf,framebuf,0,0,0,playing_field_offset,256,168);
     }
     
+    /*
+    if(!(msgdisplaybuf->clip) && Playing && msgpos && !screenscrolling)
+    {
+	    BITMAP* subBmp = 0;
+	    masked_blit(msgdisplaybuf,subBmp,0,0,0,playing_field_offset,256,168);
+	    // masked_blit(msgdisplaybuf,subBmp,0,playing_field_offset,256,168);
+	     draw_trans_sprite(framebuf, subBmp, 0, playing_field_offset);
+	    destroy_bitmap(subBmp);
+	    //void draw_sprite_ex(BITMAP *bmp, BITMAP *sprite, int x, int y, int mode, int flip);
+       // masked_blit(msgdisplaybuf,framebuf,0,0,0,playing_field_offset,256,168);
+	    //void masked_blit(BITMAP *source, BITMAP *dest, int source_x, int source_y, int dest_x, int dest_y, int width, int height);
+    }
+    */
+    
     bool nosubscr = (tmpscr->flags3&fNOSUBSCR && !(tmpscr->flags3&fNOSUBSCROFFSET));
     
     if(nosubscr)
@@ -4657,13 +4671,55 @@ int onClickToFreeze()
     return D_O_K;
 }
 
+
+static DIALOG debugconsole_dlg[] =
+{
+    /* (dialog proc)       (x)   (y)   (w)   (h)   (fg)     (bg)     (key)    (flags)    (d1)      (d2)     (dp)     (dp2) (dp3) */
+    { jwin_win_proc,       40,   38,   241,  173,  vc(14),  vc(1),   0,       D_EXIT,    0,        0, (void *) "ZC Debug COnsole", NULL,  NULL },
+    
+    
+    { jwin_text_proc,         52,   70,  140,  8,    vc(0),   vc(11),  0,       0,         0,        0, (void *) "WARNING: Closing the console window, by using the ", NULL,  NULL },
+    { jwin_text_proc,         52,   80,  140,  8,    vc(0),   vc(11),  0,       0,         0,        0, (void *) "close window widget will terminate ZC!", NULL,  NULL },
+    { jwin_text_proc,         52,   90,  140,  8,    vc(0),   vc(11),  0,       0,         0,        0, (void *) "To close the debug console, use the SHOW DEBUG CONSOLE", NULL,  NULL },
+    { jwin_text_proc,         52,   100,  140,  8,    vc(0),   vc(11),  0,       0,         0,        0, (void *) "menu uption again!", NULL,  NULL },
+    
+    { jwin_frame_proc,     47,   65,   227,  115,  vc(15),  vc(1),   0,       0,         FR_DEEP,  0,       NULL, NULL,  NULL },
+    { d_bitmap_proc,       49,   67,   222,  110,  vc(15),  vc(1),   0,       0,         0,        0,       NULL, NULL,  NULL },
+    { jwin_button_proc,    60,  184,  41,   21,   vc(14),  vc(1),   0,       D_EXIT,    0,        0, (void *) "OK", NULL,  NULL },
+    { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
+};
+
+//Warning Info Box
+int onDoDebugConsole()
+{
+	
+    debugconsole_dlg[0].dp2=lfont;
+    
+    if(is_large)
+        large_dialog(debugconsole_dlg);
+        
+    zc_popup_dialog(debugconsole_dlg,1);
+    return D_O_K;
+}
+
 int onDebugConsole()
 {
 	if ( !zconsole ) {
-		DebugConsole::Open();
+		//int ret = zc_popup_dialog(debugconsole_dlg,2);
+		//if ( ret == D_O_K )
+		//{
+		char buf[100];
+		jwin_alert("WARNING: Closing the Debug Console", "WARNING: Closing the console window by using the close window widget will TERMINATE ZC!", "To SAFELY close the debug console, use the SHOW DEBUG CONSOLE menu uption again!",
+		buf, "O&K", NULL, 'o', 0, lfont);
+		
+		
+		
+			DebugConsole::Open();
 
-		zconsole = true;
-		return D_O_K;
+			zconsole = true;
+			return D_O_K;
+		//}
+		//else return -1;
 	}
 	else { 
 		
@@ -4672,6 +4728,7 @@ int onDebugConsole()
 		return D_O_K;
 	}
 }
+
 
 int onFrameSkip()
 {
@@ -5182,6 +5239,7 @@ static DIALOG about_dlg[] =
     { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
     { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
 };
+
 
 static DIALOG quest_dlg[] =
 {

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -98,7 +98,7 @@
 #define VERSION_BUILD       31                              //build number of this version
 #define ZELDA_VERSION_STR   "2.53 Beta 10"                    //version of the program as presented in text
 #define IS_BETA             1                               //is this a beta? (1: beta, -1: alpha)
-#define DATE_STR            "25th September, 2017"
+#define DATE_STR            "1st October, 2017"
 #define COPYRIGHT_YEAR      "2017"                          //shown on title screen and in ending
 
 #define MIN_VERSION         0x0184


### PR DESCRIPTION
Added a dialogue for warning users about closing the debug console without killing the ZC process.

This is about _as good as it gets_. 