### PR TITLE
Feat: ZC & ZQ Config Saving and Filepaths

### DIFF
--- a/src/zc_sys.cpp
+++ b/src/zc_sys.cpp
@@ -6779,6 +6779,7 @@ static MENU misc_menu[] =
     { (char *)"",                           NULL,                    NULL,                      0, NULL },
     { (char *)"Take &Snapshot\tF12",        onSnapshot,              NULL,                      0, NULL },
     { (char *)"Sc&reen Saver...",           onScreenSaver,           NULL,                      0, NULL },
+    { (char *)"Save ZC Configuration",           OnSaveZCConfig,           NULL,                      0, NULL },
      { (char *)"Show Debug Console",           onDebugConsole,           NULL,                      0, NULL },
     { NULL,                                 NULL,                    NULL,                      0, NULL }
 };

--- a/src/zc_sys.cpp
+++ b/src/zc_sys.cpp
@@ -4671,35 +4671,25 @@ int onClickToFreeze()
     return D_O_K;
 }
 
-
-static DIALOG debugconsole_dlg[] =
+int OnSaveZCConfig()
 {
-    /* (dialog proc)       (x)   (y)   (w)   (h)   (fg)     (bg)     (key)    (flags)    (d1)      (d2)     (dp)     (dp2) (dp3) */
-    { jwin_win_proc,       40,   38,   241,  173,  vc(14),  vc(1),   0,       D_EXIT,    0,        0, (void *) "ZC Debug COnsole", NULL,  NULL },
-    
-    
-    { jwin_text_proc,         52,   70,  140,  8,    vc(0),   vc(11),  0,       0,         0,        0, (void *) "WARNING: Closing the console window, by using the ", NULL,  NULL },
-    { jwin_text_proc,         52,   80,  140,  8,    vc(0),   vc(11),  0,       0,         0,        0, (void *) "close window widget will terminate ZC!", NULL,  NULL },
-    { jwin_text_proc,         52,   90,  140,  8,    vc(0),   vc(11),  0,       0,         0,        0, (void *) "To close the debug console, use the SHOW DEBUG CONSOLE", NULL,  NULL },
-    { jwin_text_proc,         52,   100,  140,  8,    vc(0),   vc(11),  0,       0,         0,        0, (void *) "menu uption again!", NULL,  NULL },
-    
-    { jwin_frame_proc,     47,   65,   227,  115,  vc(15),  vc(1),   0,       0,         FR_DEEP,  0,       NULL, NULL,  NULL },
-    { d_bitmap_proc,       49,   67,   222,  110,  vc(15),  vc(1),   0,       0,         0,        0,       NULL, NULL,  NULL },
-    { jwin_button_proc,    60,  184,  41,   21,   vc(14),  vc(1),   0,       D_EXIT,    0,        0, (void *) "OK", NULL,  NULL },
-    { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
-};
-
-//Warning Info Box
-int onDoDebugConsole()
-{
-	
-    debugconsole_dlg[0].dp2=lfont;
-    
-    if(is_large)
-        large_dialog(debugconsole_dlg);
-        
-    zc_popup_dialog(debugconsole_dlg,1);
-    return D_O_K;
+	if(jwin_alert3(
+			"Save Configuration", 
+			"Are you sure that you wish to save your present configuration settings?", 
+			"This will overwrite your prior settings!",
+			NULL,
+		 "&Yes", 
+		"&No", 
+		NULL, 
+		'y', 
+		'n', 
+		NULL, 
+		lfont) == 1)	
+	{
+		save_game_configs();
+		return D_O_K;
+	}
+	else return D_O_K;
 }
 
 int onDebugConsole()
@@ -4723,6 +4713,7 @@ int onDebugConsole()
 			zconsole = true;
 			return D_O_K;
 		}
+		else return D_O_K;
 	}
 	else { 
 		

--- a/src/zq_misc.cpp
+++ b/src/zq_misc.cpp
@@ -1212,6 +1212,52 @@ int onSpacebar()
     return D_O_K;
 }
 
