### PR TITLE
Set Up Infinite Item Scripts and Prepare for ALL New Script Types

### DIFF
--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -131,9 +131,16 @@ refInfo itemScriptData;
 //The stacks
 //This is where we need to change the formula. These stacks need to be variable in some manner
 //to permit adding additional scripts to them, without manually sizing them in advance. - Z
+
+#define GLOBAL_STACK_MAIN 0
+#define GLOBAL_STACK_DMAP 1
+#define GLOBAL_STACK_SCREEN 2
+#define GLOBAL_STACK_LINK 3
+#define GLOBAL_STACK_MAX 4
+
 long(*stack)[MAX_SCRIPT_REGISTERS] = NULL;
 long ffc_stack[32][MAX_SCRIPT_REGISTERS];
-long global_stack[MAX_SCRIPT_REGISTERS];
+long global_stack[GLOBAL_STACK_MAX][MAX_SCRIPT_REGISTERS];
 long item_stack[MAX_SCRIPT_REGISTERS];
 long ffmisc[32][16];
 refInfo ffcScriptData[32];
@@ -145,7 +152,8 @@ void clear_ffc_stack(const byte i)
 
 void clear_global_stack()
 {
-    memset(global_stack, 0, MAX_SCRIPT_REGISTERS * sizeof(long));
+    //memset(global_stack, 0, MAX_SCRIPT_REGISTERS * sizeof(long));
+    memset(global_stack, 0, sizeof(global_stack));
 }
 
 //ScriptHelper
@@ -14669,9 +14677,43 @@ int run_script(const byte type, const word script, const byte i)
     case SCRIPT_GLOBAL:
     {
         ri = &globalScriptData;
+	    //needs to become ri = &(globalScriptData[global_slot]);
         
         curscript = globalscripts[script];
-        stack = &global_stack;
+        stack = &global_stack[GLOBAL_STACK_MAIN];
+	    //
+    }
+    break;
+    
+    case SCRIPT_LINK:
+    {
+        ri = &globalScriptData;
+	    //needs to become ri = &(globalScriptData[link_slot]);
+        
+        curscript = linkscripts[script];
+        stack = &global_stack[GLOBAL_STACK_LINK];
+	    //
+    }
+    break;
+    
+    case SCRIPT_SCREEN:
+    {
+        ri = &globalScriptData;
+        
+        curscript = screenscripts[script];
+	    //needs to become ri = &(globalScriptData[screen_slot]);
+        stack = &global_stack[GLOBAL_STACK_SCREEN];
+	    //
+    }
+    break;
+    
+    case SCRIPT_DMAP:
+    {
+        ri = &globalScriptData;
+	    //needs to become ri = &(globalScriptData[dmap_slot]);
+        
+        curscript = dmapscripts[script];
+        stack = &global_stack[GLOBAL_STACK_DMAP];
 	    //
     }
     break;

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -22,6 +22,8 @@ FFScript FFCore;
 zquestheader ZCheader;
 ZModule zcm;
 zcmodule moduledata;
+
+char runningItemScripts[256] = {0};
  
 //item *FFCore.temp_ff_item = NULL;
 //enemy *FFCore.temp_ff_enemy = NULL;
@@ -135,7 +137,7 @@ refInfo lweaponScriptData[256]; //should this be lweapon and eweapon, separate s
 refInfo eweaponScriptData[256]; //should this be lweapon and eweapon, separate stacks?
 refInfo itemactiveScriptData[256];
 
-char runningItemScripts[256] = {0};
+//char runningItemScripts[256] = {0};
 
 //The stacks
 //This is where we need to change the formula. These stacks need to be variable in some manner
@@ -14708,6 +14710,7 @@ int run_script(const byte type, const word script, const byte i)
         memcpy(ri->a, itemsbuf[i].initiala, 2 * sizeof(long));
         
         ri->idata = i; //'this' pointer
+	//FFCore.runningItemScripts[i] = 1;
 	runningItemScripts[i] = 1;
         
     }
@@ -16599,6 +16602,7 @@ case DMAPDATASETMUSICV: //command, string to load a music file
             break;
             
         case SCRIPT_ITEM:
+	    //FFCore.runningItemScripts[i] = 0;
 	    runningItemScripts[i] = 0;
             break; //item scripts aren't gonna go again anyway
         }
@@ -16639,22 +16643,6 @@ int ffscript_engine(const bool preload)
             
         ZScriptVersion::RunScript(SCRIPT_FFC, tmpscr->ffscript[i], i);
         tmpscr->initialized[i] = true;
-    }
-    Z_scripterrlog("Trying to check if an %s is running.\n","item script");
-    for ( byte i = 0; i < 256; i++ )
-    {
-	Z_scripterrlog("Checking item ID: %d\n",i);
-	if ( itemsbuf[i].script == 0 ) continue;
-	//if ( runningItemScripts[i] == 1 )
-	//{
-		Z_scripterrlog("Found a script running on item ID: %d\n",i);
-		//ZScriptVersion::RunScript(SCRIPT_ITEM, itemsbuf[i].script);
-		//ZScriptVersion::RunScript(SCRIPT_ITEM, itemsbuf[i].script, i);
-		Z_scripterrlog("Script Detected for that item is: %d\n",itemsbuf[i].script);
-		//if ( itemsbuf[items.spr(i)->id].script > 0 )
-			ZScriptVersion::RunScript(SCRIPT_ITEM, itemsbuf[i].script, i & 0xFFF);
-	//}
-	    
     }
     
     return 0;
