### PR TITLE
Lens of Truth Item Flags

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -31,6 +31,7 @@
 #include "title.h"
 #include "ffscript.h"
 extern FFScript FFCore;
+extern LinkClass Link;
 #include "mem_debug.h"
 #include "zscriptversion.h"
 

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -5967,7 +5967,7 @@ bool isRaftFlag(int flag)
 void do_lens()
 {
     int itemid = lensid >= 0 ? lensid : directWpn>-1 ? directWpn : current_item_id(itype_lens);
-	setLastLensID(itemid);
+	Link.setLastLensID(itemid);
     if(itemid<0)
         return;
         

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -855,6 +855,7 @@ void LinkClass::init()
     falling_oldy = y;
     magiccastclk=0;
     magicitem = nayruitem = -1;
+	last_lens_id = 0;
     
     for(int i=0; i<32; i++) miscellaneous[i] = 0;
     
@@ -5966,7 +5967,7 @@ bool isRaftFlag(int flag)
 void do_lens()
 {
     int itemid = lensid >= 0 ? lensid : directWpn>-1 ? directWpn : current_item_id(itype_lens);
-    
+	setLastLensID(itemid);
     if(itemid<0)
         return;
         
@@ -16314,6 +16315,14 @@ int LinkClass::getHoverClk()
 int LinkClass::getHoldClk()
 {
     return holdclk;
+}
+
+int LinkClass::getLastLensID(){
+	return last_lens_id;
+}
+
+void LinkClass::setLastLensID(int p_item){
+	last_lens_id = p_item;
 }
 
 void LinkClass::execute(LinkClass::WalkflagInfo info)

--- a/src/link.h
+++ b/src/link.h
@@ -438,7 +438,7 @@ public:
 	
 	
 	int getLastLensID();	
-	int setLastLensID(int p_item);
+	void setLastLensID(int p_item);
 };
 
 bool isRaftFlag(int flag);

--- a/src/link.h
+++ b/src/link.h
@@ -242,6 +242,8 @@ class LinkClass : public sprite
     int hurtsfx; //Link's Hurt SOund
     int walkspeed; //Link's walking speed.
     int lastHitBy[NUM_HIT_TYPES_USED][2]; //[enemy, eweapon, combo, flag
+	
+	int last_lens_id;// The item ID of the last Lens of Truth type item used
     
     // Methods below here.
     void movelink();
@@ -433,6 +435,10 @@ public:
     void setDiagMove(bool newdiag);
     bool getBigHitbox(); //Large H-itbox
     void setBigHitbox(bool newbighitbox);
+	
+	
+	int getLastLensID();	
+	int setLastLensID(int p_item);
 };
 
 bool isRaftFlag(int flag);

--- a/src/zc_sys.cpp
+++ b/src/zc_sys.cpp
@@ -2309,9 +2309,10 @@ int dmap_tile_mod()
 // Hints are drawn on a separate layer to combo reveals.
 void draw_lens_under(BITMAP *dest, bool layer)
 {
-    bool hints = (layer && get_bit(quest_rules,qr_LENSHINTS));
-    
-	if(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1)hints = false;
+	//Lens flag 1: Replacement for qr_LENSHINTS; if set, lens will show hints. Does nothing if flag 2 is set.
+	//Lens flag 2: Disable "hints", prevent rendering of Secret Combos
+	//Lens flag 3: Don't show armos/chest/dive items
+	bool hints = (itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2) ? false : (layer && (get_bit(quest_rules,qr_LENSHINTS) || itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1));
 	
     int strike_hint_table[11]=
     {
@@ -2358,8 +2359,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                 if(checkflag==mfSTRIKE)
                 {
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sSTRIKE],tmpscr->secretcset[sSTRIKE]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sSTRIKE],tmpscr->secretcset[sSTRIKE]);
+                    }
+					else
                     {
                         checkflag = strike_hint;
                     }
@@ -2572,7 +2575,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     if(!hints && ((!(get_debug() && key[KEY_N]) && (lensclk&16))
                                   || ((get_debug() && key[KEY_N]) && (frame&16))))
                     {
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->undercombo,tmpscr->undercset);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->undercombo,tmpscr->undercset);
                     }
                     
                     if((!(get_debug() && key[KEY_N]) && (lensclk&blink_rate))
@@ -2650,8 +2653,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfBCANDLE:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sBCANDLE],tmpscr->secretcset[sBCANDLE]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sBCANDLE],tmpscr->secretcset[sBCANDLE]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_candle,1);
                         
