### PR TITLE
Moved QRs into Item Editor Flags

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -3194,12 +3194,11 @@ void LinkClass::checkhit()
     for(int i=0; i<Lwpns.Count(); i++)
     {
         sprite *s = Lwpns.spr(i);
+	int itemid = ((weapon*)(Lwpns.spr(i)))->parentitem;
         //if ( itemdbuf[parentitem].flags&ITEM_FLAGS3 ) //can damage Link
 	    //if ( itemsbuf[parentitem].misc1 > 0 ) //damages Link by this amount. 
         if(!get_bit(quest_rules,qr_FIREPROOFLINK) && (scriptcoldet&1) && (!superman || !get_bit(quest_rules,qr_FIREPROOFLINK2)))
         {
-            int itemid = ((weapon*)(Lwpns.spr(i)))->parentitem;
-            
             if(s->id==wFire && (superman ? (diagonalMovement?s->hit(x+4,y+4,z,7,7,1):s->hit(x+7,y+7,z,2,2,1)) : s->hit(this))&&
                         (itemid < 0 || itemsbuf[itemid].family!=itype_dinsfire))
             {
@@ -3347,7 +3346,7 @@ killweapon:
             }
         }
         
-        if(get_bit(quest_rules,qr_OUCHBOMBS))
+        if(get_bit(quest_rules,qr_OUCHBOMBS) || (itemsbuf[itemid].flags & ITEM_FLAG2))
         {
             //     if(((s->id==wBomb)||(s->id==wSBomb)) && (superman ? s->hit(x+7,y+7,z,2,2,1) : s->hit(this)))
             if(((s->id==wBomb)||(s->id==wSBomb)) && s->hit(this) && !superman && (scriptcoldet&1))

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -5937,8 +5937,9 @@ bool LinkClass::doattack()
 
 bool LinkClass::can_attack()
 {
+	int currentSwordOrWand = (itemsbuf[dowpn].family == itype_wand || itemsbuf[dowpn].family == itype_sword)?dowpn:-1;
     if(action==hopping || action==swimming || action==freeze || link_is_stunned > 0 ||
-            (action==attacking && (attack!=wSword || attack!=wWand || !get_bit(quest_rules,qr_QUICKSWORD)) && charging!=0) || spins>0)
+            (action==attacking && ((attack!=wSword && attack!=wWand) || !(get_bit(quest_rules,qr_QUICKSWORD)||(itemsbuf[currentSwordOrWand].flags & ITEM_FLAG5))) && charging!=0) || spins>0)
     {
         return false;
     }
@@ -6537,7 +6538,8 @@ void LinkClass::movelink()
     
     //&0xFFF removes the "bow & arrows" bitmask
     //The Quick Sword is allowed to interrupt attacks.
-    if((!attackclk && action!=attacking) || ((attack==wSword || attack==wWand) && get_bit(quest_rules,qr_QUICKSWORD)))
+    int currentSwordOrWand = (itemsbuf[dowpn].family == itype_wand || itemsbuf[dowpn].family == itype_sword)?dowpn:-1;
+    if((!attackclk && action!=attacking) || ((attack==wSword || attack==wWand) && (get_bit(quest_rules,qr_QUICKSWORD)||(itemsbuf[currentSwordOrWand].flags & ITEM_FLAG5))))
     {
         if(DrunkrBbtn())
         {

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -3197,7 +3197,7 @@ void LinkClass::checkhit()
 	int itemid = ((weapon*)(Lwpns.spr(i)))->parentitem;
         //if ( itemdbuf[parentitem].flags&ITEM_FLAGS3 ) //can damage Link
 	    //if ( itemsbuf[parentitem].misc1 > 0 ) //damages Link by this amount. 
-        if(!get_bit(quest_rules,qr_FIREPROOFLINK) && (scriptcoldet&1) && (!superman || !get_bit(quest_rules,qr_FIREPROOFLINK2)))
+        if((!((itemsbuf[itemid].family==itype_candle||itemsbuf[itemid].family==itype_book)&&(itemsbuf[itemid].flags & ITEM_FLAG3)) || get_bit(quest_rules,qr_FIREPROOFLINK)) && (scriptcoldet&1) && (!superman || !get_bit(quest_rules,qr_FIREPROOFLINK2)))
         {
             if(s->id==wFire && (superman ? (diagonalMovement?s->hit(x+4,y+4,z,7,7,1):s->hit(x+7,y+7,z,2,2,1)) : s->hit(this))&&
                         (itemid < 0 || itemsbuf[itemid].family!=itype_dinsfire))

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -6059,7 +6059,7 @@ void LinkClass::do_hopping()
             --diveclk;
         else if(DrunkrAbtn())
         {
-            bool global_diving=(get_bit(quest_rules,qr_NODIVING) != 0);
+            bool global_diving=(get_bit(quest_rules,qr_NODIVING)>0 || (itemsbuf[current_item_id(itype_flippers)].flags & ITEM_FLAG1)>0);
             bool screen_diving=(tmpscr->flags5&fTOGGLEDIVING) != 0;
             
             if(global_diving==screen_diving)
@@ -6511,7 +6511,7 @@ void LinkClass::movelink()
     }
     else if(action==swimming)
     {
-        bool global_diving=(get_bit(quest_rules,qr_NODIVING) != 0);
+        bool global_diving=(get_bit(quest_rules,qr_NODIVING)>0 || (itemsbuf[current_item_id(itype_flippers)].flags & ITEM_FLAG1)>0);
         bool screen_diving=(tmpscr->flags5&fTOGGLEDIVING) != 0;
         
         if(DrunkrAbtn()&&(global_diving==screen_diving))

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -3197,7 +3197,7 @@ void LinkClass::checkhit()
 	int itemid = ((weapon*)(Lwpns.spr(i)))->parentitem;
         //if ( itemdbuf[parentitem].flags&ITEM_FLAGS3 ) //can damage Link
 	    //if ( itemsbuf[parentitem].misc1 > 0 ) //damages Link by this amount. 
-        if(!get_bit(quest_rules,qr_FIREPROOFLINK) && (scriptcoldet&1) && (!superman || !get_bit(quest_rules,qr_FIREPROOFLINK2)))
+        if(!((itemsbuf[itemid].family==itype_candle||itemsbuf[itemid].family==itype_book)&&(itemsbuf[itemid].flags & ITEM_FLAG3)) || get_bit(quest_rules,qr_FIREPROOFLINK)) && (scriptcoldet&1) && (!superman || !get_bit(quest_rules,qr_FIREPROOFLINK2)))
         {
             if(s->id==wFire && (superman ? (diagonalMovement?s->hit(x+4,y+4,z,7,7,1):s->hit(x+7,y+7,z,2,2,1)) : s->hit(this))&&
                         (itemid < 0 || itemsbuf[itemid].family!=itype_dinsfire))


### PR DESCRIPTION

Changelog:
Covers bombs, super  bombs, flippers, sword, and candles/books.
Feat: Ported qr_OUCHBOMBS to ITEM_FLAG2 of Bombs/SBombs  …
Feat: Ported qr_NODIVING to item editor  …
Feat: Ported qr_QUICKSWORD to Wand/Sword ITEM_FLAG5  …
Feat: Ported qr_FIREPROOFLINK to candles and books as ITEM_FLAG3.  …
