### PR TITLE
Patch for Game->Set/GetComboX

### DIFF
--- a/output/common/zscript.txt
+++ b/output/common/zscript.txt
@@ -1,5 +1,5 @@
 //Docs for 2.53.0
-//Rev. 0.7.3.1; 19th September, 2017
+//Rev. 0.7.3.2; 2nd october, 2017
 
 Search for !#! to find areas that require completion. 
 
@@ -1079,7 +1079,7 @@ float Sqrt(float val);			ZASM Instruction:
 
 /************************************************************************************************************/
 
-	int LItems			ZASM Instruction: 
+	byte LItems			ZASM Instruction: 
 					GAMELITEMSD
 	/**
 	* The exploration items (map, compass, boss key etc.) of dungeon level i
@@ -1087,15 +1087,17 @@ float Sqrt(float val);			ZASM Instruction:
 	* the index used to access this array. Each element of this
 	* array consists of flags OR'd (|) together; use the LI_ constants in
 	* std.zh to set or compare these values.
+	* The valid range of values for this variable is 0 to 255.
 	*/ Example Use: !#!
 
 /************************************************************************************************************/
 
-	int LKeys[];			ZASM Instruction: 
+	byte LKeys[];			ZASM Instruction: 
 					GAMELKEYSD
 	/**
 	* The number of level keys of level i currently under the possession of
 	* the player, where i is the index used to access this array.
+	* The valid range of values for this variable is 0 to 255.
 	*/ Example Use: !#!
 
 /************************************************************************************************************/
@@ -2811,8 +2813,25 @@ void DrawString( 	int layer, int x, int y,
 					BITMAPR
 	
 	/**
-	* Draws a source rect from off-screen Bitmap with id of bitmap_id onto
-	* an area of the screen described by dest rect at the given layer.
+	* The process of copying one bitmap to another, or to the screen, is called a 'BLIT', or 'BLITTING'.
+	* This instruction BLITs a source rect from off-screen (memory) Bitmap with id of bitmap_id onto
+	* an area of the screen (or another bitmap) using a set of rectangular coordinates, at the given layer.
+	*
+	* Use source_x + source_w to define the X axis and source_y + source_h to define the
+	* Y axis of the bitmap area that you wish to draw; then specify the target area using
+	* dest_x + dest_w and dest_y + dest_h. 
+	* 
+	* If source_w and dest_w are not equal, or source_h and dest_h are not equal, the
+	* bitmap will be scaled.
+	*
+	* The valid range of coordinates on a bitmap is 0 tp 511, on each axis. Bitmaps are
+	* 512 pixels square, in size. 
+	*
+	* Rotation defines if the bitmap will be rotated. if so, it will be rotated on its centre 
+	* by a number of DEGREES equal to the value of rotation.
+	*
+	* If you wish to mask out translucent areas of the bitmap when blitting it, set mast true. 
+	*
 	*
 	*	(!) Note* Script drawing functions are enqueued and executed in a frame-by-frame basis 
 	*	based on the order of which layer they need to be drawn to. Drawing to or from

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -2590,54 +2590,6 @@ else \
 ///----------------------------------------------------------------------------------------------------//
 //Game->GetComboX
     
-    /*
-    case COMBODDM:
-    {
-        int pos = (ri->d[0])/10000;
-        int sc = (ri->d[2]/10000);
-	//int m = (ri->d[1]/10000)-1;
-	//long scr = m*MAPSCRS+sc;
-	    //This seems to need to be set up as it was here. -Z
-        int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
-	long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-	int layr = whichlayer(scr);
-	bool err_input_found;
-	    
-	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Game->GetComboData: %d \n", m);
-		err_input_found = true;
-	}
-	
-	if ( sc < 0 || sc >= MAPSCRS ) 
-	{
-		al_trace("Invalid Screen Reference Passed to Screen->GetComboData: %d \n", sc);
-		err_input_found = true;
-	}
-	
-	if ( pos < 0 || pos > 175 ) 
-	{
-		al_trace("Invalid Position Reference Passed to Screen->GetComboData: %d \n", pos);
-		err_input_found = true;
-	}
-	
-	if ( err_input_found ) { 
-		ret = -10000;
-	}
-        
-	else{
-	   
-	    if(scr==(currmap*MAPSCRS+currscr))
-		ret=tmpscr->data[pos]*10000;
-	    else if(layr>-1)
-		ret=tmpscr2[layr].data[pos]*10000;
-	    else ret=TheMaps[scr].data[pos]*10000;
-	}
-
-    }
-    break;
-    */
-    
-    //2.50.1-2 version. 
     case COMBODDM:
     {
         int pos = (ri->d[0])/10000;
@@ -2655,54 +2607,28 @@ else \
             else ret=TheMaps[scr].data[pos]*10000;
         }
         else
-            ret = 10000;
+            ret = -10000;
     }
     break;
     
-    //GetComboCSet
-   case COMBOCDM:
+    case COMBOCDM:
     {
         int pos = (ri->d[0])/10000;
         int sc = (ri->d[2]/10000);
-	//int m = (ri->d[1]/10000)-1;
-	    int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
-	long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-	//    long scr = m*MAPSCRS+sc;
-		
-            int layr = whichlayer(scr);
-	bool err_input_found;
-	    
-	if ( m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Game->GetComboCSet: %d \n", m);
-		err_input_found = true;
-	}
-	
-	if ( sc < 0 || sc >= MAPSCRS ) 
-	{
-		al_trace("Invalid Screen Reference Passed to Screen->GetComboCSet: %d \n", sc);
-		err_input_found = true;
-	}
-	
-	if ( pos < 0 || pos > 175 ) 
-	{
-		al_trace("Invalid Position Reference Passed to Screen->GetComboCSet: %d \n", pos);
-		err_input_found = true;
-	}
-	
-	if ( err_input_found ) { 
-		ret = -10000;
-	}
+        int m = zc_max((ri->d[1]/10000)-1,0);
+        long scr = zc_max(m*MAPSCRS+sc,0);
+        int layr = whichlayer(scr);
         
-	else
-	{
-            
+        if(pos >= 0 && pos < 176 && scr >= 0 && sc < MAPSCRS && m < map_count)
+        {
             if(scr==(currmap*MAPSCRS+currscr))
                 ret=tmpscr->cset[pos]*10000;
             else if(layr>-1)
                 ret=tmpscr2[layr].cset[pos]*10000;
             else ret=TheMaps[scr].cset[pos]*10000;
-	}
-
+        }
+        else
+            ret = -10000;
     }
     break;
     