@@ -18236,7 +18224,7 @@ void FFScript::init()
 	}
 	subscreen_scroll_speed = 0; //make a define for a default and read quest override! -Z
 	kb_typing_mode = false;
-	
+	//clearRunningItemScripts();
 }
 
 
@@ -18810,4 +18798,42 @@ void FFScript::do_warp_ex(bool v)
 		}
 		
 	}
+}
+
+
+
+void FFScript::clearRunningItemScripts()
+{
+	//for ( byte q = 0; q < 256; q++ ) runningItemScripts[q] = 0;
+}
+
+
+void FFScript::newScriptEngine()
+{
+	itemScriptEngine();
+	advanceframe(true);
+}
+
+void FFScript::itemScriptEngine()
+{
+	//Z_scripterrlog("Trying to check if an %s is running.\n","item script");
+	for ( int q = 0; q < 256; q++ )
+	{
+		//Z_scripterrlog("Checking item ID: %d\n",q);
+		if ( itemsbuf[q].script == 0 ) continue;
+		//if ( runningItemScripts[i] == 1 )
+		//{
+			//Z_scripterrlog("Found a script running on item ID: %d\n",q);
+			//ZScriptVersion::RunScript(SCRIPT_ITEM, itemsbuf[i].script);
+			//ZScriptVersion::RunScript(SCRIPT_ITEM, itemsbuf[i].script, i);
+			//Z_scripterrlog("Script Detected for that item is: %d\n",itemsbuf[q].script);
+			if ( runningItemScripts[q] )
+			{
+				ZScriptVersion::RunScript(SCRIPT_ITEM, itemsbuf[q].script, q & 0xFFF);
+			}
+		//}
+		    
+	}
+	
+	//return 0;
 }

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -16593,18 +16593,28 @@ case DMAPDATASETMUSICV: //command, string to load a music file
     {
         switch(type)
         {
-        case SCRIPT_FFC:
-            tmpscr->ffscript[i] = 0;
-            break;
-            
-        case SCRIPT_GLOBAL:
-            g_doscript = 0;
-            break;
-            
-        case SCRIPT_ITEM:
-	    //FFCore.runningItemScripts[i] = 0;
-	    runningItemScripts[i] = 0;
-            break; //item scripts aren't gonna go again anyway
+		case SCRIPT_FFC:
+		    tmpscr->ffscript[i] = 0;
+		    break;
+		    
+		case SCRIPT_GLOBAL:
+		    g_doscript = 0;
+		    break;
+		    
+		case SCRIPT_ITEM:
+		{
+		    //FFCore.runningItemScripts[i] = 0;
+		    runningItemScripts[i] = 0;
+		    //ri = &(itemScriptData[i]);
+		    //ri->Clear();
+		    curscript = 0;
+		    long(*pvsstack)[MAX_SCRIPT_REGISTERS] = stack;
+		    stack = &(item_stack[i]);
+		    memset(stack, 0, MAX_SCRIPT_REGISTERS * sizeof(long));
+		    stack = pvsstack;
+		    //stack = NULL;
+		    break; //item scripts aren't gonna go again anyway
+		}
         }
     }
     else
@@ -18827,9 +18837,16 @@ void FFScript::itemScriptEngine()
 			//ZScriptVersion::RunScript(SCRIPT_ITEM, itemsbuf[i].script);
 			//ZScriptVersion::RunScript(SCRIPT_ITEM, itemsbuf[i].script, i);
 			//Z_scripterrlog("Script Detected for that item is: %d\n",itemsbuf[q].script);
-			if ( runningItemScripts[q] )
+			if ( runningItemScripts[q] == 1 )
 			{
-				ZScriptVersion::RunScript(SCRIPT_ITEM, itemsbuf[q].script, q & 0xFFF);
+				if ( get_bit(quest_rules,qr_ITEMSCRIPTSKEEPRUNNING) )
+				{
+					ZScriptVersion::RunScript(SCRIPT_ITEM, itemsbuf[q].script, q & 0xFFF);
+				}
+				else //if the QR isn't set, treat Waitframe as Quit()
+				{
+					runningItemScripts[q] = 0;
+				}
 			}
 		//}
 		    

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -122,11 +122,18 @@ word curScriptNum;
 
 //Global script data
 refInfo globalScriptData;
+refInfo linkScriptData;
+refInfo screenScriptData;
+refInfo dmapScriptData;
 word g_doscript = 1;
 bool global_wait = false;
 
-//Item script data
+//Sprite script data
 refInfo itemScriptData;
+refInfo npcScriptData[256];
+refInfo lweaponScriptData[256]; //should this be lweapon and eweapon, separate stacks?
+refInfo eweaponScriptData[256]; //should this be lweapon and eweapon, separate stacks?
+refInfo itemactiveScriptData[256];
 
 //The stacks
 //This is where we need to change the formula. These stacks need to be variable in some manner
@@ -14648,6 +14655,33 @@ int run_script(const byte type, const word script, const byte i)
     }
     break;
     
