### PR TITLE
Feat: Increase Stack & Register Size to 1024, Begin Adding Sprite Scripts

### DIFF
--- a/src/ffasm.cpp
+++ b/src/ffasm.cpp
@@ -843,7 +843,7 @@ script_variable variable_list[]=
     { "NPCBOSSPAL",        NPCBOSSPAL,           0,             0 },
     { "NPCBGSFX",          NPCBGSFX,             0,             0 },
     { "NPCCOUNT",          NPCCOUNT,             0,             0 },
-    { "GD",                GD(0),              256,             0 },
+    { "GD",                GD(0),              1024,             0 },
     { "SDD",               SDD,                  0,             0 },
     { "GDD",               GDD,                  0,             0 },
     { "SDDD",              SDDD,                 0,             0 },

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -131,21 +131,21 @@ refInfo itemScriptData;
 //The stacks
 //This is where we need to change the formula. These stacks need to be variable in some manner
 //to permit adding additional scripts to them, without manually sizing them in advance. - Z
-long(*stack)[256] = NULL;
-long ffc_stack[32][256];
-long global_stack[256];
-long item_stack[256];
+long(*stack)[MAX_SCRIPT_REGISTERS] = NULL;
+long ffc_stack[32][MAX_SCRIPT_REGISTERS];
+long global_stack[MAX_SCRIPT_REGISTERS];
+long item_stack[MAX_SCRIPT_REGISTERS];
 long ffmisc[32][16];
 refInfo ffcScriptData[32];
 
 void clear_ffc_stack(const byte i)
 {
-    memset(ffc_stack[i], 0, 256 * sizeof(long));
+    memset(ffc_stack[i], 0, MAX_SCRIPT_REGISTERS * sizeof(long));
 }
 
 void clear_global_stack()
 {
-    memset(global_stack, 0, 256 * sizeof(long));
+    memset(global_stack, 0, MAX_SCRIPT_REGISTERS * sizeof(long));
 }
 
 //ScriptHelper
@@ -6027,7 +6027,7 @@ case AUDIOPAN:
     {
         if(arg >= D(0) && arg <= D(7))			ret = ri->d[arg - D(0)];
         else if(arg >= A(0) && arg <= A(1))		ret = ri->a[arg - A(0)];
-        else if(arg >= GD(0) && arg <= GD(255))	ret = game->global_d[arg - GD(0)];
+        else if(arg >= GD(0) && arg <= GD(MAX_SCRIPT_REGISTERS))	ret = game->global_d[arg - GD(0)];
         
         break;
     }
@@ -9466,7 +9466,7 @@ break;
         break;
     
     case DEBUGSP:
-        ri->sp = vbound((value / 10000),0,256);
+        ri->sp = vbound((value / 10000),0,MAX_SCRIPT_REGISTERS-1);
         break;
         
     case DEBUGREFFFC:
@@ -11303,7 +11303,7 @@ case AUDIOPAN:
     {
         if(arg >= D(0) && arg <= D(7))			ri->d[arg - D(0)] = value;
         else if(arg >= A(0) && arg <= A(1))		ri->a[arg - A(0)] = value;
-        else if(arg >= GD(0) && arg <= GD(255))	game->global_d[arg-GD(0)] = value;
+        else if(arg >= GD(0) && arg <= GD(MAX_SCRIPT_REGISTERS))	game->global_d[arg-GD(0)] = value;
         
         break;
     }
@@ -17090,12 +17090,12 @@ int FFScript::whichlayer(long scr)
 
 void FFScript::clear_ffc_stack(const byte i)
 {
-    memset(ffc_stack[i], 0, 256 * sizeof(long));
+    memset(ffc_stack[i], 0, MAX_SCRIPT_REGISTERS * sizeof(long));
 }
 
 void FFScript::clear_global_stack()
 {
-    memset(global_stack, 0, 256 * sizeof(long));
+    memset(global_stack, 0, MAX_SCRIPT_REGISTERS * sizeof(long));
 }
 
 void FFScript::do_zapout()

--- a/src/gamedata.cpp
+++ b/src/gamedata.cpp
@@ -63,7 +63,7 @@ void gamedata::Clear()
     
     for(int i=0; i<MAXDMAPS*MAPSCRSNORMAL; i++) std::fill(screen_d[i], screen_d[i]+8, 0);
     
-    std::fill(global_d, global_d+256, 0);
+    std::fill(global_d, global_d+MAX_SCRIPT_REGISTERS, 0);
     globalRAM.clear();
     awpn=0;
     bwpn=0;
@@ -139,7 +139,7 @@ void gamedata::Copy(const gamedata& g)
         for(byte j = 0; j < 8; j++)
             screen_d[i][j] = g.screen_d[i][j];
             
-    for(word i = 0; i < 256; i++)
+    for(word i = 0; i < MAX_SCRIPT_REGISTERS; i++)
         global_d[i] = g.global_d[i];
         
     awpn = g.awpn;

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -76,7 +76,7 @@ ScriptsData* ZScript::compile(string const& filename)
 		return NULL;
     
 	FunctionData fd(program);
