### PR TITLE
Fix: Bug with Wand/Book Fire (NEEDS ER)

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -5140,13 +5140,20 @@ bool LinkClass::startwpn(int itemid)
             
         if(Lwpns.idCount(wBeam))
             Lwpns.del(Lwpns.idFirst(wBeam));
-            
-        int type = bookid != -1 ? current_item(itype_book) : itemsbuf[itemid].fam_type;
-        int pow = (bookid != -1 ? current_item_power(itype_book) : itemsbuf[itemid].power)*DAMAGE_MULTIPLIER;
+        
+	//This needs an ER -V
+        /*int type = bookid != -1 ? current_item(itype_book) : itemsbuf[itemid].fam_type;
+        int pow = (bookid != -1 ? current_item_power(itype_book) : itemsbuf[itemid].power)*DAMAGE_MULTIPLIER;*/ 
+        int type = (bookid != -1 && paybook) ? current_item(itype_book) : itemsbuf[itemid].fam_type;
+        int pow = ((bookid != -1 && paybook) ? current_item_power(itype_book) : itemsbuf[itemid].power)*DAMAGE_MULTIPLIER;
         
         for(int i=(spins==1?up:dir); i<=(spins==1 ? right:dir); i++)
             if(dir!=(i^1))
-                Lwpns.add(new weapon((fix)wx,(fix)wy,(fix)wz,wMagic,type,pow,i, itemid,getUID()));
+	    {
+		weapon *magic = new weapon((fix)wx,(fix)wy,(fix)wz,wMagic,type,pow,i, itemid,getUID());
+		if(paybook)magic->miscellaneous[31] = bookid;
+                Lwpns.add(magic);
+	    }
                 
         paymagiccost(itemid);
         

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -3330,14 +3330,22 @@ bool weapon::animate(int)
         if((id==wRefMagic)&&(findentrance(x,y,mfREFMAGIC,true))) dead=0;
         
         if((id!=ewMagic)&&(findentrance(x,y,mfSTRIKE,true))) dead=0;
-        
-        if((id==wMagic && current_item(itype_book) &&
-                itemsbuf[parentitem>-1 ? parentitem : current_item_id(itype_book)].flags&ITEM_FLAG1) && get_bit(quest_rules,qr_INSTABURNFLAGS))
+	
+        if((id==wMagic && miscellaneous[31] && itemsbuf[miscellaneous[31]].family == itype_book &&
+                itemsbuf[miscellaneous[31]].flags&ITEM_FLAG1) && get_bit(quest_rules,qr_INSTABURNFLAGS))
         {
             findentrance(x,y,mfBCANDLE,true);
             findentrance(x,y,mfRCANDLE,true);
             findentrance(x,y,mfWANDFIRE,true);
         }
+	//Create an ER to use this in older quests -V
+	/*if((id==wMagic && current_item(itype_book) &&
+                itemsbuf[parentitem>-1 ? parentitem : current_item_id(itype_book)].flags&ITEM_FLAG1) && get_bit(quest_rules,qr_INSTABURNFLAGS))
+        {
+            findentrance(x,y,mfBCANDLE,true);
+            findentrance(x,y,mfRCANDLE,true);
+            findentrance(x,y,mfWANDFIRE,true);
+        }*/
         
 mirrors:
         int checkx=0, checky=0;
@@ -4181,11 +4189,18 @@ offscreenCheck:
     case wMagic:
         dead=1; //remove the dead part to make the wand only die when clipped
         
-        if(((id==wMagic && current_item(itype_book) &&
-                (itemsbuf[current_item_id(itype_book)].flags&ITEM_FLAG1))) && Lwpns.idCount(wFire)<2)
+	//Create an ER to sue this in older quests -V
+	/*if(((id==wMagic && current_item(itype_book) &&
+		(itemsbuf[current_item_id(itype_book)].flags&ITEM_FLAG1))) && Lwpns.idCount(wFire)<2)
         {
             Lwpns.add(new weapon(x,y,z,wFire,2,1*DAMAGE_MULTIPLIER,0,current_item_id(itype_book),-1));
-            sfx(WAV_FIRE,pan(x));
+            sfx(itemsbuf[miscellaneous[31]].usesound > 0 ? itemsbuf[miscellaneous[31]].usesound : WAV_FIRE,pan(x));
+        }*/
+        if(((id==wMagic && miscellaneous[31] && itemsbuf[miscellaneous[31]].family==itype_book &&
+                (itemsbuf[miscellaneous[31]].flags&ITEM_FLAG1))) && Lwpns.idCount(wFire)<2)
+        {
+            Lwpns.add(new weapon(x,y,z,wFire,2,1*DAMAGE_MULTIPLIER,0,miscellaneous[31],-1));
+            sfx(itemsbuf[miscellaneous[31]].usesound > 0 ? itemsbuf[miscellaneous[31]].usesound : WAV_FIRE,pan(x));
         }
         
         break;


### PR DESCRIPTION
Fire will now only be created if the book's cost was paid
The Wand Magic will now only be modified if the book's cost was paid
This needs an ER in two places in weapons.cpp, and once place in link.cpp