+    case SCRIPT_NPC:
+    {
+		ri = &(npcScriptData[i]);
+		curscript = guyscripts[script];
+		stack = &(guys.spr(GuyH::getNPCIndex(ri->guyref))->stack);
+		ri->guyref = i; //'this' pointer
+    }
+    break;
+    
+    case SCRIPT_LWPN:
+    {
+		ri = &(lweaponScriptData[i]);
+		curscript = lwpnscripts[script];
+		stack = &(Lwpns.spr(LwpnH::getLWeaponIndex(ri->lwpn))->stack);
+		ri->lwpn = i; //'this' pointer
+    }
+    break;
+    
+    case SCRIPT_EWPN:
+    {
+		ri = &(eweaponScriptData[i]);
+		curscript = ewpnscripts[script];
+		stack = &(Ewpns.spr(EwpnH::getEWeaponIndex(ri->ewpn))->stack);
+		ri->ewpn = i; //'this' pointer
+    }
+    break;
+	    
     case SCRIPT_ITEM:
     {
         ri = &itemScriptData;
@@ -14677,7 +14711,7 @@ int run_script(const byte type, const word script, const byte i)
     case SCRIPT_GLOBAL:
     {
         ri = &globalScriptData;
-	    //needs to become ri = &(globalScriptData[global_slot]);
+	    //should this become ri = &(globalScriptData[global_slot]);
         
         curscript = globalscripts[script];
         stack = &global_stack[GLOBAL_STACK_MAIN];
@@ -14687,8 +14721,8 @@ int run_script(const byte type, const word script, const byte i)
     
     case SCRIPT_LINK:
     {
-        ri = &globalScriptData;
-	    //needs to become ri = &(globalScriptData[link_slot]);
+        ri = &linkScriptData;
+	    //should this become ri = &(globalScriptData[link_slot]);
         
         curscript = linkscripts[script];
         stack = &global_stack[GLOBAL_STACK_LINK];
@@ -14698,10 +14732,10 @@ int run_script(const byte type, const word script, const byte i)
     
     case SCRIPT_SCREEN:
     {
-        ri = &globalScriptData;
+        ri = &screenScriptData;
         
         curscript = screenscripts[script];
-	    //needs to become ri = &(globalScriptData[screen_slot]);
+	    //should this become ri = &(globalScriptData[screen_slot]);
         stack = &global_stack[GLOBAL_STACK_SCREEN];
 	    //
     }
@@ -14709,8 +14743,8 @@ int run_script(const byte type, const word script, const byte i)
     
     case SCRIPT_DMAP:
     {
-        ri = &globalScriptData;
-	    //needs to become ri = &(globalScriptData[dmap_slot]);
+        ri = &dmapScriptData;
+	    //should this become ri = &(globalScriptData[dmap_slot]);
         
         curscript = dmapscripts[script];
         stack = &global_stack[GLOBAL_STACK_DMAP];

--- a/src/ffscript.h
+++ b/src/ffscript.h
@@ -96,6 +96,8 @@ struct script_bitmaps
 //Module System.
 //Putting this here for now.
 
+//char runningItemScripts[256];
+
 class ZModule
 {
 	public:
@@ -125,6 +127,11 @@ int getLinkAction();
 void Play_Level_Music();
 
 long getQuestHeaderInfo(int type);
+
+
+void clearRunningItemScripts();
+void itemScriptEngine();
+void newScriptEngine();
 
 /*
 long getQuestHeaderInfo(int type)

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -8489,7 +8489,8 @@ int setupsubscreens()
 extern ffscript *ffscripts[NUMSCRIPTFFC];
 extern ffscript *itemscripts[NUMSCRIPTITEM];
 extern ffscript *guyscripts[NUMSCRIPTGUYS];
-extern ffscript *wpnscripts[NUMSCRIPTWEAPONS];
+extern ffscript *lwpnscripts[NUMSCRIPTWEAPONS];
+extern ffscript *ewpnscripts[NUMSCRIPTWEAPONS];
 extern ffscript *globalscripts[NUMSCRIPTGLOBAL];
 extern ffscript *linkscripts[NUMSCRIPTLINK];
 extern ffscript *screenscripts[NUMSCRIPTSCREEN];
@@ -8552,11 +8553,18 @@ int readffscript(PACKFILE *f, zquestheader *Header, bool keepdata)
         
         for(int i = 0; i < NUMSCRIPTWEAPONS; i++)
         {
-            ret = read_one_ffscript(f, Header, keepdata, i, s_version, s_cversion, &wpnscripts[i]);
+            ret = read_one_ffscript(f, Header, keepdata, i, s_version, s_cversion, &lwpnscripts[i]);
             
             if(ret != 0) return qe_invalid;
         }
-        
+	/*
+	for(int i = 0; i < NUMSCRIPTWEAPONS; i++)
+        {
+            ret = read_one_ffscript(f, Header, keepdata, i, s_version, s_cversion, &ewpnscripts[i]);
+            
+            if(ret != 0) return qe_invalid;
+        }
+        */
         for(int i = 0; i < NUMSCRIPTSCREEN; i++)
         {
             ret = read_one_ffscript(f, Header, keepdata, i, s_version, s_cversion, &screenscripts[i]);
@@ -8722,7 +8730,12 @@ void reset_scripts()
     
     for(int i=0; i<NUMSCRIPTWEAPONS; i++)
     {
-        if(wpnscripts[i]!=NULL) delete [] wpnscripts[i];
+        if(lwpnscripts[i]!=NULL) delete [] lwpnscripts[i];
+    }
+    
+    for(int i=0; i<NUMSCRIPTWEAPONS; i++)
+    {
+        if(ewpnscripts[i]!=NULL) delete [] ewpnscripts[i];
     }
     
     for(int i=0; i<NUMSCRIPTSCREEN; i++)
@@ -8761,8 +8774,14 @@ void reset_scripts()
     
     for(int i=0; i<NUMSCRIPTWEAPONS; i++)
     {
-        wpnscripts[i] = new ffscript[1];
-        wpnscripts[i][0].command = 0xFFFF;
+        lwpnscripts[i] = new ffscript[1];
+        lwpnscripts[i][0].command = 0xFFFF;
+    }
+    
+    for(int i=0; i<NUMSCRIPTWEAPONS; i++)
+    {
+        ewpnscripts[i] = new ffscript[1];
+        ewpnscripts[i][0].command = 0xFFFF;
     }
     
     for(int i=0; i<NUMSCRIPTSCREEN; i++)

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -8486,13 +8486,14 @@ int setupsubscreens()
     return 0;
 }
 
-extern ffscript *ffscripts[512];
-extern ffscript *itemscripts[256];
-extern ffscript *guyscripts[256];
-extern ffscript *wpnscripts[256];
+extern ffscript *ffscripts[NUMSCRIPTFFC];
+extern ffscript *itemscripts[NUMSCRIPTITEM];
+extern ffscript *guyscripts[NUMSCRIPTGUYS];
+extern ffscript *wpnscripts[NUMSCRIPTWEAPONS];
 extern ffscript *globalscripts[NUMSCRIPTGLOBAL];
-extern ffscript *linkscripts[3];
-extern ffscript *screenscripts[256];
+extern ffscript *linkscripts[NUMSCRIPTLINK];
+extern ffscript *screenscripts[NUMSCRIPTSCREEN];
+extern ffscript *dmapscripts[NUMSCRIPTSDMAP];
 
 int readffscript(PACKFILE *f, zquestheader *Header, bool keepdata)
 {
@@ -8562,7 +8563,14 @@ int readffscript(PACKFILE *f, zquestheader *Header, bool keepdata)
             
             if(ret != 0) return qe_invalid;
         }
-        
+	/*
+	for(int i = 0; i < NUMSCRIPTSDMAP; i++)
+        {
+            ret = read_one_ffscript(f, Header, keepdata, i, s_version, s_cversion, &dmapscripts[i]);
+            
+            if(ret != 0) return qe_invalid;
+        }
+        */
         if(s_version > 4)
         {
             for(int i = 0; i < NUMSCRIPTGLOBAL; i++)

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -2100,6 +2100,7 @@ struct ffscript
 #define SCRIPT_NPC             6
 #define SCRIPT_SUBSCREEN       7
 #define SCRIPT_EWPN            8
+#define SCRIPT_DMAP            9
 
 
 enum
@@ -3872,6 +3873,7 @@ extern void removeFromItemCache(int itemid);
 #define NUMSCRIPTGLOBALOLD	3
 #define NUMSCRIPTLINK		3
 #define NUMSCRIPTSCREEN		256
+#define NUMSCRIPTSDMAP		256
 
 #define GLOBAL_SCRIPT_INIT 		0
 #define GLOBAL_SCRIPT_GAME		1

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -835,7 +835,7 @@ enum
     qr_BROKENBOOKCOST,
     qr_OLDSIDEVIEWSPIKES,
 	qr_OLDINFMAGIC/* Compatibility */, //Infinite magic prevents items from draining rupees
-	qr_NEVERDISABLEAMMOONSUBSCREEN,
+	qr_NEVERDISABLEAMMOONSUBSCREEN, qr_ITEMSCRIPTSKEEPRUNNING,
     qr_MAX
 };
 

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -377,6 +377,7 @@ ffscript *guyscripts[NUMSCRIPTGUYS];
 ffscript *wpnscripts[NUMSCRIPTWEAPONS];
 ffscript *linkscripts[NUMSCRIPTLINK];
 ffscript *screenscripts[NUMSCRIPTSCREEN];
+ffscript *dmapscripts[NUMSCRIPTSDMAP];
 
 extern refInfo globalScriptData;
 extern word g_doscript;
@@ -4101,31 +4102,31 @@ int main(int argc, char* argv[])
         guy_string[i] = new char[64];
     }
     
-    for(int i=0; i<512; i++)
+    for(int i=0; i<NUMSCRIPTFFC; i++)
     {
         ffscripts[i] = new ffscript[1];
         ffscripts[i][0].command = 0xFFFF;
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTITEM; i++)
     {
         itemscripts[i] = new ffscript[1];
         itemscripts[i][0].command = 0xFFFF;
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTGUYS; i++)
     {
         guyscripts[i] = new ffscript[1];
         guyscripts[i][0].command = 0xFFFF;
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTWEAPONS; i++)
     {
         wpnscripts[i] = new ffscript[1];
         wpnscripts[i][0].command = 0xFFFF;
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTSCREEN; i++)
     {
         screenscripts[i] = new ffscript[1];
         screenscripts[i][0].command = 0xFFFF;
@@ -4137,10 +4138,16 @@ int main(int argc, char* argv[])
         globalscripts[i][0].command = 0xFFFF;
     }
     
-    for(int i=0; i<3; i++)
+    for(int i=0; i<NUMSCRIPTLINK; i++)
     {
         linkscripts[i] = new ffscript[1];
         linkscripts[i][0].command = 0xFFFF;
+    }
+    
+    for(int i=0; i<NUMSCRIPTSDMAP; i++)
+    {
+        dmapscripts[i] = new ffscript[1];
+        dmapscripts[i][0].command = 0xFFFF;
     }
     
     //script drawing bitmap allocation

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -53,6 +53,7 @@
 extern FFScript FFCore; //the core script engine.
 extern ZModule zcm; //modules
 extern zcmodule moduledata;
+extern char runningItemScripts[256];
 #include "init.h"
 #include <assert.h>
 #include "zc_array.h"
@@ -2765,6 +2766,7 @@ void game_loop()
 	al_trace("game_loop is calling: %s\n", "items.animate()\n");
 	#endif
         items.animate();
+	
 	#if LOGGAMELOOP > 0
 	al_trace("game_loop is calling: %s\n", "items.check_conveyor()\n");
 	#endif
@@ -2865,6 +2867,8 @@ void game_loop()
         ZScriptVersion::RunScript(SCRIPT_GLOBAL, GLOBAL_SCRIPT_GAME);
         global_wait=false;
     }
+    
+    
     
     #if LOGGAMELOOP > 0
 	al_trace("game_loop is calling: %s\n", "draw_screen()\n");
@@ -4432,7 +4436,9 @@ int main(int argc, char* argv[])
             
 #endif
             game_loop();
-            advanceframe(true);
+	    //Perpetual item Script:
+	    FFCore.newScriptEngine();
+            
 		
 	     //clear Link's last hits 
 	     //for ( int q = 0; q < 4; q++ ) Link.sethitLinkUID(q, 0); //clearing this here makes it impossible 

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -374,12 +374,16 @@ ffscript *globalscripts[NUMSCRIPTGLOBAL];
 
 //If only...
 ffscript *guyscripts[NUMSCRIPTGUYS];
-ffscript *wpnscripts[NUMSCRIPTWEAPONS];
+ffscript *lwpnscripts[NUMSCRIPTWEAPONS];
+ffscript *ewpnscripts[NUMSCRIPTWEAPONS];
 ffscript *linkscripts[NUMSCRIPTLINK];
 ffscript *screenscripts[NUMSCRIPTSCREEN];
 ffscript *dmapscripts[NUMSCRIPTSDMAP];
 
 extern refInfo globalScriptData;
+extern refInfo linkScriptData;
+extern refInfo screenScriptData;
+extern refInfo dmapScriptData;
 extern word g_doscript;
 extern bool global_wait;
 
@@ -4122,8 +4126,13 @@ int main(int argc, char* argv[])
     
     for(int i=0; i<NUMSCRIPTWEAPONS; i++)
     {
-        wpnscripts[i] = new ffscript[1];
-        wpnscripts[i][0].command = 0xFFFF;
+        ewpnscripts[i] = new ffscript[1];
+        ewpnscripts[i][0].command = 0xFFFF;
+    }
+    for(int i=0; i<NUMSCRIPTWEAPONS; i++)
+    {
+        lwpnscripts[i] = new ffscript[1];
+        lwpnscripts[i][0].command = 0xFFFF;
     }
     
     for(int i=0; i<NUMSCRIPTSCREEN; i++)
@@ -4665,39 +4674,48 @@ void quit_game()
     
     al_trace("Script buffers... \n");
     
-    for(int i=0; i<512; i++)
+    for(int i=0; i<NUMSCRIPTFFC; i++)
     {
         if(ffscripts[i]!=NULL) delete [] ffscripts[i];
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTITEM; i++)
     {
         if(itemscripts[i]!=NULL) delete [] itemscripts[i];
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTGUYS; i++)
     {
         if(guyscripts[i]!=NULL) delete [] guyscripts[i];
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTWEAPONS; i++)
     {
-        if(wpnscripts[i]!=NULL) delete [] wpnscripts[i];
+        if(ewpnscripts[i]!=NULL) delete [] ewpnscripts[i];
+    }
+    for(int i=0; i<NUMSCRIPTWEAPONS; i++)
+    {
+        if(lwpnscripts[i]!=NULL) delete [] lwpnscripts[i];
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTSCREEN; i++)
     {
         if(screenscripts[i]!=NULL) delete [] screenscripts[i];
     }
+    
     
     for(int i=0; i<NUMSCRIPTGLOBAL; i++)
     {
         if(globalscripts[i]!=NULL) delete [] globalscripts[i];
     }
     
-    for(int i=0; i<3; i++)
+    for(int i=0; i<NUMSCRIPTLINK; i++)
     {
         if(linkscripts[i]!=NULL) delete [] linkscripts[i];
+    }
+    for(int i=0; i<NUMSCRIPTSDMAP; i++)
+    {
+        if(dmapscripts[i]!=NULL) delete [] dmapscripts[i];
     }
     
     delete zscriptDrawingRenderTarget;

--- a/src/zelda.h
+++ b/src/zelda.h
@@ -408,7 +408,8 @@ extern ffscript *itemscripts[NUMSCRIPTITEM];
 extern ffscript *globalscripts[NUMSCRIPTGLOBAL];
 
 extern ffscript *guyscripts[NUMSCRIPTGUYS];
-extern ffscript *wpnscripts[NUMSCRIPTWEAPONS];
+extern ffscript *lwpnscripts[NUMSCRIPTWEAPONS];
+extern ffscript *ewpnscripts[NUMSCRIPTWEAPONS];
 extern ffscript *linkscripts[NUMSCRIPTLINK];
 extern ffscript *screenscripts[NUMSCRIPTSCREEN];
 extern ffscript *dmapscripts[NUMSCRIPTSDMAP];

--- a/src/zelda.h
+++ b/src/zelda.h
@@ -403,14 +403,15 @@ extern mapscr tmpscr[2];
 extern mapscr tmpscr2[6];
 extern mapscr tmpscr3[6];
 extern char   sig_str[44];
-extern ffscript *ffscripts[512];
-extern ffscript *itemscripts[256];
+extern ffscript *ffscripts[NUMSCRIPTFFC];
+extern ffscript *itemscripts[NUMSCRIPTITEM];
 extern ffscript *globalscripts[NUMSCRIPTGLOBAL];
 
-extern ffscript *guyscripts[256];
-extern ffscript *wpnscripts[256];
-extern ffscript *linkscripts[3];
-extern ffscript *screenscripts[256];
+extern ffscript *guyscripts[NUMSCRIPTGUYS];
+extern ffscript *wpnscripts[NUMSCRIPTWEAPONS];
+extern ffscript *linkscripts[NUMSCRIPTLINK];
+extern ffscript *screenscripts[NUMSCRIPTSCREEN];
+extern ffscript *dmapscripts[NUMSCRIPTSDMAP];
 extern SAMPLE customsfxdata[WAV_COUNT];
 extern int sfxdat;
 

--- a/src/zq_class.cpp
+++ b/src/zq_class.cpp
@@ -10384,13 +10384,14 @@ int write_one_subscreen(PACKFILE *f, zquestheader *Header, int i)
     new_return(0);
 }
 
-extern ffscript *ffscripts[512];
-extern ffscript *itemscripts[256];
-extern ffscript *guyscripts[256];
-extern ffscript *wpnscripts[256];
+extern ffscript *ffscripts[NUMSCRIPTFFC];
+extern ffscript *itemscripts[NUMSCRIPTITEM];
+extern ffscript *guyscripts[NUMSCRIPTGUYS];
+extern ffscript *wpnscripts[NUMSCRIPTWEAPONS];
 extern ffscript *globalscripts[NUMSCRIPTGLOBAL];
-extern ffscript *linkscripts[3];
-extern ffscript *screenscripts[256];
+extern ffscript *linkscripts[NUMSCRIPTLINK];
+extern ffscript *screenscripts[NUMSCRIPTSCREEN];
+extern ffscript *dmapscripts[NUMSCRIPTSDMAP];
 
 int writeffscript(PACKFILE *f, zquestheader *Header)
 {

--- a/src/zq_class.cpp
+++ b/src/zq_class.cpp
@@ -10387,7 +10387,8 @@ int write_one_subscreen(PACKFILE *f, zquestheader *Header, int i)
 extern ffscript *ffscripts[NUMSCRIPTFFC];
 extern ffscript *itemscripts[NUMSCRIPTITEM];
 extern ffscript *guyscripts[NUMSCRIPTGUYS];
-extern ffscript *wpnscripts[NUMSCRIPTWEAPONS];
+extern ffscript *lwpnscripts[NUMSCRIPTWEAPONS];
+extern ffscript *ewpnscripts[NUMSCRIPTWEAPONS];
 extern ffscript *globalscripts[NUMSCRIPTGLOBAL];
 extern ffscript *linkscripts[NUMSCRIPTLINK];
 extern ffscript *screenscripts[NUMSCRIPTSCREEN];
@@ -10431,7 +10432,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
         
         writesize=0;
         
-        for(int i=0; i<512; i++)
+        for(int i=0; i<NUMSCRIPTFFC; i++)
         {
             int ret = write_one_ffscript(f, Header, i, &ffscripts[i]);
             fake_pack_writing=(writecycle==0);
@@ -10442,7 +10443,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
             }
         }
         
-        for(int i=0; i<256; i++)
+        for(int i=0; i<NUMSCRIPTITEM; i++)
         {
             int ret = write_one_ffscript(f, Header, i, &itemscripts[i]);
             fake_pack_writing=(writecycle==0);
@@ -10453,7 +10454,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
             }
         }
         
-        for(int i=0; i<256; i++)
+        for(int i=0; i<NUMSCRIPTGUYS; i++)
         {
             int ret = write_one_ffscript(f, Header, i, &guyscripts[i]);
             fake_pack_writing=(writecycle==0);
@@ -10464,9 +10465,9 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
             }
         }
         