@@ -2671,8 +2676,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfRCANDLE:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sRCANDLE],tmpscr->secretcset[sRCANDLE]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sRCANDLE],tmpscr->secretcset[sRCANDLE]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_candle,2);
                         
@@ -2692,8 +2699,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfWANDFIRE:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sWANDFIRE],tmpscr->secretcset[sWANDFIRE]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sWANDFIRE],tmpscr->secretcset[sWANDFIRE]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_wand,1);
                         
@@ -2721,8 +2730,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfDINSFIRE:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sDINSFIRE],tmpscr->secretcset[sDINSFIRE]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sDINSFIRE],tmpscr->secretcset[sDINSFIRE]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_dinsfire,1);
                         
@@ -2742,8 +2753,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfARROW:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sARROW],tmpscr->secretcset[sARROW]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sARROW],tmpscr->secretcset[sARROW]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_arrow,1);
                         
@@ -2763,8 +2776,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfSARROW:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sSARROW],tmpscr->secretcset[sSARROW]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sSARROW],tmpscr->secretcset[sSARROW]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_arrow,2);
                         
@@ -2784,8 +2799,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfGARROW:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sGARROW],tmpscr->secretcset[sGARROW]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sGARROW],tmpscr->secretcset[sGARROW]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_arrow,3);
                         
@@ -2805,8 +2822,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfBOMB:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sBOMB],tmpscr->secretcset[sBOMB]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sBOMB],tmpscr->secretcset[sBOMB]);
+                    }
+					else
                     {
                         //tempitem=getItemID(itemsbuf,itype_bomb,1);
                         tempweapon = wLitBomb;
@@ -2826,8 +2845,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfSBOMB:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sSBOMB],tmpscr->secretcset[sSBOMB]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sSBOMB],tmpscr->secretcset[sSBOMB]);
+                    }
+					else
                     {
                         //tempitem=getItemID(itemsbuf,itype_sbomb,1);
                         //if (tempitem<0) break;
@@ -2847,14 +2868,17 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfARMOS_SECRET:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sSTAIRS],tmpscr->secretcset[sSTAIRS]);
-                        
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sSTAIRS],tmpscr->secretcset[sSTAIRS]);
+                    }    
                     break;
                     
                 case mfBRANG:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sBRANG],tmpscr->secretcset[sBRANG]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sBRANG],tmpscr->secretcset[sBRANG]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_brang,1);
                         
@@ -2874,8 +2898,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfMBRANG:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sMBRANG],tmpscr->secretcset[sMBRANG]);
-                    else
+			{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sMBRANG],tmpscr->secretcset[sMBRANG]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_brang,2);
                         
@@ -2895,8 +2921,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfFBRANG:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sFBRANG],tmpscr->secretcset[sFBRANG]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sFBRANG],tmpscr->secretcset[sFBRANG]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_brang,3);
                         
@@ -2916,8 +2944,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfWANDMAGIC:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sWANDMAGIC],tmpscr->secretcset[sWANDMAGIC]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sWANDMAGIC],tmpscr->secretcset[sWANDMAGIC]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_wand,1);
                         
@@ -2951,8 +2981,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfREFMAGIC:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sREFMAGIC],tmpscr->secretcset[sREFMAGIC]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sREFMAGIC],tmpscr->secretcset[sREFMAGIC]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_shield,3);
                         
@@ -2999,8 +3031,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfREFFIREBALL:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sREFFIREBALL],tmpscr->secretcset[sREFFIREBALL]);
-                    else
+                    {
+						if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sREFFIREBALL],tmpscr->secretcset[sREFFIREBALL]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_shield,3);
                         
@@ -3041,8 +3075,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfSWORD:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sSWORD],tmpscr->secretcset[sSWORD]);
-                    else
+                    {
+						if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sSWORD],tmpscr->secretcset[sSWORD]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,1);
                         
@@ -3062,8 +3098,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfWSWORD:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sWSWORD],tmpscr->secretcset[sWSWORD]);
-                    else
+                    {
+						if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sWSWORD],tmpscr->secretcset[sWSWORD]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,2);
                         