@@ -2710,44 +2636,20 @@ else \
     {
         int pos = (ri->d[0])/10000;
         int sc = (ri->d[2]/10000);
-        //int m = (ri->d[1]/10000)-1;
-	int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
-	//    long scr = m*MAPSCRS+sc;
-	long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-            int layr = whichlayer(scr);
-	bool err_input_found;
-	    
-	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Game->GetComboFlag: %d \n", m);
-		err_input_found = true;
-	}
-	
-	if ( sc < 0 || sc >= MAPSCRS ) 
-	{
-		al_trace("Invalid Screen Reference Passed to Screen->GetComboFlag: %d \n", sc);
-		err_input_found = true;
-	}
-	
-	if ( pos < 0 || pos > 175 ) 
-	{
-		al_trace("Invalid Position Reference Passed to Screen->GetComboFlag: %d \n", pos);
-		err_input_found = true;
-	}
-	
-	if ( err_input_found ) { 
-		ret = -10000;
-	}
+        int m = zc_max((ri->d[1]/10000)-1,0);
+        long scr = zc_max(m*MAPSCRS+sc,0);
+        int layr = whichlayer(scr);
         
-	else
-	{
-            
+        if(pos >= 0 && pos < 176 && scr >= 0 && sc < MAPSCRS && m < map_count)
+        {
             if(scr==(currmap*MAPSCRS+currscr))
                 ret=tmpscr->sflag[pos]*10000;
             else if(layr>-1)
                 ret=tmpscr2[layr].sflag[pos]*10000;
             else ret=TheMaps[scr].sflag[pos]*10000;
-	}
-
+        }
+        else
+            ret = -10000;
     }
     break;
     
@@ -2755,92 +2657,42 @@ else \
     {
         int pos = (ri->d[0])/10000;
         int sc = (ri->d[2]/10000);
-        //int m = (ri->d[1]/10000)-1;
-	int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
-	//long scr = m*MAPSCRS+sc;
-	long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-	int layr = whichlayer(scr);
-	bool err_input_found;
-	    
-	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Game->GetComboType: %d \n", m);
-		err_input_found = true;
-	}
-	
-	if ( sc < 0 || sc >= MAPSCRS ) 
-	{
-		al_trace("Invalid Screen Reference Passed to Screen->GetComboType: %d \n", sc);
-		err_input_found = true;
-	}
-	
-	if ( pos < 0 || pos > 175 ) 
-	{
-		al_trace("Invalid Position Reference Passed to Screen->GetComboype: %d \n", pos);
-		err_input_found = true;
-	}
-	
-	if ( err_input_found ) { 
-		ret = -10000;
-	}
+        int m = zc_max((ri->d[1]/10000)-1,0);
+        long scr = zc_max(m*MAPSCRS+sc,0);
+        int layr = whichlayer(scr);
         
-	else
-	{
-            
-            
+        if(pos >= 0 && pos < 176 && scr >= 0 && sc < MAPSCRS && m < map_count)
+        {
             if(scr==(currmap*MAPSCRS+currscr))
                 ret=combobuf[tmpscr->data[pos]].type*10000;
             else if(layr>-1)
                 ret=combobuf[tmpscr2[layr].data[pos]].type*10000;
             else ret=combobuf[
                              TheMaps[scr].data[pos]].type*10000;
-	}
-
+        }
+        else
+            ret = -10000;
     }
     break;
     
-   case COMBOIDM:
+    case COMBOIDM:
     {
         int pos = (ri->d[0])/10000;
         int sc = (ri->d[2]/10000);
-        //int m = (ri->d[1]/10000)-1;
-	int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
-	//long scr = m*MAPSCRS+sc;
-	long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-	int layr = whichlayer(scr);
-	bool err_input_found;
-	    
-	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Game->GetComboInherentFlag: %d \n", m);
-		err_input_found = true;
-	}
-	
-	if ( sc < 0 || sc >= MAPSCRS ) 
-	{
-		al_trace("Invalid Screen Reference Passed to Screen->GetComboInherentFlag: %d \n", sc);
-		err_input_found = true;
-	}
-	
-	if ( pos < 0 || pos > 175 ) 
-	{
-		al_trace("Invalid Position Reference Passed to Screen->GetComboInherentFLag: %d \n", pos);
-		err_input_found = true;
-	}
-	
-	if ( err_input_found ) { 
-		ret = -10000;
-	}
+        int m = zc_max((ri->d[1]/10000)-1,0);
+        long scr = zc_max(m*MAPSCRS+sc,0);
+        int layr = whichlayer(scr);
         
-        
-        else
+        if(pos >= 0 && pos < 176 && scr >= 0 && sc < MAPSCRS && m < map_count)
         {
-            
-            
             if(scr==(currmap*MAPSCRS+currscr))
                 ret=combobuf[tmpscr->data[pos]].flag*10000;
             else if(layr>-1)
                 ret=combobuf[tmpscr2[layr].data[pos]].flag*10000;
             else ret=combobuf[TheMaps[scr].data[pos]].flag*10000;
         }
+        else
+            ret = -10000;
     }
     break;
     