-        for(int i=0; i<256; i++)
+        for(int i=0; i<NUMSCRIPTWEAPONS; i++)
         {
-            int ret = write_one_ffscript(f, Header, i, &wpnscripts[i]);
+            int ret = write_one_ffscript(f, Header, i, &lwpnscripts[i]);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -10474,8 +10475,19 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
                 new_return(ret);
             }
         }
-        
-        for(int i=0; i<256; i++)
+	/*
+	for(int i=0; i<NUMSCRIPTWEAPONS; i++)
+        {
+            int ret = write_one_ffscript(f, Header, i, &lwpnscripts[i]);
+            fake_pack_writing=(writecycle==0);
+            
+            if(ret!=0)
+            {
+                new_return(ret);
+            }
+        }
+        */
+        for(int i=0; i<NUMSCRIPTSCREEN; i++)
         {
             int ret = write_one_ffscript(f, Header, i, &screenscripts[i]);
             fake_pack_writing=(writecycle==0);
@@ -10497,7 +10509,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
             }
         }
         
-        for(int i=0; i<3; i++)
+        for(int i=0; i<NUMSCRIPTLINK; i++)
         {
             int ret = write_one_ffscript(f, Header, i, &linkscripts[i]);
             fake_pack_writing=(writecycle==0);
@@ -10507,7 +10519,18 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
                 new_return(ret);
             }
         }
