### PR TITLE
Add Size and Weapon Size to Item Editor

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,14 @@
 //2.54 Changes
 
+//Alpha 12
+
+Began adding a 'Weapon Size' tab to the item editor. The editor fields work, but they do not yet affect anything in-game.
+
+Added a 'Size' tab to the item editor. The user may now set the following mfields for items in ZQuest, without scripts:
+TileWidth, TileHeight, HotWidth, HitHeight, HitXOffset, HitYOffset, DrawXOffset, DrawYOffset, HitZHeight
+The editor has an 'Override' flag for each. The values will only work if the override flag is enabled, and this will
+override any other internal sizes and offsets normally applied by the engine. ( ZoriaRPG, 31st October, 2017 )
+
 //Alpha 11
 
 Added Game->LoadNPCData(), LoadMapData(), LoadComboData(), LoadSpriteData(), LoadScreenData() (unused) and LoadBitmapID(). 

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -1874,7 +1874,7 @@ long get_register(const long arg)
         ret=(itemsbuf[ri->idata].weap_hxofs)*10000;
         break;
     case IDATAWEAPHYOFS:
-        ret=(itemsbuf[ri->idata].weap_yxofs)*10000;
+        ret=(itemsbuf[ri->idata].weap_hyofs)*10000;
         break;
     case IDATAWEAPHXSZ:
         ret=(itemsbuf[ri->idata].weap_hxsz)*10000;
@@ -4617,7 +4617,7 @@ void set_register(const long arg, const long value)
 	(itemsbuf[ri->idata].weap_hxofs)=(value/10000);
         break;
     case IDATAWEAPHYOFS:
-	(itemsbuf[ri->idata].weap_yxofs)=(value/10000);
+	(itemsbuf[ri->idata].weap_hyofs)=(value/10000);
         break;
     case IDATAWEAPHXSZ:
 	(itemsbuf[ri->idata].weap_hxsz)=(value/10000);

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -198,7 +198,7 @@ item::item(fix X,fix Y,fix Z,int i,int p,int c, bool isDummy) : sprite()
     frames = itemsbuf[id].frames;
     flip = itemsbuf[id].misc>>2;
     
-    if ( itemsbuf[id].flags&itemdataOVERRIDE_PICKUP ) pickup = itemsbuf[id].pickup;
+    //if ( itemsbuf[id].flags&itemdataOVERRIDE_PICKUP ) pickup = itemsbuf[id].pickup;
     
     if(itemsbuf[id].misc&1)
         flash=true;
@@ -242,16 +242,17 @@ item::item(fix X,fix Y,fix Z,int i,int p,int c, bool isDummy) : sprite()
       if(j<2) a[j]=itemsbuf[id].initiala[j]*10000;
       d[j]=itemsbuf[id].initiald[j];
     }*/
-    
-    if ( itemsbuf[id].flags&itemdataOVERRIDE_TILEWIDTH ) txsz = itemsbuf[id].tilew;
-    if ( itemsbuf[id].flags&itemdataOVERRIDE_TILEHEIGHT ) tysz = itemsbuf[id].tileh;
-    if ( itemsbuf[id].flags&itemdataOVERRIDE_HIT_WIDTH ) hxsz = itemsbuf[id].hxsz;
-    if ( itemsbuf[id].flags&itemdataOVERRIDE_HIT_HEIGHT ) hysz = itemsbuf[id].hysz;
-    if ( itemsbuf[id].flags&itemdataOVERRIDE_HIT_Z_HEIGHT ) hzsz = itemsbuf[id].hzsz;
-    if ( itemsbuf[id].flags&itemdataOVERRIDE_HIT_X_OFFSET ) hxofs = itemsbuf[id].hxofs;
-    if ( itemsbuf[id].flags&itemdataOVERRIDE_HIT_Y_OFFSET ) hyofs = itemsbuf[id].hyofs;
-    if ( itemsbuf[id].flags&itemdataOVERRIDE_DRAW_X_OFFSET ) xofs = itemsbuf[id].xofs;
-    if ( itemsbuf[id].flags&itemdataOVERRIDE_DRAW_Y_OFFSET ) yofs = itemsbuf[id].yofs;
+    if ( itemsbuf[id].overrideFLAGS > 0 ) {extend = 3; }
+    if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_TILEWIDTH ) { txsz = itemsbuf[id].tilew;}
+    if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_TILEHEIGHT ){  tysz = itemsbuf[id].tileh;}
+    if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_HIT_WIDTH ){  hxsz = itemsbuf[id].hxsz;}
+    if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_HIT_HEIGHT ) {  hysz = itemsbuf[id].hysz;}
+    if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_HIT_Z_HEIGHT ) {  hzsz = itemsbuf[id].hzsz;}
+    if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET ) {  hxofs = itemsbuf[id].hxofs;}
+    if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET ) { hyofs = itemsbuf[id].hyofs;}
+    if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET ) { xofs = itemsbuf[id].xofs;}
+    Z_message("itemsbuf.yofs = : %d\n",itemsbuf[id].yofs);
+    if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET ) {  yofs = itemsbuf[id].yofs;}
     //if ( itemsbuf[id].flags&itemdataOVERRIDE_DRAW_Z_OFFSET ) zofs = itemsbuf[id].zofs;
 }
 
@@ -261,6 +262,18 @@ void putitem(BITMAP *dest,int x,int y,int item_id)
 {
     item temp((fix)x,(fix)y,(fix)0,item_id,0,0);
     temp.yofs=0;
+	
+    if ( itemsbuf[item_id].overrideFLAGS > 0 ) {temp.extend = 3; }
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_TILEWIDTH ) { temp.txsz = itemsbuf[item_id].tilew;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_TILEHEIGHT ){temp.tysz = itemsbuf[item_id].tileh;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_WIDTH ) { temp.hxsz = itemsbuf[item_id].hxsz;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_HEIGHT ) {temp.hysz = itemsbuf[item_id].hysz;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_Z_HEIGHT ) { temp.hzsz = itemsbuf[item_id].hzsz;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET ) { temp.hxofs = itemsbuf[item_id].hxofs;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET ) {temp.hyofs = itemsbuf[item_id].hyofs;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET ) {temp.xofs = itemsbuf[item_id].xofs;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET ) { temp.yofs = itemsbuf[item_id].yofs;}
+	
     temp.animate(0);
     temp.draw(dest);
 }
@@ -276,6 +289,16 @@ void putitem2(BITMAP *dest,int x,int y,int item_id, int &aclk, int &aframe, int 
     {
         temp.flash=(flash != 0);
     }
+    if ( itemsbuf[item_id].overrideFLAGS > 0 ) {temp.extend = 3; }
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_TILEWIDTH ) { temp.txsz = itemsbuf[item_id].tilew;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_TILEHEIGHT ){temp.tysz = itemsbuf[item_id].tileh;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_WIDTH ) { temp.hxsz = itemsbuf[item_id].hxsz;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_HEIGHT ) {temp.hysz = itemsbuf[item_id].hysz;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_Z_HEIGHT ) { temp.hzsz = itemsbuf[item_id].hzsz;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET ) { temp.hxofs = itemsbuf[item_id].hxofs;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET ) {temp.hyofs = itemsbuf[item_id].hyofs;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET ) {temp.xofs = itemsbuf[item_id].xofs;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET ) { temp.yofs = itemsbuf[item_id].yofs;}
     
     temp.animate(0);
     temp.draw(dest);

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -198,6 +198,8 @@ item::item(fix X,fix Y,fix Z,int i,int p,int c, bool isDummy) : sprite()
     frames = itemsbuf[id].frames;
     flip = itemsbuf[id].misc>>2;
     