@@ -2848,46 +2700,23 @@ else \
     {
         int pos = (ri->d[0])/10000;
         int sc = (ri->d[2]/10000);
-	//int m = (ri->d[1]/10000)-1;
-	int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
-	long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-	//long scr = m*MAPSCRS+sc;
-	int layr = whichlayer(scr);
-	bool err_input_found; 
-	    
-	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Game->GetComboSolid: %d \n", m);
-		err_input_found = true;
-	}
-	
-	if ( sc < 0 || sc >= MAPSCRS ) 
-	{
-		al_trace("Invalid Screen Reference Passed to Screen->GetComboSolid: %d \n", sc);
-		err_input_found = true;
-	}
-	
-	if ( pos < 0 || pos > 175 ) 
-	{
-		al_trace("Invalid Position Reference Passed to Screen->GetComboSolid: %d \n", pos);
-		err_input_found = true;
-	}
-	
-	if ( err_input_found ) { 
-		ret = -10000;
-	}
+        int m = zc_max((ri->d[1]/10000)-1,0);
+        long scr = zc_max(m*MAPSCRS+sc,0);
+        int layr = whichlayer(scr);
         
-        else
+        if(pos >= 0 && pos < 176 && scr >= 0 && sc < MAPSCRS && m < map_count)
         {
-            
             if(scr==(currmap*MAPSCRS+currscr))
                 ret=(combobuf[tmpscr->data[pos]].walk&15)*10000;
             else if(layr>-1)
                 ret=(combobuf[tmpscr2[layr].data[pos]].walk&15)*10000;
             else ret=(combobuf[TheMaps[scr].data[pos]].walk&15)*10000;
         }
-
+        else
+            ret = -10000;
     }
     break;
+   
     
 ///----------------------------------------------------------------------------------------------------//
 //Screen Information
@@ -4738,98 +4567,14 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
     
 ///----------------------------------------------------------------------------------------------------//
 //Game->SetComboX
-
-/*
-    case COMBODDM:
-    {
-        int pos = (ri->d[0])/10000;
-        int sc = (ri->d[2]/10000);
-        int m = (ri->d[1]/10000)-1;
-        //int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
-	bool err_input_found;
-	    
-	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Screen->SetComboData: %d \n", m);
-		err_input_found = true;
-	}
-	
-	if ( sc < 0 || sc >= MAPSCRS ) 
-	{
-		al_trace("Invalid Screen Reference Passed to Screen->SetComboData: %d \n", sc);
-		err_input_found = true;
-	}
-	
-	if ( pos < 0 || pos > 175 ) 
-	{
-		al_trace("Invalid Position Reference Passed to Screen->SetComboData: %d \n", pos);
-		err_input_found = true;
-	}
-	
-	if ( err_input_found ) { 
-		break;
-	}
-        
-        //long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-	   long scr = m*MAPSCRS+sc;
-        if(scr==(currmap*MAPSCRS+currscr))
-            screen_combo_modify_preroutine(tmpscr,pos);
-            
-        TheMaps[scr].data[pos]=value/10000;
-        
-        if(scr==(currmap*MAPSCRS+currscr))
-        {
-            tmpscr->data[pos] = value/10000;
-            screen_combo_modify_postroutine(tmpscr,pos);
-        }
-        
-        int layr = whichlayer(scr);
-        
-        if(layr>-1)
-        {
-            //if (layr==(currmap*MAPSCRS+currscr))
-            //  screen_combo_modify_preroutine(tmpscr,pos);
-            tmpscr2[layr].data[pos]=value/10000;
-            //if (layr==(currmap*MAPSCRS+currscr))
-            //  screen_combo_modify_postroutine(tmpscr,pos);
-        }
-    }
-    break;
-*/
-//2.50.1-2 version
-//SetComboData
-//The changes to this in 2.50.3 broke quests. -Z
-    case COMBODDM:
+case COMBODDM:
     {
         int pos = (ri->d[0])/10000;
         int sc = (ri->d[2]/10000);
         int m = zc_max((ri->d[1]/10000)-1,0);
         long scr = zc_max(m*MAPSCRS+sc,0);
         
-	//bool err_input_found = false;
-	  /*  
-	if ( m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Screen->SetComboData: %d \n", m);
-	//	err_input_found = true;
-	}
-	
-	if ( sc < 0 || sc >= MAPSCRS ) 
-	{
-		al_trace("Invalid Screen Reference Passed to Screen->SetComboData: %d \n", sc);
-	//	err_input_found = true;
-	}
-	
-	if ( pos < 0 || pos > 175 ) 
-	{
-		al_trace("Invalid Position Reference Passed to Screen->SetComboData: %d \n", pos);
-	//	err_input_found = true;
-	}
-	
-	//if ( err_input_found ) { 
-	//	break;
-	//}
-	*/
-	
-	if(!(pos >= 0 && pos < 176 && scr >= 0 && sc < MAPSCRS && m < map_count)) break;
+        if(!(pos >= 0 && pos < 176 && scr >= 0 && sc < MAPSCRS && m < map_count)) break;
         
         if(scr==(currmap*MAPSCRS+currscr))
             screen_combo_modify_preroutine(tmpscr,pos);
@@ -4854,52 +4599,6 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
         }
     }
     break;