-        
+	/*
+	for(int i=0; i<NUMSCRIPTSDMAP; i++)
+        {
+            int ret = write_one_ffscript(f, Header, i, &dmapscripts[i]);
+            fake_pack_writing=(writecycle==0);
+            
+            if(ret!=0)
+            {
+                new_return(ret);
+            }
+        }
+        */
         if(!p_iputl((long)zScript.size(), f))
         {
             new_return(2001);

--- a/src/zq_misc.cpp
+++ b/src/zq_misc.cpp
@@ -1205,6 +1205,7 @@ int onHeader();
 int onAnimationRules();
 int onComboRules();
 int onItemRules();
+int onScriptRules();
 int onEnemyRules();
 int onFixesRules();
 int onMiscRules();

--- a/src/zq_misc.h
+++ b/src/zq_misc.h
@@ -206,6 +206,7 @@ int onHeader();
 int onAnimationRules();
 int onComboRules();
 int onItemRules();
+int onScriptRules();
 int onEnemyRules();
 int onFixesRules();
 int onMiscRules();

--- a/src/zq_rules.cpp
+++ b/src/zq_rules.cpp
@@ -636,6 +636,58 @@ int onCompatRules()
     return D_O_K;
 }
 
+static DIALOG scriptrules_dlg[] =
+{
+    /* (dialog proc)       (x)    (y)   (w)   (h)     (fg)      (bg)     (key)      (flags)     (d1)           (d2)     (dp) */
+    { jwin_win_proc,         0,   0,    300,  235,    vc(14),   vc(1),      0,      D_EXIT,     0,             0, (void *) "Quest Rules - Items", NULL, NULL },
+    { d_timer_proc,          0,    0,     0,    0,    0,        0,          0,      0,          0,             0,       NULL, NULL, NULL },
+    { d_dummy_proc,         5,   23,   290,  181,    vc(14),   vc(1),      0,      0,          1,             0, NULL, NULL, (void *)scriptrules_dlg },
+    // 3
+    { jwin_button_proc,    170,  210,    61,   21,    vc(14),   vc(1),     27,      D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
+    { jwin_button_proc,     90,  210,    61,   21,    vc(14),   vc(1),     13,      D_EXIT,     0,             0, (void *) "OK", NULL, NULL },
+    { d_keyboard_proc,       0,    0,     0,    0,         0,       0,      0,      0,          KEY_F1,        0, (void *) onHelp, NULL, NULL },
+    
+    // rules //6
+    { jwin_check_proc,      10, 21+10,  185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "Item Scripts Continue To Run", NULL, NULL },
+    
+    
+    { NULL,                  0,    0,     0,    0,    0,        0,          0,      0,          0,             0,       NULL, NULL, NULL }
+};
+
+
+static int scriptrules[] =
+{
+    qr_ITEMSCRIPTSKEEPRUNNING,
+    -1
+};
+
+int onScriptRules()
+{
+    if(is_large)
+        large_dialog(scriptrules_dlg);
+        
+    scriptrules_dlg[0].dp2=lfont;
+    
+    for(int i=0; scriptrules[i]!=-1; i++)
+    {
+        scriptrules_dlg[i+6].flags = get_bit(quest_rules,scriptrules[i]) ? D_SELECTED : 0;
+    }
+    
+    int ret = zc_popup_dialog(scriptrules_dlg,4);
+    
+    if(ret==4)
+    {
+        saved=false;
+        
+        for(int i=0; scriptrules[i]!=-1; i++)
+        {
+            set_bit(quest_rules, scriptrules[i], scriptrules_dlg[i+6].flags & D_SELECTED);
+        }
+    }
+    
+    return D_O_K;
+}
+
 void center_zq_rules_dialog()
 {
     jwin_center_dialog(animationrules_dlg);
@@ -645,5 +697,6 @@ void center_zq_rules_dialog()
     jwin_center_dialog(fixesrules_dlg);
     jwin_center_dialog(miscrules_dlg);
     jwin_center_dialog(compatrules_dlg);
+    jwin_center_dialog(scriptrules_dlg);
 }
 

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -665,6 +665,7 @@ static MENU rules_menu[] =
     { (char *)"&NES Fixes ",                onFixesRules,              NULL,                     0,            NULL   },
     { (char *)"&Other",                     onMiscRules,               NULL,                     0,            NULL   },
     { (char *)"&Backward compatibility",    onCompatRules,             NULL,                     0,            NULL   },
+    { (char *)"&Scripts",    		    onScriptRules,             NULL,                     0,            NULL   },
     {  NULL,                                NULL,                      NULL,                     0,            NULL   }
 };
 