+    if ( itemsbuf[id].flags&itemdataOVERRIDE_PICKUP ) pickup = itemsbuf[id].pickup;
+    
     if(itemsbuf[id].misc&1)
         flash=true;
         
@@ -240,6 +242,17 @@ item::item(fix X,fix Y,fix Z,int i,int p,int c, bool isDummy) : sprite()
       if(j<2) a[j]=itemsbuf[id].initiala[j]*10000;
       d[j]=itemsbuf[id].initiald[j];
     }*/
+    
+    if ( itemsbuf[id].flags&itemdataOVERRIDE_TILEWIDTH ) txsz = itemsbuf[id].tilew;
+    if ( itemsbuf[id].flags&itemdataOVERRIDE_TILEHEIGHT ) tysz = itemsbuf[id].tileh;
+    if ( itemsbuf[id].flags&itemdataOVERRIDE_HIT_WIDTH ) hxsz = itemsbuf[id].hxsz;
+    if ( itemsbuf[id].flags&itemdataOVERRIDE_HIT_HEIGHT ) hysz = itemsbuf[id].hysz;
+    if ( itemsbuf[id].flags&itemdataOVERRIDE_HIT_Z_HEIGHT ) hzsz = itemsbuf[id].hzsz;
+    if ( itemsbuf[id].flags&itemdataOVERRIDE_HIT_X_OFFSET ) hxofs = itemsbuf[id].hxofs;
+    if ( itemsbuf[id].flags&itemdataOVERRIDE_HIT_Y_OFFSET ) hyofs = itemsbuf[id].hyofs;
+    if ( itemsbuf[id].flags&itemdataOVERRIDE_DRAW_X_OFFSET ) xofs = itemsbuf[id].xofs;
+    if ( itemsbuf[id].flags&itemdataOVERRIDE_DRAW_Y_OFFSET ) yofs = itemsbuf[id].yofs;
+    //if ( itemsbuf[id].flags&itemdataOVERRIDE_DRAW_Z_OFFSET ) zofs = itemsbuf[id].zofs;
 }
 
 // easy way to draw an item

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -251,8 +251,7 @@ item::item(fix X,fix Y,fix Z,int i,int p,int c, bool isDummy) : sprite()
     if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET ) {  hxofs = itemsbuf[id].hxofs;}
     if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET ) { hyofs = itemsbuf[id].hyofs;}
     if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET ) { xofs = itemsbuf[id].xofs;}
-    Z_message("itemsbuf.yofs = : %d\n",itemsbuf[id].yofs);
-    if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET ) {  yofs = itemsbuf[id].yofs;}
+    if ( itemsbuf[id].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET ) {  yofs = itemsbuf[id].yofs+56;} //Hack, until I figure out why yofs is -56.
     //if ( itemsbuf[id].flags&itemdataOVERRIDE_DRAW_Z_OFFSET ) zofs = itemsbuf[id].zofs;
 }
 
@@ -272,7 +271,8 @@ void putitem(BITMAP *dest,int x,int y,int item_id)
     if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET ) { temp.hxofs = itemsbuf[item_id].hxofs;}
     if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET ) {temp.hyofs = itemsbuf[item_id].hyofs;}
     if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET ) {temp.xofs = itemsbuf[item_id].xofs;}
-    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET ) { temp.yofs = itemsbuf[item_id].yofs;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET ) { temp.yofs = itemsbuf[item_id].yofs; }
+    
 	
     temp.animate(0);
     temp.draw(dest);
@@ -298,7 +298,8 @@ void putitem2(BITMAP *dest,int x,int y,int item_id, int &aclk, int &aframe, int 
     if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET ) { temp.hxofs = itemsbuf[item_id].hxofs;}
     if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET ) {temp.hyofs = itemsbuf[item_id].hyofs;}
     if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET ) {temp.xofs = itemsbuf[item_id].xofs;}
-    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET ) { temp.yofs = itemsbuf[item_id].yofs;}
+    if ( itemsbuf[item_id].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET ) { temp.yofs = itemsbuf[item_id].yofs; }
+    
     
     temp.animate(0);
     temp.draw(dest);

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -5184,7 +5184,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
                         {
                             return qe_invalid;
                         }
-			if(!p_igetl(&tempitem.yxofs,f,true))
+			if(!p_igetl(&tempitem.hyofs,f,true))
                         {
                             return qe_invalid;
                         }
@@ -5212,7 +5212,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
                         {
                             return qe_invalid;
                         }
-			if(!p_igetl(&tempitem.weap_yxofs,f,true))
+			if(!p_igetl(&tempitem.weap_hyofs,f,true))
                         {
                             return qe_invalid;
                         }
@@ -5248,7 +5248,25 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
                         {
                             return qe_invalid;
                         }
+			
 		
+		}
+		if ( s_version >= 28 )  //! New itemdata vars for weapon editor. -Z
+		{
+			//Item Size FLags, TileWidth, TileHeight
+			if(!p_igetl(&tempitem.overrideFLAGS,f,true))
+                        {
+                            return qe_invalid;
+                        }
+			if(!p_igetl(&tempitem.tilew,f,true))
+                        {
+                            return qe_invalid;
+                        }
+			if(!p_igetl(&tempitem.tileh,f,true))
+                        {
+                            return qe_invalid;
+                        }
+			
 		}
         }
         else

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -5268,6 +5268,22 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
                         }
 			
 		}
+		if ( s_version >= 29 )  //! More new vars. 
+		{
+			//Item Size FLags, TileWidth, TileHeight
+			if(!p_igetl(&tempitem.weapoverrideFLAGS,f,true))
+                        {
+                            return qe_invalid;
+                        }
+			if(!p_igetl(&tempitem.weap_tilew,f,true))
+                        {
+                            return qe_invalid;
+                        }
+			if(!p_igetl(&tempitem.weap_tileh,f,true))
+                        {
+                            return qe_invalid;
+                        }
+		}
         }
         else
         {

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -5284,6 +5284,14 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
                             return qe_invalid;
                         }
 		}