@@ -3083,8 +3121,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfMSWORD:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sMSWORD],tmpscr->secretcset[sMSWORD]);
-                    else
+                    {
+						if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sMSWORD],tmpscr->secretcset[sMSWORD]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,3);
                         
@@ -3104,8 +3144,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfXSWORD:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sXSWORD],tmpscr->secretcset[sXSWORD]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sXSWORD],tmpscr->secretcset[sXSWORD]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,4);
                         
@@ -3125,8 +3167,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfSWORDBEAM:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sSWORDBEAM],tmpscr->secretcset[sSWORDBEAM]);
-                    else
+                    {
+						if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sSWORDBEAM],tmpscr->secretcset[sSWORDBEAM]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,1);
                         
@@ -3146,8 +3190,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfWSWORDBEAM:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sWSWORDBEAM],tmpscr->secretcset[sWSWORDBEAM]);
-                    else
+                    {
+						if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sWSWORDBEAM],tmpscr->secretcset[sWSWORDBEAM]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,2);
                         
@@ -3167,8 +3213,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfMSWORDBEAM:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sMSWORDBEAM],tmpscr->secretcset[sMSWORDBEAM]);
-                    else
+                    {
+						if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sMSWORDBEAM],tmpscr->secretcset[sMSWORDBEAM]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,3);
                         
@@ -3188,8 +3236,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfXSWORDBEAM:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sXSWORDBEAM],tmpscr->secretcset[sXSWORDBEAM]);
-                    else
+                    {
+						if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sXSWORDBEAM],tmpscr->secretcset[sXSWORDBEAM]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,4);
                         
@@ -3209,8 +3259,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfHOOKSHOT:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sHOOKSHOT],tmpscr->secretcset[sHOOKSHOT]);
-                    else
+                    {
+						if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sHOOKSHOT],tmpscr->secretcset[sHOOKSHOT]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_hookshot,1);
                         
@@ -3230,8 +3282,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfWAND:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sWAND],tmpscr->secretcset[sWAND]);
-                    else
+					{
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sWAND],tmpscr->secretcset[sWAND]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_wand,1);
                         
@@ -3251,8 +3305,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfHAMMER:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sHAMMER],tmpscr->secretcset[sHAMMER]);
-                    else
+                    {
+			if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[sHAMMER],tmpscr->secretcset[sHAMMER]);
+                    }
+					else
                     {
                         tempitem=getItemID(itemsbuf,itype_hammer,1);
                         
@@ -3272,10 +3328,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfARMOS_ITEM:
                 case mfDIVE_ITEM:
-                    if(!getmapflag())
-                        //          putitem2(dest,x,y,tmpscr->catchall);
+                    if(!getmapflag() && !(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG3))
+		    {
                         putitem2(dest,x,y,tmpscr->catchall, lens_hint_item[tmpscr->catchall][0], lens_hint_item[tmpscr->catchall][1], 0);
-                        
+		    }
                     break;
                     
                 case 16:
@@ -3295,14 +3351,24 @@ void draw_lens_under(BITMAP *dest, bool layer)
                 case 30:
                 case 31:
                     if(!hints)
-                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[checkflag-16+4],
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,x,y,tmpscr->secretcombo[checkflag-16+4],
                                  tmpscr->secretcset[checkflag-16+4]);
                                  
                     break;
-		    
-		
+				
+				case mfSTRIKE:
+					if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))
+					{
+						goto special;
+					}
+					else
+					{
+						break;
+					}
                     