@@ -24379,6 +24380,7 @@ command_pair commands[cmdMAX]=
     { "Report: Integrity Check",              0, (intF) onIntegrityCheckAll                                    },
     { "Save ZQuest Settings",              0, (intF) onSaveZQuestSettings                                    },
     { "Clear Quest Filepath",              0, (intF) onClearQuestFilepath                                    },
+    { "Script Rules",              0, (intF) onScriptRules                                   },
     
 
 };

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -303,7 +303,8 @@ BITMAP *hw_screen, *scrtmp;
 ffscript *ffscripts[NUMSCRIPTFFC];
 ffscript *itemscripts[NUMSCRIPTITEM];
 ffscript *guyscripts[NUMSCRIPTGUYS];
-ffscript *wpnscripts[NUMSCRIPTWEAPONS];
+ffscript *lwpnscripts[NUMSCRIPTWEAPONS];
+ffscript *ewpnscripts[NUMSCRIPTWEAPONS];
 ffscript *globalscripts[NUMSCRIPTGLOBAL];
 ffscript *linkscripts[NUMSCRIPTLINK];
 ffscript *screenscripts[NUMSCRIPTSCREEN];
@@ -22793,46 +22794,58 @@ int main(int argc,char **argv)
         memset(guy_string[i], 0, 64);
     }
     