-    /*
-     case COMBOCDM:
-    {
-        int pos = (ri->d[0])/10000;
-        int sc = (ri->d[2]/10000);
-        int m = (ri->d[1]/10000)-1;
-	    //int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
-	bool err_input_found;
-	    
-	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Screen->SetComboCSet: %d \n", m);
-		err_input_found = true;
-	}
-	
-	if ( sc < 0 || sc >= MAPSCRS ) 
-	{
-		al_trace("Invalid Screen Reference Passed to Screen->SetComboSet: %d \n", sc);
-		err_input_found = true;
-	}
-	
-	if ( pos < 0 || pos > 175 ) 
-	{
-		al_trace("Invalid Position Reference Passed to Screen->SetComboSet: %d \n", pos);
-		err_input_found = true;
-	}
-	
-	if ( err_input_found ) { 
-		break;
-	}
-        
-         //long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-	long scr = m*MAPSCRS+sc;
-        TheMaps[scr].cset[pos]=(value/10000)&15;
-        
-        if(scr==(currmap*MAPSCRS+currscr))
-            tmpscr->cset[pos] = value/10000;
-            
-        int layr = whichlayer(scr);
-        
-        if(layr>-1)
-            tmpscr2[layr].cset[pos]=(value/10000)&15;
-    }
-    break;
-    */
-    
-    //2.50.2
     
     case COMBOCDM:
     {
@@ -4922,52 +4621,6 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
     }
     break;
     
-    /*
-    case COMBOFDM:
-    {
-        int pos = (ri->d[0])/10000;
-        int sc = (ri->d[2]/10000);
-        int m = (ri->d[1]/10000)-1;
-	    //int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
-	    long scr = m*MAPSCRS+sc;
-	//long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-	bool err_input_found;
-	    
-	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Screen->SetComboFlag: %d \n", m);
-		err_input_found = true;
-	}
-	
-	if ( sc < 0 || sc >= MAPSCRS ) 
-	{
-		al_trace("Invalid Screen Reference Passed to Screen->SetComboFlag: %d \n", sc);
-		err_input_found = true;
-	}
-	
-	if ( pos < 0 || pos > 175 ) 
-	{
-		al_trace("Invalid Position Reference Passed to Screen->SetComboFlag: %d \n", pos);
-		err_input_found = true;
-	}
-	
-	if ( err_input_found ) { 
-		break;
-	}
-
-        
-        
-        TheMaps[scr].sflag[pos]=value/10000;
-        
-        if(scr==(currmap*MAPSCRS+currscr))
-            tmpscr->sflag[pos] = value/10000;
-            
-        int layr = whichlayer(scr);
-        
-        if(layr>-1)
-            tmpscr2[layr].sflag[pos]=value/10000;
-    }
-    break;
-    */
     case COMBOFDM:
     {
         int pos = (ri->d[0])/10000;
@@ -4989,63 +4642,6 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
     }
     break;
     
-    /*
-    case COMBOTDM:
-    {
-        int pos = (ri->d[0])/10000;
-        int sc = (ri->d[2]/10000);
-        int m = (ri->d[1]/10000)-1;
-	    //int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
-	bool err_input_found;
-	    
-	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Screen->SetComboType: %d \n", m);
-		err_input_found = true;
-	}
-	
-	if ( sc < 0 || sc >= MAPSCRS ) 
-	{
-		al_trace("Invalid Screen Reference Passed to Screen->SetComboType: %d \n", sc);
-		err_input_found = true;
-	}
-	
-	if ( pos < 0 || pos > 175 ) 
-	{
-		al_trace("Invalid Position Reference Passed to Screen->SetComboType: %d \n", pos);
-		err_input_found = true;
-	}
-	
-	if ( err_input_found ) { 
-		break;
-	}
-        
-        long scr = m*MAPSCRS+sc;
-	//long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-        int cdata = TheMaps[scr].data[pos];
-        
-        // Preprocess the screen's combos in case the combo changed is present on the screen. -L
-        for(int i = 0; i < 176; i++)
-        {
-            if(tmpscr->data[i] == cdata)
-            {
-                screen_combo_modify_preroutine(tmpscr,i);
-            }
-        }
-        
-        combobuf[cdata].type=value/10000;
-        
-        for(int i = 0; i < 176; i++)
-        {
-            if(tmpscr->data[i] == cdata)
-            {
-                screen_combo_modify_postroutine(tmpscr,i);
-            }
-        }
-    }
-    break;
-    */
-    
-    //2.50.2
     case COMBOTDM:
     {
         int pos = (ri->d[0])/10000;
@@ -5078,45 +4674,6 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
         }
     }
     break;
-    
-    /*
-    case COMBOIDM:
-    {
-        int pos = (ri->d[0])/10000;
-        int sc = (ri->d[2]/10000);
-        int m = (ri->d[1]/10000)-1;
-	    //int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
-	bool err_input_found;
-	    
-	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Screen->SetComboInherentFlag: %d \n", m);
-		err_input_found = true;
-	}
-	
-	if ( sc < 0 || sc >= MAPSCRS ) 
-	{
-		al_trace("Invalid Screen Reference Passed to Screen->SetComboInherentFlag: %d \n", sc);
-		err_input_found = true;
-	}
-	
-	if ( pos < 0 || pos > 175 ) 
-	{
-		al_trace("Invalid Position Reference Passed to Screen->SetComboInherentFlag: %d \n", pos);
-		err_input_found = true;
-	}
-	
-	if ( err_input_found ) { 
-		break;
-	}
-        
-        long scr = m*MAPSCRS+sc;
-	//long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-        combobuf[TheMaps[scr].data[pos]].flag=value/10000;
-    }
-    break;
-    
-    */
-    //2.50.2
     
     case COMBOIDM:
     {
@@ -5137,7 +4694,7 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
 	    //This is how it was in 2.50.1-2
 		int pos = (ri->d[0])/10000;
 		long scr = (ri->d[1]/10000)*MAPSCRS+(ri->d[2]/10000);
-		//This (below) us the precise code from 2.50.1
+		//This (below) us the precise code from 2.50.1 (?)
 		//long scr = zc_max((ri->d[1]/10000)*MAPSCRS+(ri->d[2]/10000),0); //Not below 0. 
 
 		if(pos < 0 || pos >= 176 || scr < 0) break;

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -2589,28 +2589,33 @@ else \
     
 ///----------------------------------------------------------------------------------------------------//
 //Game->GetComboX
+    
+    
     case COMBODDM:
     {
         int pos = (ri->d[0])/10000;
         int sc = (ri->d[2]/10000);
-	int m = (ri->d[1]/10000)-1;
-        //int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
+	//int m = (ri->d[1]/10000)-1;
+	//long scr = m*MAPSCRS+sc;
+        int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
+	long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
+	int layr = whichlayer(scr);
 	bool err_input_found;
 	    
 	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Game->GetComboData: \n %d", m);
+		al_trace("Invalid Map Reference Passed to Game->GetComboData: %d \n", m);
 		err_input_found = true;
 	}
 	
 	if ( sc < 0 || sc >= MAPSCRS ) 
 	{
-		al_trace("Invalid Screen Reference Passed to Screen->GetComboData: \n %d", sc);
+		al_trace("Invalid Screen Reference Passed to Screen->GetComboData: %d \n", sc);
 		err_input_found = true;
 	}
 	
 	if ( pos < 0 || pos > 175 ) 
 	{
-		al_trace("Invalid Position Reference Passed to Screen->GetComboData: \n %d", pos);
+		al_trace("Invalid Position Reference Passed to Screen->GetComboData: %d \n", pos);
 		err_input_found = true;
 	}
 	
@@ -2619,9 +2624,7 @@ else \
 	}
         
 	else{
-	    //long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-	    long scr = m*MAPSCRS+sc;
-		int layr = whichlayer(scr);
+	   
 	    if(scr==(currmap*MAPSCRS+currscr))
 		ret=tmpscr->data[pos]*10000;
 	    else if(layr>-1)
@@ -2632,28 +2635,56 @@ else \
     }
     break;
     