-                default:
+                default: goto special;
+				
+				special:
                     if(layer && ((checkflag!=mfRAFT && checkflag!=mfRAFT_BRANCH&& checkflag!=mfRAFT_BOUNCE) || get_bit(quest_rules,qr_RAFTLENS)))
                     {
                         if((!(get_debug() && key[KEY_N]) && (lensclk&1)) || ((get_debug() && key[KEY_N]) && (frame&1)))
@@ -3354,7 +3420,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
         if(tmpscr->stairx + tmpscr->stairy)
         {
             if(!hints)
-                if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,tmpscr->stairx,tmpscr->stairy+playing_field_offset,tmpscr->secretcombo[sSTAIRS],tmpscr->secretcset[sSTAIRS]);
+                if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG2))putcombo(dest,tmpscr->stairx,tmpscr->stairy+playing_field_offset,tmpscr->secretcombo[sSTAIRS],tmpscr->secretcset[sSTAIRS]);
             else
             {
                 if(tmpscr->flags&fWHISTLE)

--- a/src/zc_sys.cpp
+++ b/src/zc_sys.cpp
@@ -2311,6 +2311,8 @@ void draw_lens_under(BITMAP *dest, bool layer)
 {
     bool hints = (layer && get_bit(quest_rules,qr_LENSHINTS));
     
+	if(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1)hints = false;
+	
     int strike_hint_table[11]=
     {
         mfARROW, mfBOMB, mfBRANG, mfWANDMAGIC,
@@ -2356,7 +2358,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                 if(checkflag==mfSTRIKE)
                 {
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sSTRIKE],tmpscr->secretcset[sSTRIKE]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sSTRIKE],tmpscr->secretcset[sSTRIKE]);
                     else
                     {
                         checkflag = strike_hint;
@@ -2570,7 +2572,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     if(!hints && ((!(get_debug() && key[KEY_N]) && (lensclk&16))
                                   || ((get_debug() && key[KEY_N]) && (frame&16))))
                     {
-                        putcombo(dest,x,y,tmpscr->undercombo,tmpscr->undercset);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->undercombo,tmpscr->undercset);
                     }
                     
                     if((!(get_debug() && key[KEY_N]) && (lensclk&blink_rate))
@@ -2648,7 +2650,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfBCANDLE:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sBCANDLE],tmpscr->secretcset[sBCANDLE]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sBCANDLE],tmpscr->secretcset[sBCANDLE]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_candle,1);
@@ -2669,7 +2671,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfRCANDLE:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sRCANDLE],tmpscr->secretcset[sRCANDLE]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sRCANDLE],tmpscr->secretcset[sRCANDLE]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_candle,2);
@@ -2690,7 +2692,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfWANDFIRE:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sWANDFIRE],tmpscr->secretcset[sWANDFIRE]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sWANDFIRE],tmpscr->secretcset[sWANDFIRE]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_wand,1);
@@ -2719,7 +2721,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfDINSFIRE:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sDINSFIRE],tmpscr->secretcset[sDINSFIRE]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sDINSFIRE],tmpscr->secretcset[sDINSFIRE]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_dinsfire,1);
@@ -2740,7 +2742,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfARROW:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sARROW],tmpscr->secretcset[sARROW]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sARROW],tmpscr->secretcset[sARROW]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_arrow,1);
@@ -2761,7 +2763,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfSARROW:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sSARROW],tmpscr->secretcset[sSARROW]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sSARROW],tmpscr->secretcset[sSARROW]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_arrow,2);
@@ -2782,7 +2784,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfGARROW:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sGARROW],tmpscr->secretcset[sGARROW]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sGARROW],tmpscr->secretcset[sGARROW]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_arrow,3);
@@ -2803,7 +2805,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfBOMB:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sBOMB],tmpscr->secretcset[sBOMB]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sBOMB],tmpscr->secretcset[sBOMB]);
                     else
                     {
                         //tempitem=getItemID(itemsbuf,itype_bomb,1);
@@ -2824,7 +2826,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfSBOMB:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sSBOMB],tmpscr->secretcset[sSBOMB]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sSBOMB],tmpscr->secretcset[sSBOMB]);
                     else
                     {
                         //tempitem=getItemID(itemsbuf,itype_sbomb,1);
@@ -2845,13 +2847,13 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfARMOS_SECRET:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sSTAIRS],tmpscr->secretcset[sSTAIRS]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sSTAIRS],tmpscr->secretcset[sSTAIRS]);
                         
                     break;
                     
                 case mfBRANG:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sBRANG],tmpscr->secretcset[sBRANG]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sBRANG],tmpscr->secretcset[sBRANG]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_brang,1);