-    for(int i=0; i<512; i++)
+    for(int i=0; i<NUMSCRIPTFFC; i++)
     {
         ffscripts[i] = new ffscript[1];
         ffscripts[i][0].command = 0xFFFF;
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTITEM; i++)
     {
         itemscripts[i] = new ffscript[1];
         itemscripts[i][0].command = 0xFFFF;
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTGUYS; i++)
     {
         guyscripts[i] = new ffscript[1];
         guyscripts[i][0].command = 0xFFFF;
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTWEAPONS; i++)
     {
-        wpnscripts[i] = new ffscript[1];
-        wpnscripts[i][0].command = 0xFFFF;
+        lwpnscripts[i] = new ffscript[1];
+        lwpnscripts[i][0].command = 0xFFFF;
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTWEAPONS; i++)
+    {
+        ewpnscripts[i] = new ffscript[1];
+        ewpnscripts[i][0].command = 0xFFFF;
+    }
+    
+    for(int i=0; i<NUMSCRIPTSCREEN; i++)
     {
         screenscripts[i] = new ffscript[1];
         screenscripts[i][0].command = 0xFFFF;
     }
     
-    for(int i=0; i<3; i++)
+    for(int i=0; i<3; i++) //should this be NUMSCRIPTGLOBAL or NUMSCRIPTGLOBALOLD? -Z
     {
         globalscripts[i] = new ffscript[1];
         globalscripts[i][0].command = 0xFFFF;
     }
     