+int onSaveZQuestSettings()
+{
+	if(jwin_alert3(
+			"Save Configuration", 
+			"Are you sure that you wish to save your present configuration settings?", 
+			"This will overwrite your prior settings!",
+			NULL,
+		 "&Yes", 
+		"&No", 
+		NULL, 
+		'y', 
+		'n', 
+		NULL, 
+		lfont) == 1)	
+	{
+		save_config_file();
+		return D_O_K;
+	}
+	else return D_O_K;	
+	
+}
+
+
+
+int onClearQuestFilepath()
+{
+	if(jwin_alert3(
+			"Clear Quest Path", 
+			"Clear the current default filepath?", 
+			NULL,
+			NULL,
+		 "&Yes", 
+		"&No", 
+		NULL, 
+		'y', 
+		'n', 
+		NULL, 
+		lfont) == 1)	
+	{
+		ZQ_ClearQuestPath();
+		return D_O_K;
+	}
+	else return D_O_K;	
+	
+}
+
 int onSnapshot()
 {
     char buf[26];

--- a/src/zq_misc.h
+++ b/src/zq_misc.h
@@ -292,6 +292,8 @@ void KeyFileName(char *kfname);
 
 int onSpacebar();
 int onSnapshot();
+int onSaveZQuestSettings();
+int onClearQuestFilepath();
 void go();
 void comeback();
 int checksave();

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -826,6 +826,8 @@ static MENU etc_menu[] =
     { (char *)"&Change track",              changeTrack,               NULL,                     0,            NULL   },
     { (char *)"&Stop tunes",                stopMusic,                 NULL,                     0,            NULL   },
     { (char *)"",                           NULL,                      NULL,                     0,            NULL   },
+    { (char *)"Save ZQuest Configuraton",          onSaveZQuestSettings,                NULL,                     0,            NULL   },
+    { (char *)"Clear Quest Filepath",          onClearQuestFilepath,                NULL,                     0,            NULL   },
     { (char *)"&Take Snapshot\tZ",          onSnapshot,                NULL,                     0,            NULL   },
     {  NULL,                                NULL,                      NULL,                     0,            NULL   }
 };
@@ -21580,6 +21582,7 @@ int main(int argc,char **argv)
     gboraclepfont = (FONT*)fontsdata[FONT_GB_ORACLE_P].dat;
     dsphantomfont = (FONT*)fontsdata[FONT_DS_PHANTOM].dat;
     dsphantompfont = (FONT*)fontsdata[FONT_DS_PHANTOM_P].dat;
+    //Do not forhet to init the fonts! -Z
     
     for(int i=0; i<MAXCUSTOMTUNES; i++)
     {
@@ -24076,7 +24079,10 @@ command_pair commands[cmdMAX]=
     { "Report: Item Locations",              0, (intF) onItemLocationReport                             },
     { "Report: Script Locations",              0, (intF) onScriptLocationReport                                    },
     { "Report: What Links Here",              0, (intF) onWhatWarpsReport                                    },
-    { "Report: Integrity Check",              0, (intF) onIntegrityCheckAll                                    }
+    { "Report: Integrity Check",              0, (intF) onIntegrityCheckAll                                    },
+    { "Save ZQuest Settings",              0, (intF) onSaveZQuestSettings                                    },
+    { "Clear Quest Filepath",              0, (intF) onClearQuestFilepath                                    },
+    
 
 };
 
@@ -24259,7 +24265,9 @@ void clear_tooltip()
     update_tooltip(-1, -1, -1, -1, 0, 0, NULL);
 }
 
- 
+void ZQ_ClearQuestPath(){
+	last_quest_name = "";
+}
 
 
 

--- a/src/zquest.h
+++ b/src/zquest.h
@@ -661,6 +661,8 @@ enum
     cmdScriptLocations,
     cmdWhatLinksHere,
     cmdIntegrityCheck,
+    cmdSaveZQuestSettings,
+    cmdOnClearQuestFilepath,
     cmdMAX
 };
 
@@ -1102,7 +1104,7 @@ void check_autosave();
 
 void update_tooltip(int x, int y, int trigger_x, int trigger_y, int trigger_w, int trigger_h, char *tipmsg);
 void clear_tooltip();
-
+void ZQ_ClearQuestPath();
 void cflag_help(int id);
 void ctype_help(int id);
 


### PR DESCRIPTION
Added the ability to save the ag.cfg settings for ZC and ZQuest at any time from the menus, and
added the initial groundwork for clearing the default file path in ZQuest.