@@ -2872,7 +2874,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfMBRANG:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sMBRANG],tmpscr->secretcset[sMBRANG]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sMBRANG],tmpscr->secretcset[sMBRANG]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_brang,2);
@@ -2893,7 +2895,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfFBRANG:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sFBRANG],tmpscr->secretcset[sFBRANG]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sFBRANG],tmpscr->secretcset[sFBRANG]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_brang,3);
@@ -2914,7 +2916,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfWANDMAGIC:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sWANDMAGIC],tmpscr->secretcset[sWANDMAGIC]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sWANDMAGIC],tmpscr->secretcset[sWANDMAGIC]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_wand,1);
@@ -2949,7 +2951,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfREFMAGIC:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sREFMAGIC],tmpscr->secretcset[sREFMAGIC]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sREFMAGIC],tmpscr->secretcset[sREFMAGIC]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_shield,3);
@@ -2997,7 +2999,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfREFFIREBALL:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sREFFIREBALL],tmpscr->secretcset[sREFFIREBALL]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sREFFIREBALL],tmpscr->secretcset[sREFFIREBALL]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_shield,3);
@@ -3039,7 +3041,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfSWORD:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sSWORD],tmpscr->secretcset[sSWORD]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sSWORD],tmpscr->secretcset[sSWORD]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,1);
@@ -3060,7 +3062,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfWSWORD:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sWSWORD],tmpscr->secretcset[sWSWORD]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sWSWORD],tmpscr->secretcset[sWSWORD]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,2);
@@ -3081,7 +3083,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfMSWORD:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sMSWORD],tmpscr->secretcset[sMSWORD]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sMSWORD],tmpscr->secretcset[sMSWORD]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,3);
@@ -3102,7 +3104,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfXSWORD:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sXSWORD],tmpscr->secretcset[sXSWORD]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sXSWORD],tmpscr->secretcset[sXSWORD]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,4);
@@ -3123,7 +3125,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfSWORDBEAM:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sSWORDBEAM],tmpscr->secretcset[sSWORDBEAM]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sSWORDBEAM],tmpscr->secretcset[sSWORDBEAM]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,1);
@@ -3144,7 +3146,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfWSWORDBEAM:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sWSWORDBEAM],tmpscr->secretcset[sWSWORDBEAM]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sWSWORDBEAM],tmpscr->secretcset[sWSWORDBEAM]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,2);
@@ -3165,7 +3167,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfMSWORDBEAM:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sMSWORDBEAM],tmpscr->secretcset[sMSWORDBEAM]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sMSWORDBEAM],tmpscr->secretcset[sMSWORDBEAM]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,3);
@@ -3186,7 +3188,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfXSWORDBEAM:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sXSWORDBEAM],tmpscr->secretcset[sXSWORDBEAM]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sXSWORDBEAM],tmpscr->secretcset[sXSWORDBEAM]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_sword,4);
@@ -3207,7 +3209,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfHOOKSHOT:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sHOOKSHOT],tmpscr->secretcset[sHOOKSHOT]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sHOOKSHOT],tmpscr->secretcset[sHOOKSHOT]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_hookshot,1);
@@ -3228,7 +3230,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfWAND:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sWAND],tmpscr->secretcset[sWAND]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sWAND],tmpscr->secretcset[sWAND]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_wand,1);
@@ -3249,7 +3251,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                     
                 case mfHAMMER:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[sHAMMER],tmpscr->secretcset[sHAMMER]);
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[sHAMMER],tmpscr->secretcset[sHAMMER]);
                     else
                     {
                         tempitem=getItemID(itemsbuf,itype_hammer,1);
@@ -3293,7 +3295,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
                 case 30:
                 case 31:
                     if(!hints)
-                        putcombo(dest,x,y,tmpscr->secretcombo[checkflag-16+4],
+                        if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,x,y,tmpscr->secretcombo[checkflag-16+4],
                                  tmpscr->secretcset[checkflag-16+4]);
                                  
                     break;
@@ -3352,7 +3354,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
         if(tmpscr->stairx + tmpscr->stairy)
         {
             if(!hints)
-                putcombo(dest,tmpscr->stairx,tmpscr->stairy+playing_field_offset,tmpscr->secretcombo[sSTAIRS],tmpscr->secretcset[sSTAIRS]);
+                if(!(itemsbuf[Link.getLastLensID()].flags & ITEM_FLAG1))putcombo(dest,tmpscr->stairx,tmpscr->stairy+playing_field_offset,tmpscr->secretcombo[sSTAIRS],tmpscr->secretcset[sSTAIRS]);
             else
             {
                 if(tmpscr->flags&fWHISTLE)


### PR DESCRIPTION
Flag 1: equivalent to qr_LENSHINTS being set for that item
Flag 2: prevents secret combos as well as qr_LENSHINTS hints from being shown by that lens item
Flag 3: prevents Armos/Chest -> Item and Dive -> Item items from being shown by that lens item

Someone needs to do the ZQ end of this, giving the flags names in-editor.