-	if (fd.globalVariables.size() > 256)
+	if (fd.globalVariables.size() > MAX_SCRIPT_REGISTERS)
 	{
 		box_out_err(CompileError::TooManyGlobal(NULL));
 		return NULL;

--- a/src/parser/ZScript.h
+++ b/src/parser/ZScript.h
@@ -7,6 +7,8 @@
 #include "CompilerUtils.h"
 #include "Types.h"
 
+#define MAX_SCRIPT_REGISTERS 1024
+
 namespace ZScript
 {
 	class CompileErrorHandler;

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -50,6 +50,7 @@ sprite::sprite()
     drawstyle=0;
     extend=0;
     wpnsprite = 0; //wpnsprite is new for 2.6 -Z
+    memset(stack,0,sizeof(stack));
     
     /*ewpnclass=0;
     lwpnclass=0;
@@ -156,6 +157,11 @@ ewpnclass(other.ewpnclass)*/
     for(int i=0; i<32; i++) miscellaneous[i] = other.miscellaneous[i];
     
     scriptcoldet = other.scriptcoldet;
+    
+    for ( int q = 0; q < MAX_SCRIPT_REGISTERS; q++ )
+    {
+	stack[q] = other.stack[q];
+    }
 }
 
 sprite::sprite(fix X,fix Y,int T,int CS,int F,int Clk,int Yofs):

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -76,7 +76,7 @@ public:
     long miscellaneous[32];
     byte scriptcoldet;
     int wpnsprite; //wpnsprite is new for 2.6 -Z
-    //long stack[256];
+    long stack[MAX_SCRIPT_REGISTERS];
     //Are you kidding? Really? 256 * sizeof(long) = 2048 bytes = 2kb of wasted memory for every sprite, and it'll never
     //even get used because item scripts only run for one frame. Gah! Maybe when we have npc scripts, not not now...
     

--- a/src/title.cpp
+++ b/src/title.cpp
@@ -1568,14 +1568,27 @@ int readsaves(gamedata *savedata, PACKFILE *f)
                     }
                 }
             }
-            
-            for(int j=0; j<256; j++)
-            {
-                if(!p_igetl(&savedata[i].global_d[j],f,true))
-                {
-                    return 45;
-                }
-            }
+            if ( section_version >= 12 )
+	    {
+		    for(int j=0; j<MAX_SCRIPT_REGISTERS; j++)
+		    {
+			if(!p_igetl(&savedata[i].global_d[j],f,true))
+			{
+			    return 45;
+			}
+		    }
+	    }
+	    else
+	    {
+		for(int j=0; j<256; j++)
+		{
+			if(!p_igetl(&savedata[i].global_d[j],f,true))
+			{
+			    return 45;
+			}
+		}    
+		    
+	    }
         }
         
         if(section_version>2)
@@ -2049,7 +2062,7 @@ int writesaves(gamedata *savedata, PACKFILE *f)
             }
         }
         
-        for(int j=0; j<256; j++)
+        for(int j=0; j<MAX_SCRIPT_REGISTERS; j++)
         {
             if(!p_iputl(savedata[i].global_d[j],f))
             {

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -121,6 +121,9 @@
 
 #define MAX_INTERNAL_QUESTS 	5
 
+#define MAX_SCRIPT_REGISTERS 1024
+#define MAX_SCRIPT_REGISTERS_250 256
+
 enum {ENC_METHOD_192B104=0, ENC_METHOD_192B105, ENC_METHOD_192B185, ENC_METHOD_211B9, ENC_METHOD_211B18, ENC_METHOD_MAX};
 
 #ifdef ALLEGRO_DOS
@@ -191,7 +194,7 @@ enum {ENC_METHOD_192B104=0, ENC_METHOD_192B105, ENC_METHOD_192B185, ENC_METHOD_2
 #define V_GUYS            38
 #define V_MIDIS            4
 #define V_CHEATS           1
-#define V_SAVEGAME        11
+#define V_SAVEGAME        12
 #define V_COMBOALIASES     3
 #define V_LINKSPRITES      5
 #define V_SUBSCREEN        6
@@ -3037,7 +3040,7 @@ struct gamedata
     byte  icon[128];
     byte  pal[48];
     long  screen_d[MAXDMAPS*MAPSCRSNORMAL][8];                // script-controlled screen variables
-    long  global_d[256];                                      // script-controlled global variables
+    long  global_d[MAX_SCRIPT_REGISTERS];                                      // script-controlled global variables
     std::vector< ZCArray <long> > globalRAM;
     
     byte awpn, bwpn;											// Currently selected weapon slots


### PR DESCRIPTION
Changelog: Preparing for Large Stacks and Sprite Scripts
Increased max ZASM registers from 256 to 1024.
Increased stack sizes from 256 to 1024.
Increased global var cap to 1024. 
Added stacks to sprites.