+    /*
+    //2.50.1-2 version. 
+    case COMBODDM:
+    {
+        int pos = (ri->d[0])/10000;
+        int sc = (ri->d[2]/10000);
+        int m = zc_max((ri->d[1]/10000)-1,0);
+        long scr = zc_max(m*MAPSCRS+sc,0);
+        int layr = whichlayer(scr);
+        
+        if(pos >= 0 && pos < 176 && scr >= 0 && sc < MAPSCRS && m < map_count)
+        {
+            if(scr==(currmap*MAPSCRS+currscr))
+                ret=tmpscr->data[pos]*10000;
+            else if(layr>-1)
+                ret=tmpscr2[layr].data[pos]*10000;
+            else ret=TheMaps[scr].data[pos]*10000;
+        }
+        else
+            ret = 10000;
+    }
+    break;
+    */
+    //GetComboCSet
    case COMBOCDM:
     {
         int pos = (ri->d[0])/10000;
         int sc = (ri->d[2]/10000);
-        int m = (ri->d[1]/10000)-1;
-	    //int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
+	//int m = (ri->d[1]/10000)-1;
+	    int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
+	    long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
+	    //long scr = m*MAPSCRS+sc;
+		
+            int layr = whichlayer(scr);
 	bool err_input_found;
 	    
 	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Game->GetComboCSet: \n %d", m);
+		al_trace("Invalid Map Reference Passed to Game->GetComboCSet: %d \n", m);
 		err_input_found = true;
 	}
 	
 	if ( sc < 0 || sc >= MAPSCRS ) 
 	{
-		al_trace("Invalid Screen Reference Passed to Screen->GetComboCSet: \n %d", sc);
+		al_trace("Invalid Screen Reference Passed to Screen->GetComboCSet: %d \n", sc);
 		err_input_found = true;
 	}
 	
 	if ( pos < 0 || pos > 175 ) 
 	{
-		al_trace("Invalid Position Reference Passed to Screen->GetComboCSet: \n %d", pos);
+		al_trace("Invalid Position Reference Passed to Screen->GetComboCSet: %d \n", pos);
 		err_input_found = true;
 	}
 	
