### PR TITLE
Fix: VBound ZQuest Combo Editor Values

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,12 +1,30 @@
-ChangeLog for 2.53.0 Beta 10
-12-OCT-2017
+ChangeLog for 2.53.0 Beta 11
+16-OCT-2017
+
+VBund ZQuest combo editor fields: Cset to -15/+15, Aframes (0,255), ASpeed (0,255) to prevent rollover from lack
+of sanity bounding. ( ZoriaRPG 16th october, 2017 )
+
+Fixed game ending sequence clipping from carrying over to another quest if ZC is reset during the ending.
+Possible fix for the crash reported by Lut where scrolling through a specific pixel of the lower-left corner
+of screens would crash ZC. ( ZoriaRPG, 16th October, 2017 )
+
+Fixed a bug in std.zh where GetHighestLevelItem() would fail to return the correct values if the item IDs and levels
+were not in a matched ascending order (e.g. item 16 is level 2, item 18 is level 1), and similar.
+Added GetHighestLevelItemOwned() to std.zh. ( ZoriaRPG, 15th October, 2017 )
+
+Fixed button interface commandline filenames in ZCL. Updated version to 2.6.4. ( ZoriaRPG, 15th October, 2017 )
+
+Fixed issues with 1.84 quests.
+Added possible fix for Win10 slowdown. ( Gleeok, 15th October, 2017 )
 
 Reworded language for controller button dialogue:
 The controller button input dialogue used the wording 'Use Analogue Stick Instead of Buttons', which is misleading. 
 On standard USB game pads, with a DPad, ZC recognises the DPad as an analogue stick (when using Windows), and thus, 
 the controller DPad buttons cannot be mapped on an individual basis. This adjusts the wording to 'Use Analogue Stick/DPad'. ( ZoriaRPG, 10th October, 2017 )
 
-Fixed issues with 1.84 quests. ( Gleeok )
+Split up ag.cfg into ag.cfg (RomView, ZCL), zc.cfg (Zelda Classic), and zquest.cfg (ZQuest) to fix some issues with 
+ZC/ZQuest creating an access clash with one config file. 
+Updated ZCl to use the new files. ZCL is now 2.6.3. ( ZoriaRPG, 6th Oct, 2017 )
 
 Reverted all of the Game->SetCombo* and Game->GetCombo* functions to their 2.50.2 states. 
 The revised (2.50.3) functions broke quests using these functions in a way that cannot be resolved

--- a/src/zq_tiles.cpp
+++ b/src/zq_tiles.cpp
@@ -11396,7 +11396,7 @@ bool edit_combo(int c,bool freshen,int cs)
             }
         }
         
-        curr_combo.csets = atoi(cset_str) & 15;
+        curr_combo.csets = vbound(atoi(cset_str),-15,15) & 15; //Bound this to a size of csets, so that it does not wrap!
         
         for(int i=0; i<4; i++)
         {
@@ -11410,8 +11410,8 @@ bool edit_combo(int c,bool freshen,int cs)
             }
         }
         
-        curr_combo.skipanim = zc_max(0,atoi(skip));
-        curr_combo.skipanimy = zc_max(0,atoi(skipy));
+        curr_combo.skipanim = zc_max(0,vbound(atoi(skip),0,255)); //bind to size of byte! -Z
+        curr_combo.skipanimy = zc_max(0,vbound(atoi(skipy),0,255)); //bind to size of byte! -Z
         
         //lastframe = frames+(frames-1)*skip+(frames-1)*TILES_PER_ROW*skipy
         //frames+frames*skip+frames*skipy*TILES_PER_ROW = lastframe + skip + TILES_PER_ROW*skipy
@@ -11420,9 +11420,9 @@ bool edit_combo(int c,bool freshen,int cs)
                     (1+curr_combo.skipanim+TILES_PER_ROW*curr_combo.skipanimy);
                     
         //curr_combo.frames = vbound(atoi(frm),0,bound); //frames is stored as byte.
-        curr_combo.frames = vbound(atoi(frm),0,zc_min(bound,255));
+        curr_combo.frames = vbound(atoi(frm),0,255); //bind to size of byte! -Z
         
-        curr_combo.speed = atoi(spd);
+        curr_combo.speed = vbound(atoi(spd),0,255);  //bind to size of byte! -Z
         curr_combo.type = bict[combo_dlg[24].d1].i;
         curr_combo.nextcombo = combo_dlg[31].d1;
         curr_combo.nextcset = combo_dlg[31].fg;


### PR DESCRIPTION
Changelog: VBound ZQuest combo editor fields: Cset to -15/+15, Aframes (0,255), ASpeed (0,255) to 
prevent rollover from lack of sanity bounding. 