### PR TITLE
Fix: Missing case for BITMAPEXR

### DIFF
--- a/src/script_drawing.cpp
+++ b/src/script_drawing.cpp
@@ -3779,7 +3779,12 @@ void do_primitives(BITMAP *targetBitmap, int type, mapscr *, int xoff, int yoff)
             do_drawbitmapr(bmp, sdci, xoffset, yoffset);
         }
         break;
-	
+		
+		case BITMAPEXR:
+        {
+            do_drawbitmapexr(bmp, sdci, xoffset, yoffset);
+        }
+        break;
         
         case DRAWLAYERR:
         {


### PR DESCRIPTION
Changelog: Re-added case for BITMAPEXR that was lost in migration from DD Master. -Z