@@ -2663,9 +2694,7 @@ else \
         
 	else
 	{
-            long scr = m*MAPSCRS+sc;
-		//long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-            int layr = whichlayer(scr);
+            
             if(scr==(currmap*MAPSCRS+currscr))
                 ret=tmpscr->cset[pos]*10000;
             else if(layr>-1)
@@ -2680,24 +2709,27 @@ else \
     {
         int pos = (ri->d[0])/10000;
         int sc = (ri->d[2]/10000);
-        int m = (ri->d[1]/10000)-1;
-	    //int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
+        //int m = (ri->d[1]/10000)-1;
+	int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
+	//    long scr = m*MAPSCRS+sc;
+	long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
+            int layr = whichlayer(scr);
 	bool err_input_found;
 	    
 	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Game->GetComboFlag: \n %d", m);
+		al_trace("Invalid Map Reference Passed to Game->GetComboFlag: %d \n", m);
 		err_input_found = true;
 	}
 	
 	if ( sc < 0 || sc >= MAPSCRS ) 
 	{
-		al_trace("Invalid Screen Reference Passed to Screen->GetComboFlag: \n %d", sc);
+		al_trace("Invalid Screen Reference Passed to Screen->GetComboFlag: %d \n", sc);
 		err_input_found = true;
 	}
 	
 	if ( pos < 0 || pos > 175 ) 
 	{
-		al_trace("Invalid Position Reference Passed to Screen->GetComboFlag: \n %d", pos);
+		al_trace("Invalid Position Reference Passed to Screen->GetComboFlag: %d \n", pos);
 		err_input_found = true;
 	}
 	
@@ -2707,9 +2739,7 @@ else \
         
 	else
 	{
-            long scr = m*MAPSCRS+sc;
-		//long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-            int layr = whichlayer(scr);
+            
             if(scr==(currmap*MAPSCRS+currscr))
                 ret=tmpscr->sflag[pos]*10000;
             else if(layr>-1)
@@ -2724,24 +2754,27 @@ else \
     {
         int pos = (ri->d[0])/10000;
         int sc = (ri->d[2]/10000);
-        int m = (ri->d[1]/10000)-1;
-	    //int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
+        //int m = (ri->d[1]/10000)-1;
+	int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
+	//long scr = m*MAPSCRS+sc;
+	long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
+	int layr = whichlayer(scr);
 	bool err_input_found;
 	    
 	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Game->GetComboType: \n %d", m);
+		al_trace("Invalid Map Reference Passed to Game->GetComboType: %d \n", m);
 		err_input_found = true;
 	}
 	
 	if ( sc < 0 || sc >= MAPSCRS ) 
 	{
-		al_trace("Invalid Screen Reference Passed to Screen->GetComboType: \n %d", sc);
+		al_trace("Invalid Screen Reference Passed to Screen->GetComboType: %d \n", sc);
 		err_input_found = true;
 	}
 	
 	if ( pos < 0 || pos > 175 ) 
 	{
-		al_trace("Invalid Position Reference Passed to Screen->GetComboype: \n %d", pos);
+		al_trace("Invalid Position Reference Passed to Screen->GetComboype: %d \n", pos);
 		err_input_found = true;
 	}
 	
@@ -2751,9 +2784,8 @@ else \
         
 	else
 	{
-            long scr = m*MAPSCRS+sc;
-		//long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-            int layr = whichlayer(scr);
+            
+            
             if(scr==(currmap*MAPSCRS+currscr))
                 ret=combobuf[tmpscr->data[pos]].type*10000;
             else if(layr>-1)
@@ -2769,24 +2801,27 @@ else \
     {
         int pos = (ri->d[0])/10000;
         int sc = (ri->d[2]/10000);
-        int m = (ri->d[1]/10000)-1;
-	     //int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
+        //int m = (ri->d[1]/10000)-1;
+	int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
+	//long scr = m*MAPSCRS+sc;
+	long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
+	int layr = whichlayer(scr);
 	bool err_input_found;
 	    
 	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Game->GetComboInherentFlag: \n %d", m);
+		al_trace("Invalid Map Reference Passed to Game->GetComboInherentFlag: %d \n", m);
 		err_input_found = true;
 	}
 	
 	if ( sc < 0 || sc >= MAPSCRS ) 
 	{
-		al_trace("Invalid Screen Reference Passed to Screen->GetComboInherentFlag: \n %d", sc);
+		al_trace("Invalid Screen Reference Passed to Screen->GetComboInherentFlag: %d \n", sc);
 		err_input_found = true;
 	}
 	
 	if ( pos < 0 || pos > 175 ) 
 	{
-		al_trace("Invalid Position Reference Passed to Screen->GetComboInherentFLag: \n %d", pos);
+		al_trace("Invalid Position Reference Passed to Screen->GetComboInherentFLag: %d \n", pos);
 		err_input_found = true;
 	}
 	
@@ -2797,9 +2832,8 @@ else \
         
         else
         {
-            long scr = m*MAPSCRS+sc;
-		//long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-            int layr = whichlayer(scr);
+            
+            
             if(scr==(currmap*MAPSCRS+currscr))
                 ret=combobuf[tmpscr->data[pos]].flag*10000;
             else if(layr>-1)
@@ -2813,24 +2847,27 @@ else \
     {
         int pos = (ri->d[0])/10000;
         int sc = (ri->d[2]/10000);
-	    int m = (ri->d[1]/10000)-1;
-         //int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
+	//int m = (ri->d[1]/10000)-1;
+	int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
+	long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
+	//long scr = m*MAPSCRS+sc;
+	int layr = whichlayer(scr);
 	bool err_input_found; 
 	    
 	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Game->GetComboSolid: \n %d", m);
+		al_trace("Invalid Map Reference Passed to Game->GetComboSolid: %d \n", m);
 		err_input_found = true;
 	}
 	
 	if ( sc < 0 || sc >= MAPSCRS ) 
 	{
-		al_trace("Invalid Screen Reference Passed to Screen->GetComboSolid: \n %d", sc);
+		al_trace("Invalid Screen Reference Passed to Screen->GetComboSolid: %d \n", sc);
 		err_input_found = true;
 	}
 	
 	if ( pos < 0 || pos > 175 ) 
 	{
-		al_trace("Invalid Position Reference Passed to Screen->GetComboSolid: \n %d", pos);
+		al_trace("Invalid Position Reference Passed to Screen->GetComboSolid: %d \n", pos);
 		err_input_found = true;
 	}
 	
@@ -2840,9 +2877,7 @@ else \
         
         else
         {
-            //long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-	    long scr = m*MAPSCRS+sc;
-            int layr = whichlayer(scr);
+            
             if(scr==(currmap*MAPSCRS+currscr))
                 ret=(combobuf[tmpscr->data[pos]].walk&15)*10000;
             else if(layr>-1)
@@ -4702,6 +4737,8 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
     
 ///----------------------------------------------------------------------------------------------------//
 //Game->SetComboX
+
+/*
     case COMBODDM:
     {
         int pos = (ri->d[0])/10000;
@@ -4711,19 +4748,19 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
 	bool err_input_found;
 	    
 	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Screen->SetComboData: \n %d", m);
+		al_trace("Invalid Map Reference Passed to Screen->SetComboData: %d \n", m);
 		err_input_found = true;
 	}
 	
 	if ( sc < 0 || sc >= MAPSCRS ) 
 	{
-		al_trace("Invalid Screen Reference Passed to Screen->SetComboData: \n %d", sc);
+		al_trace("Invalid Screen Reference Passed to Screen->SetComboData: %d \n", sc);
 		err_input_found = true;
 	}
 	
 	if ( pos < 0 || pos > 175 ) 
 	{
-		al_trace("Invalid Position Reference Passed to Screen->SetComboData: \n %d", pos);
+		al_trace("Invalid Position Reference Passed to Screen->SetComboData: %d \n", pos);
 		err_input_found = true;
 	}
 	
@@ -4732,7 +4769,42 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
 	}
         
         //long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-	    long scr = m*MAPSCRS+sc;
+	   long scr = m*MAPSCRS+sc;
+        if(scr==(currmap*MAPSCRS+currscr))
+            screen_combo_modify_preroutine(tmpscr,pos);
+            
+        TheMaps[scr].data[pos]=value/10000;
+        
+        if(scr==(currmap*MAPSCRS+currscr))
+        {
+            tmpscr->data[pos] = value/10000;
+            screen_combo_modify_postroutine(tmpscr,pos);
+        }
+        
+        int layr = whichlayer(scr);
+        
+        if(layr>-1)
+        {
+            //if (layr==(currmap*MAPSCRS+currscr))
+            //  screen_combo_modify_preroutine(tmpscr,pos);
+            tmpscr2[layr].data[pos]=value/10000;
+            //if (layr==(currmap*MAPSCRS+currscr))
+            //  screen_combo_modify_postroutine(tmpscr,pos);
+        }
+    }
+    break;
+*/
+//2.50.1-2 version
+//SetComboData
+    case COMBODDM:
+    {
+        int pos = (ri->d[0])/10000;
+        int sc = (ri->d[2]/10000);
+        int m = zc_max((ri->d[1]/10000)-1,0);
+        long scr = zc_max(m*MAPSCRS+sc,0);
+        
+        if(!(pos >= 0 && pos < 176 && scr >= 0 && sc < MAPSCRS && m < map_count)) break;
+        
         if(scr==(currmap*MAPSCRS+currscr))
             screen_combo_modify_preroutine(tmpscr,pos);
             
@@ -4766,19 +4838,19 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
 	bool err_input_found;
 	    
 	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Screen->SetComboCSet: \n %d", m);
+		al_trace("Invalid Map Reference Passed to Screen->SetComboCSet: %d \n", m);
 		err_input_found = true;
 	}
 	
 	if ( sc < 0 || sc >= MAPSCRS ) 
 	{
-		al_trace("Invalid Screen Reference Passed to Screen->SetComboSet: \n %d", sc);
+		al_trace("Invalid Screen Reference Passed to Screen->SetComboSet: %d \n", sc);
 		err_input_found = true;
 	}
 	
 	if ( pos < 0 || pos > 175 ) 
 	{
-		al_trace("Invalid Position Reference Passed to Screen->SetComboSet: \n %d", pos);
+		al_trace("Invalid Position Reference Passed to Screen->SetComboSet: %d \n", pos);
 		err_input_found = true;
 	}
 	
@@ -4806,22 +4878,24 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
         int sc = (ri->d[2]/10000);
         int m = (ri->d[1]/10000)-1;
 	    //int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
+	    long scr = m*MAPSCRS+sc;
+	//long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
 	bool err_input_found;
 	    
 	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Screen->SetComboFlag: \n %d", m);
+		al_trace("Invalid Map Reference Passed to Screen->SetComboFlag: %d \n", m);
 		err_input_found = true;
 	}
 	
 	if ( sc < 0 || sc >= MAPSCRS ) 
 	{
-		al_trace("Invalid Screen Reference Passed to Screen->SetComboFlag: \n %d", sc);
+		al_trace("Invalid Screen Reference Passed to Screen->SetComboFlag: %d \n", sc);
 		err_input_found = true;
 	}
 	
 	if ( pos < 0 || pos > 175 ) 
 	{
-		al_trace("Invalid Position Reference Passed to Screen->SetComboFlag: \n %d", pos);
+		al_trace("Invalid Position Reference Passed to Screen->SetComboFlag: %d \n", pos);
 		err_input_found = true;
 	}
 	
@@ -4830,8 +4904,7 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
 	}
 
         
-        long scr = m*MAPSCRS+sc;
-	//long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
+        
         TheMaps[scr].sflag[pos]=value/10000;
         
         if(scr==(currmap*MAPSCRS+currscr))
@@ -4853,19 +4926,19 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
 	bool err_input_found;
 	    
 	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Screen->SetComboType: \n %d", m);
+		al_trace("Invalid Map Reference Passed to Screen->SetComboType: %d \n", m);
 		err_input_found = true;
 	}
 	
 	if ( sc < 0 || sc >= MAPSCRS ) 
 	{
-		al_trace("Invalid Screen Reference Passed to Screen->SetComboType: \n %d", sc);
+		al_trace("Invalid Screen Reference Passed to Screen->SetComboType: %d \n", sc);
 		err_input_found = true;
 	}
 	
 	if ( pos < 0 || pos > 175 ) 
 	{
-		al_trace("Invalid Position Reference Passed to Screen->SetComboType: \n %d", pos);
+		al_trace("Invalid Position Reference Passed to Screen->SetComboType: %d \n", pos);
 		err_input_found = true;
 	}
 	
@@ -4907,19 +4980,19 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
 	bool err_input_found;
 	    
 	if ( m < 0 || m >= map_count ) {
-		al_trace("Invalid Map Reference Passed to Screen->SetComboInherentFlag: \n %d", m);
+		al_trace("Invalid Map Reference Passed to Screen->SetComboInherentFlag: %d \n", m);
 		err_input_found = true;
 	}
 	
 	if ( sc < 0 || sc >= MAPSCRS ) 
 	{
-		al_trace("Invalid Screen Reference Passed to Screen->SetComboInherentFlag: \n %d", sc);
+		al_trace("Invalid Screen Reference Passed to Screen->SetComboInherentFlag: %d \n", sc);
 		err_input_found = true;
 	}
 	
 	if ( pos < 0 || pos > 175 ) 
 	{
-		al_trace("Invalid Position Reference Passed to Screen->SetComboInherentFlag: \n %d", pos);
+		al_trace("Invalid Position Reference Passed to Screen->SetComboInherentFlag: %d \n", pos);
 		err_input_found = true;
 	}
 	

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -2590,7 +2590,7 @@ else \
 ///----------------------------------------------------------------------------------------------------//
 //Game->GetComboX
     
-    
+    /*
     case COMBODDM:
     {
         int pos = (ri->d[0])/10000;
@@ -2635,8 +2635,8 @@ else \
 
     }
     break;
+    */
     
-    /*
     //2.50.1-2 version. 
     case COMBODDM:
     {
@@ -2658,7 +2658,7 @@ else \
             ret = 10000;
     }
     break;
-    */
+    
     //GetComboCSet
    case COMBOCDM:
     {
@@ -2666,8 +2666,8 @@ else \
         int sc = (ri->d[2]/10000);
 	//int m = (ri->d[1]/10000)-1;
 	    int m = zc_max((ri->d[1]/10000)-1,0); //2.50.1 had this. 
-	    long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
-	    //long scr = m*MAPSCRS+sc;
+	long scr = zc_max(m*MAPSCRS+sc,0); //2.50.1 had this. 
+	//    long scr = m*MAPSCRS+sc;
 		
             int layr = whichlayer(scr);
 	bool err_input_found;
@@ -4804,30 +4804,31 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
         int sc = (ri->d[2]/10000);
         int m = zc_max((ri->d[1]/10000)-1,0);
         long scr = zc_max(m*MAPSCRS+sc,0);
-        /*
-	bool err_input_found = false;
-	    
+        
+	//bool err_input_found = false;
+	  /*  
 	if ( m >= map_count ) {
 		al_trace("Invalid Map Reference Passed to Screen->SetComboData: %d \n", m);
-		err_input_found = true;
+	//	err_input_found = true;
 	}
 	
 	if ( sc < 0 || sc >= MAPSCRS ) 
 	{
 		al_trace("Invalid Screen Reference Passed to Screen->SetComboData: %d \n", sc);
-		err_input_found = true;
+	//	err_input_found = true;
 	}
 	
 	if ( pos < 0 || pos > 175 ) 
 	{
 		al_trace("Invalid Position Reference Passed to Screen->SetComboData: %d \n", pos);
-		err_input_found = true;
+	//	err_input_found = true;
 	}
 	
-	if ( err_input_found ) { 
-		break;
-	}
+	//if ( err_input_found ) { 
+	//	break;
+	//}
 	*/
+	
 	if(!(pos >= 0 && pos < 176 && scr >= 0 && sc < MAPSCRS && m < map_count)) break;
         
         if(scr==(currmap*MAPSCRS+currscr))
@@ -5113,9 +5114,10 @@ if(GuyH::loadNPC(ri->guyref, str) == SH::_NoError) \
         combobuf[TheMaps[scr].data[pos]].flag=value/10000;
     }
     break;
-    */
     
+    */
     //2.50.2
+    
     case COMBOIDM:
     {
         int pos = (ri->d[0])/10000;

--- a/src/script_drawing.cpp
+++ b/src/script_drawing.cpp
@@ -1277,7 +1277,7 @@ void do_drawintr(BITMAP *bmp, int *sdci, int xoffset, int yoffset)
     int bg_color=sdci[6]/10000; //-1 = transparent
     int w=sdci[7]/10000;
     int h=sdci[8]/10000;
-    float number=static_cast<float>(sdci[9])/10000.0f;
+    //float number=static_cast<float>(sdci[9])/10000.0f;
 	//int numberint = sdci[9]/10000;
     int decplace=sdci[10]/10000;
     int opacity=sdci[11]/10000;
@@ -1299,23 +1299,23 @@ void do_drawintr(BITMAP *bmp, int *sdci, int xoffset, int yoffset)
         break;					//reducing the value by -1, so 8.000 printed as '7'. -Z
         
     case 1:
-        sprintf(numbuf,"%.01f",number);
-	//sprintf(numbuf,"%.01f",(static_cast<float>(sdci[9])/10000.0f)); //Would this be slower? 
+        //sprintf(numbuf,"%.01f",number);
+	sprintf(numbuf,"%.01f",(static_cast<float>(sdci[9])/10000.0f)); //Would this be slower? 
         break;
         
     case 2:
-        sprintf(numbuf,"%.02f",number);
-	//sprintf(numbuf,"%.02f",(static_cast<float>(sdci[9])/10000.0f));
+        //sprintf(numbuf,"%.02f",number);
+	sprintf(numbuf,"%.02f",(static_cast<float>(sdci[9])/10000.0f));
         break;
         
     case 3:
-        sprintf(numbuf,"%.03f",number);
-	//sprintf(numbuf,"%.03f",(static_cast<float>(sdci[9])/10000.0f));
+        //sprintf(numbuf,"%.03f",number);
+	sprintf(numbuf,"%.03f",(static_cast<float>(sdci[9])/10000.0f));
         break;
         
     case 4:
-        sprintf(numbuf,"%.04f",number);
-	//sprintf(numbuf,"%.04f",(static_cast<float>(sdci[9])/10000.0f));
+        //sprintf(numbuf,"%.04f",number);
+	sprintf(numbuf,"%.04f",(static_cast<float>(sdci[9])/10000.0f));
         break;
     }
     

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -98,7 +98,7 @@
 #define VERSION_BUILD       31                              //build number of this version
 #define ZELDA_VERSION_STR   "2.53 Beta 10"                    //version of the program as presented in text
 #define IS_BETA             1                               //is this a beta? (1: beta, -1: alpha)
-#define DATE_STR            "1st October, 2017"
+#define DATE_STR            "2nd October, 2017"
 #define COPYRIGHT_YEAR      "2017"                          //shown on title screen and in ending
 
 #define MIN_VERSION         0x0184


### PR DESCRIPTION
All of the changes to Game->GetComboX and Game->SetComboX since build 1793 are reverted. 

Every <= 2.50.2 quest that I tried that used these, was in some way broken, often fatally broken, on 2.53. 

We can try again later, to make these better. 