-    for(int i=0; i<3; i++)
+    for(int i=0; i<NUMSCRIPTLINK; i++)
     {
         linkscripts[i] = new ffscript[1];
         linkscripts[i][0].command = 0xFFFF;
+    }
+    
+    for(int i=0; i<NUMSCRIPTSDMAP; i++)
+    {
+        dmapscripts[i] = new ffscript[1];
+        dmapscripts[i][0].command = 0xFFFF;
     }
     
     zScript = std::string();
@@ -23286,39 +23299,49 @@ void quit_game()
     
     al_trace("Cleaning script buffer. \n");
     
-    for(int i=0; i<512; i++)
+    for(int i=0; i<NUMSCRIPTFFC; i++)
     {
         if(ffscripts[i]!=NULL) delete [] ffscripts[i];
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTITEM; i++)
     {
         if(itemscripts[i]!=NULL) delete [] itemscripts[i];
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTGUYS; i++)
     {
         if(guyscripts[i]!=NULL) delete [] guyscripts[i];
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTWEAPONS; i++)
     {
-        if(wpnscripts[i]!=NULL) delete [] wpnscripts[i];
+        if(lwpnscripts[i]!=NULL) delete [] lwpnscripts[i];
     }
     
-    for(int i=0; i<256; i++)
+    for(int i=0; i<NUMSCRIPTWEAPONS; i++)
+    {
+        if(ewpnscripts[i]!=NULL) delete [] ewpnscripts[i];
+    }
+    
+    for(int i=0; i<NUMSCRIPTSCREEN; i++)
     {
         if(screenscripts[i]!=NULL) delete [] screenscripts[i];
     }
     
-    for(int i=0; i<3; i++)
+    for(int i=0; i<3; i++) //should this be NUMSCRIPTGLOBAL or NUMSCRIPTGLOBALOLD? -Z
     {
         if(globalscripts[i]!=NULL) delete [] globalscripts[i];
     }
     
-    for(int i=0; i<3; i++)
+    for(int i=0; i<NUMSCRIPTLINK; i++)
     {
         if(linkscripts[i]!=NULL) delete [] linkscripts[i];
+    }
+    
+    for(int i=0; i<NUMSCRIPTSDMAP; i++)
+    {
+        if(dmapscripts[i]!=NULL) delete [] dmapscripts[i];
     }
     
     al_trace("Cleaning qst buffers. \n");

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -307,6 +307,7 @@ ffscript *wpnscripts[NUMSCRIPTWEAPONS];
 ffscript *globalscripts[NUMSCRIPTGLOBAL];
 ffscript *linkscripts[NUMSCRIPTLINK];
 ffscript *screenscripts[NUMSCRIPTSCREEN];
+ffscript *dmapscripts[NUMSCRIPTSDMAP];
 
 // Dummy - needed to compile, but unused
 refInfo ffcScriptData[32];

--- a/src/zquest.h
+++ b/src/zquest.h
@@ -675,6 +675,7 @@ enum
     cmdIntegrityCheck,
     cmdSaveZQuestSettings,
     cmdOnClearQuestFilepath,
+    cmdOnScriptRules,
     cmdMAX
 };
 
@@ -990,6 +991,7 @@ int RulesPage_10();
 int onAnimationRules();
 int onComboRules();
 int onItemRules();
+int onScriptRules();
 int onEnemyRules();
 int onFixesRules();
 int onMiscRules();


### PR DESCRIPTION

Changelog

I refactored item scripts so that they can run for more than one frame. 
This behaviour is enabled only if the QR 'Item Scripts Continue to Run' is enabled in Quest->Rules->Scripts.

To accomplish this, I added a stack per item (Link's inventory). Then, I added control code under FFCore.newScriptEngine() and FFCore.itemScriptEngine(), called in main() in zelda.cpp.

I moved the advance_frame(true) call in main() inside the FFCore.newScriptEngine() function, to prevent the game from running that loop perpetually, which happened if it was in the game_loop. I need to determine how best to call it without setting up an infinite condition, later.

If the QR is on, then item scripts that have an infinite loop will set the new var, `runningItemScripts[id] = 1`.

If that var == 1, then the item script will continue to run, every frame.

If the script is quit, then quitting it sets `runningItemScript[id] = 0`. 

If the QR is off, then an item script will set `runningItemScripts[id] = 0` as soon as it reaches the end of its scope (or a call to Waitframe), as per normal 2.50 behaviour.

The system may have timing issues at present, but it does work.

Once we work out the timing issues, then we can add all other new script types int he same manner.

We can probably add some kind of callbacks (e.g. Waitdraw) in the process of timing the new system.