+		if ( s_version >= 30 )  //! More new vars. 
+		{
+			//Pickup Type
+			if(!p_igetl(&tempitem.pickup,f,true))
+                        {
+                            return qe_invalid;
+                        }
+		}
         }
         else
         {

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -178,7 +178,7 @@ enum {ENC_METHOD_192B104=0, ENC_METHOD_192B105, ENC_METHOD_192B185, ENC_METHOD_2
 #define V_MAPS            18
 #define V_DMAPS            9
 #define V_DOORS            1
-#define V_ITEMS           29
+#define V_ITEMS           30
 #define V_WEAPONS          6
 #define V_COLORS           2
 #define V_ICONS            1
@@ -1339,7 +1339,7 @@ struct itemdata
     int hxofs, hyofs, hxsz, hysz, hzsz, xofs, yofs; //item
     int weap_hxofs, weap_hyofs, weap_hxsz, weap_hysz, weap_hzsz, weap_xofs, weap_yofs; //weapon
     int tilew, tileh, weap_tilew, weap_tileh; //New for 2.54
-    //i_pickuptype
+    int pickup; 
 
     
   
@@ -1355,6 +1355,7 @@ struct itemdata
 #define itemdataOVERRIDE_DRAW_X_OFFSET	0x00000080
 #define itemdataOVERRIDE_DRAW_Y_OFFSET	0x00000100
 #define itemdataOVERRIDE_DRAW_Z_OFFSET	0x00000200
+#define itemdataOVERRIDE_PICKUP		0x00000400
 
     int overrideFLAGS; //Override flags.
     int weapoverrideFLAGS; 

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -98,10 +98,10 @@
 #define ZC_VERSION 25400 //Version ID for ZScript Game->Version
 #define VERSION_BUILD       40                              //build number of this version
 //31 == 2.53.0 , leaving 32-39 for bugfixes, and jumping to 40. 
-#define ZELDA_VERSION_STR   "2.54 Alpha 11"                    //version of the program as presented in text
-#define IS_BETA             -11                              //is this a beta? (1: beta, -1: alpha)
+#define ZELDA_VERSION_STR   "2.54 Alpha 12"                    //version of the program as presented in text
+#define IS_BETA             -12                              //is this a beta? (1: beta, -1: alpha)
 #define VERSION_BETA        00010
-#define DATE_STR            "30th October, 2017"
+#define DATE_STR            "31sr October, 2017"
 #define COPYRIGHT_YEAR      "2017"                          //shown on title screen and in ending
 
 #define MIN_VERSION         0x0184
@@ -178,7 +178,7 @@ enum {ENC_METHOD_192B104=0, ENC_METHOD_192B105, ENC_METHOD_192B185, ENC_METHOD_2
 #define V_MAPS            18
 #define V_DMAPS            9
 #define V_DOORS            1
-#define V_ITEMS           28
+#define V_ITEMS           29
 #define V_WEAPONS          6
 #define V_COLORS           2
 #define V_ICONS            1
@@ -1338,7 +1338,7 @@ struct itemdata
     long collectflags;
     int hxofs, hyofs, hxsz, hysz, hzsz, xofs, yofs; //item
     int weap_hxofs, weap_hyofs, weap_hxsz, weap_hysz, weap_hzsz, weap_xofs, weap_yofs; //weapon
-    int tilew, tileh; //New for 2.54
+    int tilew, tileh, weap_tilew, weap_tileh; //New for 2.54
     //i_pickuptype
 
     
@@ -1357,6 +1357,7 @@ struct itemdata
 #define itemdataOVERRIDE_DRAW_Z_OFFSET	0x00000200
 
     int overrideFLAGS; //Override flags.
+    int weapoverrideFLAGS; 
     
     word weaponscript; //If only. -Z This would link an item to a weapon script in the item editor.
     int wpnsprite; //enemy weapon sprite. 

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -178,7 +178,7 @@ enum {ENC_METHOD_192B104=0, ENC_METHOD_192B105, ENC_METHOD_192B185, ENC_METHOD_2
 #define V_MAPS            18
 #define V_DMAPS            9
 #define V_DOORS            1
-#define V_ITEMS           27
+#define V_ITEMS           28
 #define V_WEAPONS          6
 #define V_COLORS           2
 #define V_ICONS            1
@@ -1336,8 +1336,27 @@ struct itemdata
     
     byte drawlayer;
     long collectflags;
-    int hxofs, yxofs, hxsz, hysz, hzsz, xofs, yofs; //item
-    int weap_hxofs, weap_yxofs, weap_hxsz, weap_hysz, weap_hzsz, weap_xofs, weap_yofs; //weapon
+    int hxofs, hyofs, hxsz, hysz, hzsz, xofs, yofs; //item
+    int weap_hxofs, weap_hyofs, weap_hxsz, weap_hysz, weap_hzsz, weap_xofs, weap_yofs; //weapon
+    int tilew, tileh; //New for 2.54
+    //i_pickuptype
+
+    
+  
+//Guydata Enemy Editor Size Panel FLags
+
+#define itemdataOVERRIDE_TILEWIDTH	0x00000001
+#define itemdataOVERRIDE_TILEHEIGHT	0x00000002
+#define itemdataOVERRIDE_HIT_WIDTH	0x00000004
+#define itemdataOVERRIDE_HIT_HEIGHT	0x00000008
+#define itemdataOVERRIDE_HIT_Z_HEIGHT	0x00000010
+#define itemdataOVERRIDE_HIT_X_OFFSET	0x00000020
+#define itemdataOVERRIDE_HIT_Y_OFFSET	0x00000040
+#define itemdataOVERRIDE_DRAW_X_OFFSET	0x00000080
+#define itemdataOVERRIDE_DRAW_Y_OFFSET	0x00000100
+#define itemdataOVERRIDE_DRAW_Z_OFFSET	0x00000200
+
+    int overrideFLAGS; //Override flags.
     
     word weaponscript; //If only. -Z This would link an item to a weapon script in the item editor.
     int wpnsprite; //enemy weapon sprite. 

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -101,7 +101,7 @@
 #define ZELDA_VERSION_STR   "2.54 Alpha 12"                    //version of the program as presented in text
 #define IS_BETA             -12                              //is this a beta? (1: beta, -1: alpha)
 #define VERSION_BETA        00010
-#define DATE_STR            "31sr October, 2017"
+#define DATE_STR            "31st October, 2017"
 #define COPYRIGHT_YEAR      "2017"                          //shown on title screen and in ending
 
 #define MIN_VERSION         0x0184

--- a/src/zq_class.cpp
+++ b/src/zq_class.cpp
@@ -7560,6 +7560,10 @@ int writeitems(PACKFILE *f, zquestheader *Header)
 		{
 		    new_return(80);
 		}
+		if(!p_iputl(itemsbuf[i].pickup,f))
+		{
+		    new_return(81);
+		}
 		
 	    
         }

--- a/src/zq_class.cpp
+++ b/src/zq_class.cpp
@@ -7548,6 +7548,18 @@ int writeitems(PACKFILE *f, zquestheader *Header)
 		{
 		    new_return(77);
 		}
+		if(!p_iputl(itemsbuf[i].weapoverrideFLAGS,f))
+		{
+		    new_return(78);
+		}
+		if(!p_iputl(itemsbuf[i].weap_tilew,f))
+		{
+		    new_return(79);
+		}
+		if(!p_iputl(itemsbuf[i].weap_tileh,f))
+		{
+		    new_return(80);
+		}
 		
 	    
         }

--- a/src/zq_class.cpp
+++ b/src/zq_class.cpp
@@ -7472,7 +7472,7 @@ int writeitems(PACKFILE *f, zquestheader *Header)
 		{
 		    new_return(58);
 		}
-		if(!p_iputl(itemsbuf[i].yxofs,f))
+		if(!p_iputl(itemsbuf[i].hyofs,f))
 		{
 		    new_return(59);
 		}
@@ -7500,7 +7500,7 @@ int writeitems(PACKFILE *f, zquestheader *Header)
 		{
 		    new_return(65);
 		}
-		if(!p_iputl(itemsbuf[i].weap_yxofs,f))
+		if(!p_iputl(itemsbuf[i].weap_hyofs,f))
 		{
 		    new_return(66);
 		}
@@ -7535,6 +7535,18 @@ int writeitems(PACKFILE *f, zquestheader *Header)
 		if(!p_iputl(itemsbuf[i].magiccosttimer,f))
 		{
 		    new_return(74);
+		}
+		if(!p_iputl(itemsbuf[i].overrideFLAGS,f))
+		{
+		    new_return(75);
+		}
+		if(!p_iputl(itemsbuf[i].tilew,f))
+		{
+		    new_return(76);
+		}
+		if(!p_iputl(itemsbuf[i].tileh,f))
+		{
+		    new_return(77);
 		}
 		
 	    

--- a/src/zq_custom.cpp
+++ b/src/zq_custom.cpp
@@ -396,7 +396,7 @@ static int itemdata_scriptargs_list[] =
 static int itemdata_itemsize_list[] =
 {
     // dialog control number
-    201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215,216,217,218,219,220,221,222,223,224,225,226,227 -1
+    201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215,216,217,218,219,220,221,222,223,224,225,226,227, -1
 };
 
 static int itemdata_weaponsize_list[] =
@@ -422,7 +422,7 @@ static TABPANEL itemdata_tabs[] =
     { (char *)"Scripts",      0,             itemdata_scriptargs_list,    0, NULL },
     { (char *)"Size",      0,             itemdata_itemsize_list,    0, NULL },
    //  { (char *)"Weapon",      0,             itemdata_weaponargs_list,    0, NULL },
-    { (char *)"W.Size",      0,             itemdata_itemsize_list,    0, NULL },
+   // { (char *)"W.Size",      0,             itemdata_itemsize_list,    0, NULL },
     { NULL,                   0,             NULL,                        0, NULL }
 };
 
@@ -1063,35 +1063,38 @@ static DIALOG itemdata_dlg[] =
     { jwin_text_proc,         83,     48,     30,      8,    vc(14),                 vc(1),                   0,       0,           0,    0, (void *) "M.Cost Timer:",                              NULL,   NULL                  },
     { jwin_edit_proc,         129,	44,     28,     16,    vc(12),                 vc(1),                   0,       0,           3,    0,  NULL,                                           NULL,   NULL                  },
    //201
-    { jwin_text_proc,       6,   29+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "TileWidth:", NULL, NULL },
-    { jwin_text_proc,       6,   48+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "TileHeight:", NULL, NULL },
-    { jwin_text_proc,       6,   67+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitWidth:", NULL, NULL },
-    { jwin_text_proc,       6,   86+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitHeight:", NULL, NULL },
-    { jwin_text_proc,       6,   105+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitXOffset:", NULL, NULL },
-    { jwin_text_proc,       6,   124+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitYOffset:", NULL, NULL },
-    { jwin_text_proc,       6,  143+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitZHeight:", NULL, NULL },
-    { jwin_text_proc,       6,  162+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "DrawXOffset:", NULL, NULL },
-    { jwin_text_proc,       6,  191+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "DrawYOffset:", NULL, NULL },
+    { jwin_text_proc,       6,   29+19,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "TileWidth:", NULL, NULL },
+    { jwin_text_proc,       6,   48+17,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "TileHeight:", NULL, NULL },
+    { jwin_text_proc,       6,   67+15,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitWidth:", NULL, NULL },
+    { jwin_text_proc,       6,   86+13,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitHeight:", NULL, NULL },
+    
+    { jwin_text_proc,       148,   29+19,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitXOffset:", NULL, NULL },
+    { jwin_text_proc,       148,   48+17,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitYOffset:", NULL, NULL },
+    { jwin_text_proc,       148,  67+15,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitZHeight:", NULL, NULL },
+    { jwin_text_proc,       148,  86+13,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "DrawXOffset:", NULL, NULL },
+    { jwin_text_proc,       148,  105+12,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "DrawYOffset:", NULL, NULL },
     //210
-    { jwin_edit_proc,      34,   25+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
-    { jwin_edit_proc,      34,   42+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
-    { jwin_edit_proc,      34,   59+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
-    { jwin_edit_proc,      34,   76+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
-    { jwin_edit_proc,      34,   93+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
-    { jwin_edit_proc,      34,   110+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
-    { jwin_edit_proc,      34,   127+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
-    { jwin_edit_proc,      34,  144+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
-    { jwin_edit_proc,      34,  161+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      50,   25+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      50,   42+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      50,   59+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      50,   76+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    
+    { jwin_edit_proc,      198,   25+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      198,   42+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      198,   59+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      198,  76+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      198,  93+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
     //219
-     { jwin_check_proc,        84,     25+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
-     { jwin_check_proc,        84,     42+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  }, 
-     { jwin_check_proc,        84,     59+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  }, 
-     { jwin_check_proc,        84,     76+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
-     { jwin_check_proc,        84,     93+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
-     { jwin_check_proc,        84,     110+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
-     { jwin_check_proc,        84,     107+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
-     { jwin_check_proc,        84,     144+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
-     { jwin_check_proc,        84,     161+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        86,     29+19,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        86,     48+17,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  }, 
+     { jwin_check_proc,        86,     67+15,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  }, 
+     { jwin_check_proc,        86,     86+13,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+  
+     { jwin_check_proc,        242,     29+19,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        242,     48+17,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        242,     67+15,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        242,     86+13,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        242,     105+12,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
 	//228
     
     
@@ -1543,7 +1546,7 @@ void edit_itemdata(int index)
     char mgtimer[8]; //timer for magic usage
 	char i_tilew[9], i_tileh[8], i_hxofs[8], i_hyofs[8], i_hxsz[8], i_hysz[8], i_hzsz[8], i_xofs[8], i_yofs[8]; //item sizing
 	char i_pickuptype[8]; //item pickup type
-    char i_weap_hxofs[8], i_weap_yxofs[8], i_weap_hxsz[8], i_weap_hysz[8], i_weap_hzsz[8], i_weap_xofs[8], i_weap_yofs[8]; //weapon sizing
+    char i_weap_hxofs[8], i_weap_hyofs[8], i_weap_hxsz[8], i_weap_hysz[8], i_weap_hzsz[8], i_weap_xofs[8], i_weap_yofs[8]; //weapon sizing
     
     
     sprintf(itemnumstr,"Item %d: %s", index, item_string[index]);
@@ -1590,13 +1593,14 @@ void edit_itemdata(int index)
      
      
     //Override flags for item size
+    
     itemdata_dlg[219].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_TILEWIDTH) ? D_SELECTED : 0;
     itemdata_dlg[220].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_TILEHEIGHT) ? D_SELECTED : 0;
-    itemdata_dlg[221].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET) ? D_SELECTED : 0;
-    itemdata_dlg[222].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET) ? D_SELECTED : 0;
-    itemdata_dlg[223].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_WIDTH) ? D_SELECTED : 0;
-    itemdata_dlg[223].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_HEIGHT) ? D_SELECTED : 0;
-    itemdata_dlg[224].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_Z_HEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[221].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_WIDTH) ? D_SELECTED : 0;
+    itemdata_dlg[222].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_HEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[223].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[224].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[225].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_Z_HEIGHT) ? D_SELECTED : 0;
     itemdata_dlg[226].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET) ? D_SELECTED : 0;
     itemdata_dlg[227].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET) ? D_SELECTED : 0;
 
@@ -1710,10 +1714,10 @@ void edit_itemdata(int index)
     //item size flags
     itemdata_dlg[219].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_TILEWIDTH) ? D_SELECTED : 0;
     itemdata_dlg[220].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_TILEHEIGHT) ? D_SELECTED : 0;
-    itemdata_dlg[221].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET) ? D_SELECTED : 0;
-    itemdata_dlg[222].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET) ? D_SELECTED : 0;
-    itemdata_dlg[223].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_WIDTH) ? D_SELECTED : 0;
-    itemdata_dlg[224].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_HEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[221].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_WIDTH) ? D_SELECTED : 0;
+    itemdata_dlg[222].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_HEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[223].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[224].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET) ? D_SELECTED : 0;
     itemdata_dlg[225].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_Z_HEIGHT) ? D_SELECTED : 0;
     itemdata_dlg[226].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET) ? D_SELECTED : 0;
     itemdata_dlg[227].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET) ? D_SELECTED : 0;
@@ -1855,14 +1859,13 @@ void edit_itemdata(int index)
 	test.yofs = vbound(atoi(i_yofs),  -214747, 214747);
 	
 	
-	//item sizing override flags
 	if(itemdata_dlg[219].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_TILEWIDTH;
 	if(itemdata_dlg[220].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_TILEHEIGHT;
 	if(itemdata_dlg[221].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_WIDTH;
 	if(itemdata_dlg[222].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_HEIGHT;
-	if(itemdata_dlg[223].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_Z_HEIGHT;
-	if(itemdata_dlg[224].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_X_OFFSET;
-	if(itemdata_dlg[225].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_Y_OFFSET;
+	if(itemdata_dlg[223].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_X_OFFSET;
+	if(itemdata_dlg[224].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_Y_OFFSET;
+	if(itemdata_dlg[225].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_Z_HEIGHT;
 	if(itemdata_dlg[226].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_DRAW_X_OFFSET;
 	if(itemdata_dlg[227].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_DRAW_Y_OFFSET;
         

--- a/src/zq_custom.cpp
+++ b/src/zq_custom.cpp
@@ -1777,10 +1777,10 @@ void edit_itemdata(int index)
     //item size
     itemdata_dlg[210].dp = i_tilew;
     itemdata_dlg[211].dp = i_tileh;
-    itemdata_dlg[212].dp = i_hxofs;
-    itemdata_dlg[213].dp = i_hyofs;
-    itemdata_dlg[214].dp = i_hxsz;
-    itemdata_dlg[215].dp = i_hysz;
+    itemdata_dlg[212].dp = i_hxsz;
+    itemdata_dlg[213].dp = i_hysz;
+    itemdata_dlg[214].dp = i_hxofs;
+    itemdata_dlg[215].dp = i_hyofs;
     itemdata_dlg[216].dp = i_hzsz;
     itemdata_dlg[217].dp = i_xofs;
     itemdata_dlg[218].dp = i_yofs;
@@ -1788,10 +1788,10 @@ void edit_itemdata(int index)
     //weapon size
     itemdata_dlg[237].dp = i_weap_tilew;
     itemdata_dlg[238].dp = i_weap_tileh;
-    itemdata_dlg[239].dp = i_weap_hxofs;
-    itemdata_dlg[240].dp = i_weap_hyofs;
-    itemdata_dlg[241].dp = i_weap_hxsz;
-    itemdata_dlg[242].dp = i_weap_hysz;
+    itemdata_dlg[239].dp = i_weap_hxsz;
+    itemdata_dlg[240].dp = i_weap_hysz;
+    itemdata_dlg[241].dp = i_weap_hxofs;
+    itemdata_dlg[242].dp = i_weap_hyofs;
     itemdata_dlg[243].dp = i_weap_hzsz;
     itemdata_dlg[244].dp = i_weap_xofs;
     itemdata_dlg[245].dp = i_weap_yofs;

--- a/src/zq_custom.cpp
+++ b/src/zq_custom.cpp
@@ -402,7 +402,7 @@ static int itemdata_itemsize_list[] =
 static int itemdata_weaponsize_list[] =
 {
     // dialog control number
-	222, -1
+	228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254, -1
 };
 
 static int itemdata_weaponargs_list[] =
@@ -422,7 +422,7 @@ static TABPANEL itemdata_tabs[] =
     { (char *)"Scripts",      0,             itemdata_scriptargs_list,    0, NULL },
     { (char *)"Size",      0,             itemdata_itemsize_list,    0, NULL },
    //  { (char *)"Weapon",      0,             itemdata_weaponargs_list,    0, NULL },
-   // { (char *)"W.Size",      0,             itemdata_itemsize_list,    0, NULL },
+    { (char *)"Weapon Size",      0,             itemdata_weaponsize_list,    0, NULL },
     { NULL,                   0,             NULL,                        0, NULL }
 };
 
@@ -1095,7 +1095,42 @@ static DIALOG itemdata_dlg[] =
      { jwin_check_proc,        242,     67+15,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
      { jwin_check_proc,        242,     86+13,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
      { jwin_check_proc,        242,     105+12,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
-	//228
+     
+     //Item Editor Weapon Size
+     //228
+    { jwin_text_proc,       6,   29+19,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "TileWidth:", NULL, NULL },
+    { jwin_text_proc,       6,   48+17,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "TileHeight:", NULL, NULL },
+    { jwin_text_proc,       6,   67+15,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitWidth:", NULL, NULL },
+    { jwin_text_proc,       6,   86+13,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitHeight:", NULL, NULL },
+    //232
+    { jwin_text_proc,       148,   29+19,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitXOffset:", NULL, NULL },
+    { jwin_text_proc,       148,   48+17,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitYOffset:", NULL, NULL },
+    { jwin_text_proc,       148,  67+15,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitZHeight:", NULL, NULL },
+    { jwin_text_proc,       148,  86+13,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "DrawXOffset:", NULL, NULL },
+    { jwin_text_proc,       148,  105+12,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "DrawYOffset:", NULL, NULL },
+    //237
+    { jwin_edit_proc,      50,   25+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      50,   42+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      50,   59+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      50,   76+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    //241
+    { jwin_edit_proc,      198,   25+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      198,   42+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      198,   59+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      198,  76+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      198,  93+20,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    //246
+     { jwin_check_proc,        86,     29+19,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        86,     48+17,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  }, 
+     { jwin_check_proc,        86,     67+15,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  }, 
+     { jwin_check_proc,        86,     86+13,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+  //250
+     { jwin_check_proc,        242,     29+19,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        242,     48+17,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        242,     67+15,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        242,     86+13,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        242,     105+12,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+	//255
     
     
     /* Weapon Editor Goes Here
@@ -1546,7 +1581,7 @@ void edit_itemdata(int index)
     char mgtimer[8]; //timer for magic usage
 	char i_tilew[9], i_tileh[8], i_hxofs[8], i_hyofs[8], i_hxsz[8], i_hysz[8], i_hzsz[8], i_xofs[8], i_yofs[8]; //item sizing
 	char i_pickuptype[8]; //item pickup type
-    char i_weap_hxofs[8], i_weap_hyofs[8], i_weap_hxsz[8], i_weap_hysz[8], i_weap_hzsz[8], i_weap_xofs[8], i_weap_yofs[8]; //weapon sizing
+    char i_weap_tileh[8], i_weap_tilew[8], i_weap_hxofs[8], i_weap_hyofs[8], i_weap_hxsz[8], i_weap_hysz[8], i_weap_hzsz[8], i_weap_xofs[8], i_weap_yofs[8]; //weapon sizing
     
     
     sprintf(itemnumstr,"Item %d: %s", index, item_string[index]);
@@ -1581,6 +1616,7 @@ void edit_itemdata(int index)
     
     //Item sizing tileh, tilew, hxofs, hyofs, hxsz, hysz, hzsz, xofs, yofs; //item
 
+     //item size
      sprintf(i_tilew, "%d", itemsbuf[index].tilew);
      sprintf(i_tileh, "%d", itemsbuf[index].tileh);
      sprintf(i_hxofs, "%d", itemsbuf[index].hxofs);
@@ -1590,6 +1626,17 @@ void edit_itemdata(int index)
      sprintf(i_hzsz, "%d", itemsbuf[index].hzsz);
      sprintf(i_xofs, "%d", itemsbuf[index].xofs);
      sprintf(i_yofs, "%d", itemsbuf[index].yofs);
+     
+     //Weapon sizes    
+     sprintf(i_weap_tilew, "%d", itemsbuf[index].weap_tilew);
+     sprintf(i_weap_tileh, "%d", itemsbuf[index].weap_tileh);
+     sprintf(i_weap_hxofs, "%d", itemsbuf[index].weap_hxofs);
+     sprintf(i_weap_hyofs, "%d", itemsbuf[index].weap_hyofs);
+     sprintf(i_weap_hxsz, "%d", itemsbuf[index].weap_hxsz);
+     sprintf(i_weap_hysz, "%d", itemsbuf[index].weap_hysz);
+     sprintf(i_weap_hzsz, "%d", itemsbuf[index].weap_hzsz);
+     sprintf(i_weap_xofs, "%d", itemsbuf[index].weap_xofs);
+     sprintf(i_weap_yofs, "%d", itemsbuf[index].weap_yofs);
      
      
     //Override flags for item size
@@ -1604,6 +1651,16 @@ void edit_itemdata(int index)
     itemdata_dlg[226].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET) ? D_SELECTED : 0;
     itemdata_dlg[227].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET) ? D_SELECTED : 0;
 
+    //Weapon Size
+    itemdata_dlg[246].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_TILEWIDTH) ? D_SELECTED : 0;
+    itemdata_dlg[247].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_TILEHEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[248].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_HIT_WIDTH) ? D_SELECTED : 0;
+    itemdata_dlg[249].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_HIT_HEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[250].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[251].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[252].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_HIT_Z_HEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[253].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[254].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET) ? D_SELECTED : 0;
     
     /*
     //New itemdata vars
@@ -1701,6 +1758,7 @@ void edit_itemdata(int index)
     
     //item sizing
     
+    //item size
     itemdata_dlg[210].dp = i_tilew;
     itemdata_dlg[211].dp = i_tileh;
     itemdata_dlg[212].dp = i_hxofs;
@@ -1710,6 +1768,17 @@ void edit_itemdata(int index)
     itemdata_dlg[216].dp = i_hzsz;
     itemdata_dlg[217].dp = i_xofs;
     itemdata_dlg[218].dp = i_yofs;
+    
+    //weapon size
+    itemdata_dlg[237].dp = i_weap_tilew;
+    itemdata_dlg[238].dp = i_weap_tileh;
+    itemdata_dlg[239].dp = i_weap_hxofs;
+    itemdata_dlg[240].dp = i_weap_hyofs;
+    itemdata_dlg[241].dp = i_weap_hxsz;
+    itemdata_dlg[242].dp = i_weap_hysz;
+    itemdata_dlg[243].dp = i_weap_hzsz;
+    itemdata_dlg[244].dp = i_weap_xofs;
+    itemdata_dlg[245].dp = i_weap_yofs;
     
     //item size flags
     itemdata_dlg[219].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_TILEWIDTH) ? D_SELECTED : 0;
@@ -1722,6 +1791,16 @@ void edit_itemdata(int index)
     itemdata_dlg[226].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET) ? D_SELECTED : 0;
     itemdata_dlg[227].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET) ? D_SELECTED : 0;
 
+	//Weapon Size
+    itemdata_dlg[246].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_TILEWIDTH) ? D_SELECTED : 0;
+    itemdata_dlg[247].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_TILEHEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[248].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_HIT_WIDTH) ? D_SELECTED : 0;
+    itemdata_dlg[249].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_HIT_HEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[250].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[251].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[252].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_HIT_Z_HEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[253].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[254].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET) ? D_SELECTED : 0;
 
     
     
@@ -1848,6 +1927,8 @@ void edit_itemdata(int index)
 	test.magiccosttimer = vbound(atoi(mgtimer), 0, 255);
 	
 	//item Sizing
+	
+	//item size
 	test.tilew = vbound(atoi(i_tilew), 0, 32);
 	test.tileh = vbound(atoi(i_tileh), 0, 32);
 	test.hxofs = vbound(atoi(i_hxofs), -214747, 214747);
@@ -1857,8 +1938,6 @@ void edit_itemdata(int index)
 	test.hzsz = vbound(atoi(i_hzsz),  -214747, 214747);
 	test.xofs = vbound(atoi(i_xofs),  -214747, 214747);
 	test.yofs = vbound(atoi(i_yofs),  -214747, 214747);
-	
-	
 	if(itemdata_dlg[219].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_TILEWIDTH;
 	if(itemdata_dlg[220].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_TILEHEIGHT;
 	if(itemdata_dlg[221].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_WIDTH;
@@ -1868,6 +1947,27 @@ void edit_itemdata(int index)
 	if(itemdata_dlg[225].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_Z_HEIGHT;
 	if(itemdata_dlg[226].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_DRAW_X_OFFSET;
 	if(itemdata_dlg[227].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_DRAW_Y_OFFSET;
+	
+	//Weapon Size
+	
+	test.weap_tilew = vbound(atoi(i_weap_tilew), 0, 32);
+	test.weap_tileh = vbound(atoi(i_weap_tileh), 0, 32);
+	test.weap_hxofs = vbound(atoi(i_weap_hxofs), -214747, 214747);
+	test.weap_hyofs = vbound(atoi(i_weap_hyofs), -214747, 214747);
+	test.weap_hxsz = vbound(atoi(i_weap_hxsz),  -214747, 214747);
+	test.weap_hysz = vbound(atoi(i_weap_hysz),  -214747, 214747);
+	test.weap_hzsz = vbound(atoi(i_weap_hzsz),  -214747, 214747);
+	test.weap_xofs = vbound(atoi(i_weap_xofs),  -214747, 214747);
+	test.weap_yofs = vbound(atoi(i_weap_yofs),  -214747, 214747);
+	if(itemdata_dlg[246].flags & D_SELECTED) test.weapoverrideFLAGS |= itemdataOVERRIDE_TILEWIDTH;
+	if(itemdata_dlg[247].flags & D_SELECTED) test.weapoverrideFLAGS |= itemdataOVERRIDE_TILEHEIGHT;
+	if(itemdata_dlg[248].flags & D_SELECTED) test.weapoverrideFLAGS |= itemdataOVERRIDE_HIT_WIDTH;
+	if(itemdata_dlg[249].flags & D_SELECTED) test.weapoverrideFLAGS |= itemdataOVERRIDE_HIT_HEIGHT;
+	if(itemdata_dlg[250].flags & D_SELECTED) test.weapoverrideFLAGS |= itemdataOVERRIDE_HIT_X_OFFSET;
+	if(itemdata_dlg[251].flags & D_SELECTED) test.weapoverrideFLAGS |= itemdataOVERRIDE_HIT_Y_OFFSET;
+	if(itemdata_dlg[252].flags & D_SELECTED) test.weapoverrideFLAGS |= itemdataOVERRIDE_HIT_Z_HEIGHT;
+	if(itemdata_dlg[253].flags & D_SELECTED) test.weapoverrideFLAGS |= itemdataOVERRIDE_DRAW_X_OFFSET;
+	if(itemdata_dlg[254].flags & D_SELECTED) test.weapoverrideFLAGS |= itemdataOVERRIDE_DRAW_Y_OFFSET;
         
 	//New itemdata vars -Z
 	/*

--- a/src/zq_custom.cpp
+++ b/src/zq_custom.cpp
@@ -378,7 +378,7 @@ static int itemdata_gfx_list[] =
 static int itemdata_pickup_list[] =
 {
     // dialog control number
-    92, 93, 94, 95, 96, 97, 98, 99, 100, /*101, 102,*/ 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, -1
+    92, 93, 94, 95, 96, 97, 98, 99, 100, /*101, 102,*/ 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 255,256,257, -1
 };
 
 static int itemdata_action_list[] =
@@ -661,6 +661,9 @@ const char *counterlist(int index, int *list_size)
 }
 
 static ListData counter_list(counterlist, &pfont);
+
+
+
 
 //Moved defenselist up here so that it is also available to itemdata. -Z
 
@@ -1131,8 +1134,11 @@ static DIALOG itemdata_dlg[] =
      { jwin_check_proc,        242,     86+13,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
      { jwin_check_proc,        242,     105+12,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
 	//255
-    
-    
+    { jwin_text_proc,           8,     187,     96,      8,    vc(14),                 vc(1),                   0,       0,           0,    0, (void *) "Pick-Up Flags:",                  NULL,   NULL                  },
+    { jwin_edit_proc,      66,   182,   32,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_check_proc,        100,     186,     40,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+    //258
+
     /* Weapon Editor Goes Here
     { jwin_text_proc,       6+10,   29+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "Misc[0]:", NULL, NULL },
     { jwin_text_proc,       6+10,   47+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "Misc[1]:", NULL, NULL },
@@ -1614,6 +1620,9 @@ void edit_itemdata(int index)
     //Magic cost timer
     sprintf(mgtimer, "%d", itemsbuf[index].magiccosttimer);
     
+    //Item Pickip Flags
+    sprintf(i_pickuptype, "%d", itemsbuf[index].pickup);
+    
     //Item sizing tileh, tilew, hxofs, hyofs, hxsz, hysz, hzsz, xofs, yofs; //item
 
      //item size
@@ -1661,6 +1670,9 @@ void edit_itemdata(int index)
     itemdata_dlg[252].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_HIT_Z_HEIGHT) ? D_SELECTED : 0;
     itemdata_dlg[253].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET) ? D_SELECTED : 0;
     itemdata_dlg[254].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET) ? D_SELECTED : 0;
+    
+    //Pickup Flags Override
+    itemdata_dlg[257].flags = (itemsbuf[index].weapoverrideFLAGS&itemdataOVERRIDE_PICKUP) ? D_SELECTED : 0;
     
     /*
     //New itemdata vars
@@ -1755,6 +1767,10 @@ void edit_itemdata(int index)
     
     //Magic cost timer
     itemdata_dlg[200].dp = mgtimer;
+    
+    //Pickup Flags
+    itemdata_dlg[256].dp = i_pickuptype;
+    itemdata_dlg[257].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_PICKUP) ? D_SELECTED : 0;
     
     //item sizing
     
@@ -1925,6 +1941,10 @@ void edit_itemdata(int index)
         test.family = vbound(biic[itemdata_dlg[9].d1].i, 0, 255);
 	//Magic cost timer
 	test.magiccosttimer = vbound(atoi(mgtimer), 0, 255);
+	
+	//Pickup Flags
+	test.pickup = vbound(atoi(i_pickuptype), 0, 214747);
+	if(itemdata_dlg[257].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_PICKUP;
 	
 	//item Sizing
 	

--- a/src/zq_custom.cpp
+++ b/src/zq_custom.cpp
@@ -393,6 +393,18 @@ static int itemdata_scriptargs_list[] =
     101, 102, 131, 132, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, -1
 };
 
+static int itemdata_itemsize_list[] =
+{
+    // dialog control number
+    201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215,216,217,218,219,220,221,222,223,224,225,226,227 -1
+};
+
+static int itemdata_weaponsize_list[] =
+{
+    // dialog control number
+	222, -1
+};
+
 static int itemdata_weaponargs_list[] =
 {
     // dialog control number
@@ -408,7 +420,9 @@ static TABPANEL itemdata_tabs[] =
     { (char *)"Pickup",       0,             itemdata_pickup_list,        0, NULL },
     { (char *)"Action",       0,             itemdata_action_list,        0, NULL },
     { (char *)"Scripts",      0,             itemdata_scriptargs_list,    0, NULL },
+    { (char *)"Size",      0,             itemdata_itemsize_list,    0, NULL },
    //  { (char *)"Weapon",      0,             itemdata_weaponargs_list,    0, NULL },
+    { (char *)"W.Size",      0,             itemdata_itemsize_list,    0, NULL },
     { NULL,                   0,             NULL,                        0, NULL }
 };
 
@@ -1044,12 +1058,43 @@ static DIALOG itemdata_dlg[] =
     //197
     { jwin_edit_proc,      140+10,  25+20,   32,    16,   vc(12),   vc(1),   0,       0,          2,             0,       NULL, NULL, NULL },
     { jwin_edit_proc,      140+10,  43+20,   32,    16,   vc(12),   vc(1),   0,       0,          2,             0,       NULL, NULL, NULL },
-    //200
-    
+    //199
     //Magic Cost Timer, 199
     { jwin_text_proc,         83,     48,     30,      8,    vc(14),                 vc(1),                   0,       0,           0,    0, (void *) "M.Cost Timer:",                              NULL,   NULL                  },
     { jwin_edit_proc,         129,	44,     28,     16,    vc(12),                 vc(1),                   0,       0,           3,    0,  NULL,                                           NULL,   NULL                  },
    //201
+    { jwin_text_proc,       6,   29+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "TileWidth:", NULL, NULL },
+    { jwin_text_proc,       6,   48+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "TileHeight:", NULL, NULL },
+    { jwin_text_proc,       6,   67+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitWidth:", NULL, NULL },
+    { jwin_text_proc,       6,   86+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitHeight:", NULL, NULL },
+    { jwin_text_proc,       6,   105+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitXOffset:", NULL, NULL },
+    { jwin_text_proc,       6,   124+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitYOffset:", NULL, NULL },
+    { jwin_text_proc,       6,  143+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "HitZHeight:", NULL, NULL },
+    { jwin_text_proc,       6,  162+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "DrawXOffset:", NULL, NULL },
+    { jwin_text_proc,       6,  191+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "DrawYOffset:", NULL, NULL },
+    //210
+    { jwin_edit_proc,      34,   25+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      34,   42+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      34,   59+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      34,   76+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      34,   93+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      34,   110+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      34,   127+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      34,  144+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      34,  161+20,   48,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    //219
+     { jwin_check_proc,        84,     25+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        84,     42+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  }, 
+     { jwin_check_proc,        84,     59+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  }, 
+     { jwin_check_proc,        84,     76+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        84,     93+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        84,     110+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        84,     107+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        84,     144+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+     { jwin_check_proc,        84,     161+20,     95,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Override",                        NULL,   NULL                  },
+	//228
+    
+    
     /* Weapon Editor Goes Here
     { jwin_text_proc,       6+10,   29+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "Misc[0]:", NULL, NULL },
     { jwin_text_proc,       6+10,   47+20,   24,    36,   0,        0,       0,       0,          0,             0, (void *) "Misc[1]:", NULL, NULL },
@@ -1494,8 +1539,12 @@ void edit_itemdata(int index)
     char ms1[8], ms2[8], ms3[8], ms4[8], ms5[8], ms6[8], ms7[8], ms8[8], ms9[8], ms10[8];
     char itemnumstr[75];
     char da[10][13];
-    char wrange[8], wdur[8], wdef[8], wweap[8], wptrn[8], warg1[8], warg2[8], warg3[8], warg4[8], warg5[8], warg6[8];
-    char mgtimer[8];
+    char wrange[8], wdur[8], wdef[8], wweap[8], wptrn[8], warg1[8], warg2[8], warg3[8], warg4[8], warg5[8], warg6[8]; //weapon editor
+    char mgtimer[8]; //timer for magic usage
+	char i_tilew[9], i_tileh[8], i_hxofs[8], i_hyofs[8], i_hxsz[8], i_hysz[8], i_hzsz[8], i_xofs[8], i_yofs[8]; //item sizing
+	char i_pickuptype[8]; //item pickup type
+    char i_weap_hxofs[8], i_weap_yxofs[8], i_weap_hxsz[8], i_weap_hysz[8], i_weap_hzsz[8], i_weap_xofs[8], i_weap_yofs[8]; //weapon sizing
+    
     
     sprintf(itemnumstr,"Item %d: %s", index, item_string[index]);
     sprintf(fcs,"%d",itemsbuf[index].csets>>4);
@@ -1526,6 +1575,32 @@ void edit_itemdata(int index)
     
     //Magic cost timer
     sprintf(mgtimer, "%d", itemsbuf[index].magiccosttimer);
+    
+    //Item sizing tileh, tilew, hxofs, hyofs, hxsz, hysz, hzsz, xofs, yofs; //item
+
+     sprintf(i_tilew, "%d", itemsbuf[index].tilew);
+     sprintf(i_tileh, "%d", itemsbuf[index].tileh);
+     sprintf(i_hxofs, "%d", itemsbuf[index].hxofs);
+     sprintf(i_hyofs, "%d", itemsbuf[index].hyofs);
+     sprintf(i_hxsz, "%d", itemsbuf[index].hxsz);
+     sprintf(i_hysz, "%d", itemsbuf[index].hysz);
+     sprintf(i_hzsz, "%d", itemsbuf[index].hzsz);
+     sprintf(i_xofs, "%d", itemsbuf[index].xofs);
+     sprintf(i_yofs, "%d", itemsbuf[index].yofs);
+     
+     
+    //Override flags for item size
+    itemdata_dlg[219].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_TILEWIDTH) ? D_SELECTED : 0;
+    itemdata_dlg[220].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_TILEHEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[221].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[222].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[223].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_WIDTH) ? D_SELECTED : 0;
+    itemdata_dlg[223].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_HEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[224].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_Z_HEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[226].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[227].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET) ? D_SELECTED : 0;
+
+    
     /*
     //New itemdata vars
     sprintf(wrange,"%d",itemsbuf[index].weaprange);
@@ -1619,6 +1694,32 @@ void edit_itemdata(int index)
     
     //Magic cost timer
     itemdata_dlg[200].dp = mgtimer;
+    
+    //item sizing
+    
+    itemdata_dlg[210].dp = i_tilew;
+    itemdata_dlg[211].dp = i_tileh;
+    itemdata_dlg[212].dp = i_hxofs;
+    itemdata_dlg[213].dp = i_hyofs;
+    itemdata_dlg[214].dp = i_hxsz;
+    itemdata_dlg[215].dp = i_hysz;
+    itemdata_dlg[216].dp = i_hzsz;
+    itemdata_dlg[217].dp = i_xofs;
+    itemdata_dlg[218].dp = i_yofs;
+    
+    //item size flags
+    itemdata_dlg[219].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_TILEWIDTH) ? D_SELECTED : 0;
+    itemdata_dlg[220].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_TILEHEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[221].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_X_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[222].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_Y_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[223].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_WIDTH) ? D_SELECTED : 0;
+    itemdata_dlg[224].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_HEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[225].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_HIT_Z_HEIGHT) ? D_SELECTED : 0;
+    itemdata_dlg[226].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_DRAW_X_OFFSET) ? D_SELECTED : 0;
+    itemdata_dlg[227].flags = (itemsbuf[index].overrideFLAGS&itemdataOVERRIDE_DRAW_Y_OFFSET) ? D_SELECTED : 0;
+
+
+    
     
     for(int i=0; i<10; ++i)
     {
@@ -1741,6 +1842,29 @@ void edit_itemdata(int index)
         test.family = vbound(biic[itemdata_dlg[9].d1].i, 0, 255);
 	//Magic cost timer
 	test.magiccosttimer = vbound(atoi(mgtimer), 0, 255);
+	
+	//item Sizing
+	test.tilew = vbound(atoi(i_tilew), 0, 32);
+	test.tileh = vbound(atoi(i_tileh), 0, 32);
+	test.hxofs = vbound(atoi(i_hxofs), -214747, 214747);
+	test.hyofs = vbound(atoi(i_hyofs), -214747, 214747);
+	test.hxsz = vbound(atoi(i_hxsz),  -214747, 214747);
+	test.hysz = vbound(atoi(i_hysz),  -214747, 214747);
+	test.hzsz = vbound(atoi(i_hzsz),  -214747, 214747);
+	test.xofs = vbound(atoi(i_xofs),  -214747, 214747);
+	test.yofs = vbound(atoi(i_yofs),  -214747, 214747);
+	
+	
+	//item sizing override flags
+	if(itemdata_dlg[219].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_TILEWIDTH;
+	if(itemdata_dlg[220].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_TILEHEIGHT;
+	if(itemdata_dlg[221].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_WIDTH;
+	if(itemdata_dlg[222].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_HEIGHT;
+	if(itemdata_dlg[223].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_Z_HEIGHT;
+	if(itemdata_dlg[224].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_X_OFFSET;
+	if(itemdata_dlg[225].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_HIT_Y_OFFSET;
+	if(itemdata_dlg[226].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_DRAW_X_OFFSET;
+	if(itemdata_dlg[227].flags & D_SELECTED) test.overrideFLAGS |= itemdataOVERRIDE_DRAW_Y_OFFSET;
         
 	//New itemdata vars -Z
 	/*


### PR DESCRIPTION
Added a 'Size' tab to the item editor. The user may now set the following fields for items in ZQuest, without scripts:
TileWidth, TileHeight, HotWidth, HitHeight, HitXOffset, HitYOffset, DrawXOffset, DrawYOffset, HitZHeight

The editor has an 'Override' flag for each. The values will only work if the override flag is enabled, and this willoverride any other internal sizes and offsets normally applied by the engine. 

Began a 'Weapon Size' tab to the item editor. The editor fields work, but they do not yet affect anything in-game.