### PR TITLE
Add New Script Types to Parser

### DIFF
--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -18852,13 +18852,14 @@ void FFScript::clearRunningItemScripts()
 }
 
 
-void FFScript::newScriptEngine()
+bool FFScript::newScriptEngine()
 {
 	itemScriptEngine();
 	advanceframe(true);
+	return false;
 }
 
-void FFScript::itemScriptEngine()
+bool FFScript::itemScriptEngine()
 {
 	//Z_scripterrlog("Trying to check if an %s is running.\n","item script");
 	for ( int q = 0; q < 256; q++ )
@@ -18891,5 +18892,5 @@ void FFScript::itemScriptEngine()
 		    
 	}
 	
-	//return 0;
+	return false;
 }

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -90,6 +90,13 @@ extern int skipcont;
 extern std::map<int, std::pair<string,string> > ffcmap;
 extern std::map<int, std::pair<string,string> > itemmap;
 extern std::map<int, std::pair<string,string> > globalmap;
+extern std::map<int, std::pair<string, string> > itemmap;
+extern std::map<int, std::pair<string, string> > npcmap;
+extern std::map<int, std::pair<string, string> > ewpnmap;
+extern std::map<int, std::pair<string, string> > lwpnmap;
+extern std::map<int, std::pair<string, string> > linkmap;
+extern std::map<int, std::pair<string, string> > dmapmap;
+extern std::map<int, std::pair<string, string> > screenmap;
 
 PALETTE tempgreypal; //Palettes go here. This is used for Greyscale() / Monochrome()
 PALETTE userPALETTE[256]; //Palettes go here. This is used for Greyscale() / Monochrome()

--- a/src/ffscript.h
+++ b/src/ffscript.h
@@ -130,8 +130,8 @@ long getQuestHeaderInfo(int type);
 
 
 void clearRunningItemScripts();
-void itemScriptEngine();
-void newScriptEngine();
+bool itemScriptEngine();
+bool newScriptEngine();
 
 /*
 long getQuestHeaderInfo(int type)

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -229,6 +229,71 @@ IntermediateData* ScriptParser::generateOCode(FunctionData& fdata)
 		if (isRun)
 		{
 			ScriptType type = program.getScript(scriptname)->getType();
+			
+			switch(type)
+			{
+				case ScriptType::ffc:
+				{
+					funccode.push_back(
+						new OSetRegister(new VarArgument(EXP2),
+						                 new VarArgument(REFFFC)));
+					break;
+					
+				}
+				case ScriptType::item:
+				{
+					funccode.push_back(
+						new OSetRegister(new VarArgument(EXP2),
+						                 new VarArgument(REFITEMCLASS)));
+					break;
+				}
+				case ScriptType::npc:
+				{
+					funccode.push_back(
+						new OSetRegister(new VarArgument(EXP2),
+						                 new VarArgument(REFNPC)));
+					break;
+				}
+				case ScriptType::lweapon:
+				{
+					funccode.push_back(
+						new OSetRegister(new VarArgument(EXP2),
+						                 new VarArgument(REFLWPN)));
+					break;
+				}
+				case ScriptType::eweapon:
+				{
+					funccode.push_back(
+						new OSetRegister(new VarArgument(EXP2),
+						                 new VarArgument(REFEWPN)));
+					break;
+				}
+				case ScriptType::dmap:
+				{
+					funccode.push_back(
+						new OSetRegister(new VarArgument(EXP2),
+						                 new VarArgument(LOADMAPDATA)));
+					break;
+				}
+				/* Do we want these here--ever? -Z
+				case ScriptType::link:
+				{
+					funccode.push_back(
+						new OSetRegister(new VarArgument(EXP2),
+						                 new VarArgument(link?)));
+					break;
+				}
+				case ScriptType::screen:
+				{
+					funccode.push_back(
+						new OSetRegister(new VarArgument(EXP2),
+						                 new VarArgument(tempscr?)));
+					break;
+				}
+				*/
+				
+			}
+			/*
 			if (type == ScriptType::ffc)
 				funccode.push_back(
 						new OSetRegister(new VarArgument(EXP2),
@@ -237,7 +302,7 @@ IntermediateData* ScriptParser::generateOCode(FunctionData& fdata)
 				funccode.push_back(
 						new OSetRegister(new VarArgument(EXP2),
 						                 new VarArgument(REFITEMCLASS)));
-            
+			*/
 			funccode.push_back(new OPushRegister(new VarArgument(EXP2)));
 		}
         

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -265,7 +265,7 @@ IntermediateData* ScriptParser::generateOCode(FunctionData& fdata)
 							 new VarArgument(REFEWPN)));
 				
 			}
-			else if (type == ScriptType::dmap )
+			else if (type == ScriptType::dmapdata )
 			{
 				funccode.push_back(
 					new OSetRegister(new VarArgument(EXP2),

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -230,66 +230,63 @@ IntermediateData* ScriptParser::generateOCode(FunctionData& fdata)
 		{
 			ScriptType type = program.getScript(scriptname)->getType();
 			
-			switch(type)
+			if (type == ScriptType::ffc )
 			{
-				case ScriptType::ffc:
-				{
-					funccode.push_back(
-						new OSetRegister(new VarArgument(EXP2),
-						                 new VarArgument(REFFFC)));
-					break;
-					
-				}
-				case ScriptType::item:
-				{
-					funccode.push_back(
-						new OSetRegister(new VarArgument(EXP2),
-						                 new VarArgument(REFITEMCLASS)));
-					break;
-				}
-				case ScriptType::npc:
-				{
-					funccode.push_back(
-						new OSetRegister(new VarArgument(EXP2),
-						                 new VarArgument(REFNPC)));
-					break;
-				}
-				case ScriptType::lweapon:
-				{
-					funccode.push_back(
-						new OSetRegister(new VarArgument(EXP2),
-						                 new VarArgument(REFLWPN)));
-					break;
-				}
-				case ScriptType::eweapon:
-				{
-					funccode.push_back(
-						new OSetRegister(new VarArgument(EXP2),
-						                 new VarArgument(REFEWPN)));
-					break;
-				}
-				case ScriptType::dmap:
-				{
-					funccode.push_back(
-						new OSetRegister(new VarArgument(EXP2),
-						                 new VarArgument(LOADMAPDATA)));
-					break;
-				}
-				/* Do we want these here--ever? -Z
-				case ScriptType::link:
-				{
-					funccode.push_back(
-						new OSetRegister(new VarArgument(EXP2),
-						                 new VarArgument(link?)));
-					break;
-				}
-				case ScriptType::screen:
-				{
-					funccode.push_back(
-						new OSetRegister(new VarArgument(EXP2),
-						                 new VarArgument(tempscr?)));
-					break;
-				}
+				funccode.push_back(
+					new OSetRegister(new VarArgument(EXP2),
+							 new VarArgument(REFFFC)));
+				
+				
+			}
+			else if (type == ScriptType::item )
+			{
+				funccode.push_back(
+					new OSetRegister(new VarArgument(EXP2),
+							 new VarArgument(REFITEMCLASS)));
+				
+			}
+			else if (type == ScriptType::npc )
+			{
+				funccode.push_back(
+					new OSetRegister(new VarArgument(EXP2),
+							 new VarArgument(REFNPC)));
+				
+			}
+			else if (type == ScriptType::lweapon )
+			{
+				funccode.push_back(
+					new OSetRegister(new VarArgument(EXP2),
+							 new VarArgument(REFLWPN)));
+			}
+			else if (type == ScriptType::eweapon )
+			{
+				funccode.push_back(
+					new OSetRegister(new VarArgument(EXP2),
+							 new VarArgument(REFEWPN)));
+				
+			}
+			else if (type == ScriptType::dmap )
+			{
+				funccode.push_back(
+					new OSetRegister(new VarArgument(EXP2),
+							 new VarArgument(LOADMAPDATA)));
+			
+			}
+			/* Do we want these here--ever? -Z
+			else if (type == ScriptType::link )
+			{
+				funccode.push_back(
+					new OSetRegister(new VarArgument(EXP2),
+							 new VarArgument(link?)));
+				
+			}
+			else if (type == ScriptType::screen )
+			{
+				funccode.push_back(
+					new OSetRegister(new VarArgument(EXP2),
+							 new VarArgument(tempscr?)));
+				
+			}
 				*/
 				
 			}

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -289,7 +289,7 @@ IntermediateData* ScriptParser::generateOCode(FunctionData& fdata)
 			}
 				*/
 				
-			}
+		
 			/*
 			if (type == ScriptType::ffc)
 				funccode.push_back(

--- a/src/parser/Types.cpp
+++ b/src/parser/Types.cpp
@@ -131,6 +131,7 @@ DataTypeSimple const DataType::BOOL(ZVARTYPEID_BOOL, "bool");
 DataTypeArray const DataType::STRING(FLOAT);
 DataTypeClass const DataType::GAME(ZCLASSID_GAME, "Game");
 DataTypeClass const DataType::LINK(ZCLASSID_LINK, "Link");
+//DataTypeClass const DataType::PLAYER(ZCLASSID_LINK, "Player");
 DataTypeClass const DataType::SCREEN(ZCLASSID_SCREEN, "Screen");
 DataTypeClass const DataType::FFC(ZCLASSID_FFC, "FFC");
 DataTypeClass const DataType::ITEM(ZCLASSID_ITEM, "Item");
@@ -439,11 +440,12 @@ namespace // file local
 		{"ffc", ZVARTYPEID_FFC},
 		{"item", ZVARTYPEID_ITEMCLASS},
 		{"npc", ZVARTYPEID_NPC},
-		{"lweapon", ZVARTYPEID_LWPN},
 		{"eweapon", ZVARTYPEID_EWPN},
+		{"lweapon", ZVARTYPEID_LWPN},
 		{"link", ZVARTYPEID_LINK},
-		{"screen", ZVARTYPEID_SCREEN},
-		{"dmap", ZVARTYPEID_DMAPDATA},
+		{"player", ZVARTYPEID_LINK},
+		{"screendata", ZVARTYPEID_SCREEN},
+		{"dmapdata", ZVARTYPEID_DMAPDATA},
 	};
 }
 
@@ -455,8 +457,9 @@ ScriptType const ScriptType::npc(idNPC);
 ScriptType const ScriptType::lweapon(idLWeapon);
 ScriptType const ScriptType::eweapon(idEWeapon);
 ScriptType const ScriptType::link(idLink);
-ScriptType const ScriptType::screen(idScreen);
-ScriptType const ScriptType::dmap(idDMap);
+ScriptType const ScriptType::player(idPlayer);
+ScriptType const ScriptType::screendata(idScreen);
+ScriptType const ScriptType::dmapdata(idDMap);
 
 string const& ScriptType::getName() const
 {

--- a/src/parser/Types.cpp
+++ b/src/parser/Types.cpp
@@ -438,6 +438,12 @@ namespace // file local
 		{"global", ZVARTYPEID_VOID},
 		{"ffc", ZVARTYPEID_FFC},
 		{"item", ZVARTYPEID_ITEMCLASS},
+		{"npc", ZVARTYPEID_NPC},
+		{"lweapon", ZVARTYPEID_LWPN},
+		{"eweapon", ZVARTYPEID_EWPN},
+		{"link", ZVARTYPEID_LINK},
+		{"screen", ZVARTYPEID_SCREEN},
+		{"dmap", ZVARTYPEID_DMAPDATA},
 	};
 }
 
@@ -445,6 +451,12 @@ ScriptType const ScriptType::invalid(idInvalid);
 ScriptType const ScriptType::global(idGlobal);
 ScriptType const ScriptType::ffc(idFfc);
 ScriptType const ScriptType::item(idItem);
+ScriptType const ScriptType::npc(idNPC);
+ScriptType const ScriptType::lweapon(idLWeapon);
+ScriptType const ScriptType::eweapon(idEWeapon);
+ScriptType const ScriptType::link(idLink);
+ScriptType const ScriptType::screen(idScreen);
+ScriptType const ScriptType::dmap(idDMap);
 
 string const& ScriptType::getName() const
 {

--- a/src/parser/Types.h
+++ b/src/parser/Types.h
@@ -349,6 +349,12 @@ namespace ZScript
 		static ScriptType const global;
 		static ScriptType const ffc;
 		static ScriptType const item;
+		static ScriptType const npc;
+		static ScriptType const eweapon;
+		static ScriptType const lweapon;
+		static ScriptType const link;
+		static ScriptType const dmap;
+		static ScriptType const screen;
 
 	private:
 		ScriptType(Id id) : id_(id) {}

--- a/src/parser/Types.h
+++ b/src/parser/Types.h
@@ -333,6 +333,7 @@ namespace ZScript
 			idEWeapon,
 			idLWeapon,
 			idLink,
+			idPlayer,
 			idScreen,
 			idDMap,
 			
@@ -353,8 +354,9 @@ namespace ZScript
 		static ScriptType const eweapon;
 		static ScriptType const lweapon;
 		static ScriptType const link;
-		static ScriptType const dmap;
-		static ScriptType const screen;
+		static ScriptType const player;
+		static ScriptType const dmapdata;
+		static ScriptType const screendata;
 
 	private:
 		ScriptType(Id id) : id_(id) {}

--- a/src/parser/Types.h
+++ b/src/parser/Types.h
@@ -329,6 +329,13 @@ namespace ZScript
 			idGlobal = idStart,
 			idFfc,
 			idItem,
+			idNPC,
+			idEWeapon,
+			idLWeapon,
+			idLink,
+			idScreen,
+			idDMap,
+			
 			idEnd
 		};
 	

--- a/src/parser/ffscript.lpp
+++ b/src/parser/ffscript.lpp
@@ -111,8 +111,9 @@ shopdata	TOKEN( SHOP );
 spritedata	TOKEN( SPRITE );
 musicdata		TOKEN( TUNE );
 warpring	TOKEN( WARPRING );
+screendata	TOKEN( SCREEN );
+player	TOKEN( PLAYER );
 link	TOKEN( LINK );
-screen	TOKEN( SCREEN );
 
  /* Syntax */
 ","		TOKEN( COMMA );

--- a/src/parser/ffscript.lpp
+++ b/src/parser/ffscript.lpp
@@ -111,6 +111,8 @@ shopdata	TOKEN( SHOP );
 spritedata	TOKEN( SPRITE );
 musicdata		TOKEN( TUNE );
 warpring	TOKEN( WARPRING );
+link	TOKEN( LINK );
+screen	TOKEN( SCREEN );
 
  /* Syntax */
 ","		TOKEN( COMMA );

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -133,6 +133,8 @@ extern YYLTYPE noloc;
 %token SPRITE
 %token TUNE
 %token WARPRING
+%token LINK
+%token SCREEN
 
  // Syntax
 %token COMMA
@@ -443,6 +445,12 @@ Script_Type :
 	GLOBAL {$$ = new ASTScriptType(ScriptType::global, @$);}
 	| FFC {$$ = new ASTScriptType(ScriptType::ffc, @$);}
 	| ITEM {$$ = new ASTScriptType(ScriptType::item, @$);}
+	| EWEAPON {$$ = new ASTScriptType(ScriptType::eweapon, @$);}
+	| LWEAPON {$$ = new ASTScriptType(ScriptType::lweapon, @$);}
+	| NPC {$$ = new ASTScriptType(ScriptType::npc, @$);}
+	| SCREEN {$$ = new ASTScriptType(ScriptType::screen, @$);}
+	| DMAP {$$ = new ASTScriptType(ScriptType::dmap, @$);}
+	| LINK {$$ = new ASTScriptType(ScriptType::link, @$);}
 	| IDENTIFIER {
 		ASTString* name = static_cast<ASTString*>($1);
 		$$ = new ASTScriptType(name->getValue(), @$);

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -133,8 +133,9 @@ extern YYLTYPE noloc;
 %token SPRITE
 %token TUNE
 %token WARPRING
-%token LINK
 %token SCREEN
+%token PLAYER
+%token LINK
 
  // Syntax
 %token COMMA
@@ -448,9 +449,10 @@ Script_Type :
 	| EWEAPON {$$ = new ASTScriptType(ScriptType::eweapon, @$);}
 	| LWEAPON {$$ = new ASTScriptType(ScriptType::lweapon, @$);}
 	| NPC {$$ = new ASTScriptType(ScriptType::npc, @$);}
-	| SCREEN {$$ = new ASTScriptType(ScriptType::screen, @$);}
-	| DMAP {$$ = new ASTScriptType(ScriptType::dmap, @$);}
+	| SCREEN {$$ = new ASTScriptType(ScriptType::screendata, @$);}
+	| DMAP {$$ = new ASTScriptType(ScriptType::dmapdata, @$);}
 	| LINK {$$ = new ASTScriptType(ScriptType::link, @$);}
+	| PLAYER {$$ = new ASTScriptType(ScriptType::player, @$);}
 	| IDENTIFIER {
 		ASTString* name = static_cast<ASTString*>($1);
 		$$ = new ASTScriptType(name->getValue(), @$);

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -80,6 +80,12 @@ string				             zScript;
 std::map<int, pair<string,string> > ffcmap;
 std::map<int, pair<string,string> > globalmap;
 std::map<int, pair<string,string> > itemmap;
+std::map<int, pair<string, string> > npcmap;
+std::map<int, pair<string, string> > ewpnmap;
+std::map<int, pair<string, string> > lwpnmap;
+std::map<int, pair<string, string> > linkmap;
+std::map<int, pair<string, string> > dmapmap;
+std::map<int, pair<string, string> > screenmap;
 
 bool combosread=false;
 bool mapsread=false;

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -2830,6 +2830,10 @@ void game_loop()
 	al_trace("game_loop is calling: %s\n", "Lwpns.animate()\n");
 	#endif
         Lwpns.animate();
+        #if LOGGAMELOOP > 0
+	al_trace("game_loop is calling: %s\n", "FFCore.itemScriptEngine())\n");
+	#endif
+        FFCore.itemScriptEngine();
 	#if LOGGAMELOOP > 0
 	al_trace("game_loop is calling: %s\n", "decorations.animate()\n");
 	#endif

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -98,6 +98,14 @@ CScriptDrawingCommands script_drawing_commands;
 using std::string;
 using std::pair;
 extern std::map<int, pair<string,string> > ffcmap;
+extern std::map<int, pair<string,string> > globalmap;
+extern std::map<int, pair<string, string> > itemmap;
+extern std::map<int, pair<string, string> > npcmap;
+extern std::map<int, pair<string, string> > ewpnmap;
+extern std::map<int, pair<string, string> > lwpnmap;
+extern std::map<int, pair<string, string> > linkmap;
+extern std::map<int, pair<string, string> > dmapmap;
+extern std::map<int, pair<string, string> > screenmap;
 
 int zq_screen_w, zq_screen_h;
 int passive_subscreen_height=56;

--- a/src/zq_class.cpp
+++ b/src/zq_class.cpp
@@ -59,6 +59,13 @@ extern string zScript;
 extern std::map<int, pair<string, string> > ffcmap;
 extern std::map<int, pair<string, string> > globalmap;
 extern std::map<int, pair<string, string> > itemmap;
+extern std::map<int, pair<string, string> > npcmap;
+extern std::map<int, pair<string, string> > ewpnmap;
+extern std::map<int, pair<string, string> > lwpnmap;
+extern std::map<int, pair<string, string> > linkmap;
+extern std::map<int, pair<string, string> > dmapmap;
+extern std::map<int, pair<string, string> > screenmap;
+
 zmap Map;
 int prv_mode=0;
 short ffposx[32]= {-1000,-1000,-1000,-1000,-1000,-1000,-1000,-1000,-1000,-1000,-1000,-1000,-1000,-1000,-1000,-1000,

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -19263,6 +19263,38 @@ int onCompileScript()
             {
 	            string const& name = it->first;
 	            ZScript::ScriptType type = it->second;
+                    switch(type)
+                    {
+                        case ZScript::ScriptType::ffc:
+                            asffcscripts.push_back(name); break;
+                        case ZScript::ScriptType::item:
+                            asitemscripts.push_back(name); break;
+                        case ZScript::ScriptType::npc:
+                            asnpcscripts.push_back(name); break;
+                        case ZScript::ScriptType::eweapon:
+                            aseweaponscripts.push_back(name); break;
+                        case ZScript::ScriptType::lweapon:
+                            aslweaponscripts.push_back(name); break;
+                        case ZScript::ScriptType::link:
+                            aslinkscripts.push_back(name); break;
+                        case ZScript::ScriptType::dmap:
+                            asdmapscripts.push_back(name); break;
+                        case ZScript::ScriptType::screen:
+                            asscreenscripts.push_back(name); break;
+                        case ZScript::ScriptType::global:
+                        {
+                            if (name != "~Init")
+                            {
+                                asglobalscripts.push_back(name);
+                            }
+                            break;
+                            
+                        }
+                        
+                        
+                        
+                    } 
+                    /*
 	            if (type == ZScript::ScriptType::ffc)
                     asffcscripts.push_back(name);
 	            else if (type == ZScript::ScriptType::item)
@@ -19272,6 +19304,7 @@ int onCompileScript()
 	                     // script, bad things could happen
 	                     && name != "~Init")
 		            asglobalscripts.push_back(name);
+                    */
             }
             
             assignscript_dlg[0].dp2 = lfont;

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -179,6 +179,20 @@ std::vector<string> asglobalscripts;
 extern std::map<int, pair<string, string> > itemmap;
 std::vector<string> asitemscripts;
 
+
+extern std::map<int, pair<string, string> > npcmap;
+std::vector<string> asnpcscripts;
+extern std::map<int, pair<string, string> > ewpnmap;
+std::vector<string> aseweaponscripts;
+extern std::map<int, pair<string, string> > lwpnmap;
+std::vector<string> aslweaponscripts;
+extern std::map<int, pair<string, string> > linkmap;
+std::vector<string> aslinkscripts;
+extern std::map<int, pair<string, string> > dmapmap;
+std::vector<string> asdmapscripts;
+extern std::map<int, pair<string, string> > screenmap;
+std::vector<string> asscreenscripts;
+
 int CSET_SIZE = 16;
 int CSET_SHFT = 4;
 //editbox_data temp_eb_data;
@@ -19257,43 +19271,51 @@ int onCompileScript()
             asglobalscripts.push_back("<none>");
             asitemscripts.clear();
             asitemscripts.push_back("<none>");
+            asnpcscripts.clear();
+            asnpcscripts.push_back("<none>");
+            aseweaponscripts.clear();
+            aseweaponscripts.push_back("<none>");
+            aslweaponscripts.clear();
+            aslweaponscripts.push_back("<none>");
+            aslinkscripts.clear();
+            aslinkscripts.push_back("<none>");
+            asdmapscripts.clear();
+            asdmapscripts.push_back("<none>");
+            asscreenscripts.clear();
+            asscreenscripts.push_back("<none>");
             
             for (std::map<string, ZScript::ScriptType>::iterator it =
 	                 stypes.begin(); it != stypes.end(); ++it)
             {
 	            string const& name = it->first;
 	            ZScript::ScriptType type = it->second;
-                    switch(type)
+                    if ( type == ZScript::ScriptType::ffc )
+                    {        asffcscripts.push_back(name); }
+                    else if ( type == ZScript::ScriptType::item )
+                    {        asitemscripts.push_back(name); }
+                    else if ( type == ZScript::ScriptType::npc )
+                    {        asnpcscripts.push_back(name); }
+                    else if ( type == ZScript::ScriptType::eweapon )
+                    {        aseweaponscripts.push_back(name); }
+                    else if ( type == ZScript::ScriptType::lweapon )
+                    {        aslweaponscripts.push_back(name); } 
+                    else if ( type == ZScript::ScriptType::link )
+                    {        aslinkscripts.push_back(name); }
+                    else if ( type == ZScript::ScriptType::dmap )
+                    {        asdmapscripts.push_back(name); }
+                    else if ( type == ZScript::ScriptType::screen )
+                    {        asscreenscripts.push_back(name); }
+                    else if ( type == ZScript::ScriptType::global )
                     {
-                        case ZScript::ScriptType::ffc:
-                            asffcscripts.push_back(name); break;
-                        case ZScript::ScriptType::item:
-                            asitemscripts.push_back(name); break;
-                        case ZScript::ScriptType::npc:
-                            asnpcscripts.push_back(name); break;
-                        case ZScript::ScriptType::eweapon:
-                            aseweaponscripts.push_back(name); break;
-                        case ZScript::ScriptType::lweapon:
-                            aslweaponscripts.push_back(name); break;
-                        case ZScript::ScriptType::link:
-                            aslinkscripts.push_back(name); break;
-                        case ZScript::ScriptType::dmap:
-                            asdmapscripts.push_back(name); break;
-                        case ZScript::ScriptType::screen:
-                            asscreenscripts.push_back(name); break;
-                        case ZScript::ScriptType::global:
+                        if (name != "~Init")
                         {
-                            if (name != "~Init")
-                            {
-                                asglobalscripts.push_back(name);
-                            }
-                            break;
-                            
+                            asglobalscripts.push_back(name);
                         }
+                    }
                         
                         
                         
-                    } 
+                    
                     /*
 	            if (type == ZScript::ScriptType::ffc)
                     asffcscripts.push_back(name);
@@ -19377,23 +19399,23 @@ int onCompileScript()
                 } 
                 for(int i = 0; i < NUMSCRIPTWEAPONS-1; i++)
                 {
-                    if(eweaponmap[i].second == "")
+                    if(ewpnmap[i].second == "")
                         sprintf(temp, "Slot %d: <none>", i+1);
-                    else if(scripts.find(eweaponmap[i].second) != scripts.end())
-                        sprintf(temp, "Slot %d: %s", i+1, eweaponmap[i].second.c_str());
+                    else if(scripts.find(ewpnmap[i].second) != scripts.end())
+                        sprintf(temp, "Slot %d: %s", i+1, ewpnmap[i].second.c_str());
                     else // Previously loaded script not found
-                        sprintf(temp, "Slot %d: **%s**", i+1, eweaponmap[i].second.c_str());
-                    eweaponmap[i].first = temp;
+                        sprintf(temp, "Slot %d: **%s**", i+1, ewpnmap[i].second.c_str());
+                    ewpnmap[i].first = temp;
                 }
                 for(int i = 0; i < NUMSCRIPTWEAPONS-1; i++)
                 {
-                    if(lweaponmap[i].second == "")
+                    if(lwpnmap[i].second == "")
                         sprintf(temp, "Slot %d: <none>", i+1);
-                    else if(scripts.find(lweaponmap[i].second) != scripts.end())
-                        sprintf(temp, "Slot %d: %s", i+1, lweaponmap[i].second.c_str());
+                    else if(scripts.find(lwpnmap[i].second) != scripts.end())
+                        sprintf(temp, "Slot %d: %s", i+1, lwpnmap[i].second.c_str());
                     else // Previously loaded script not found
-                        sprintf(temp, "Slot %d: **%s**", i+1, lweaponmap[i].second.c_str());
-                    lweaponmap[i].first = temp;
+                        sprintf(temp, "Slot %d: **%s**", i+1, lwpnmap[i].second.c_str());
+                    lwpnmap[i].first = temp;
                 }
                 for(int i = 0; i < NUMSCRIPTLINK-1; i++)
                 {
@@ -19606,7 +19628,7 @@ int onCompileScript()
                             guyscripts[it->first+1][0].command = 0xFFFF;
                         }
                     }
-                    for(std::map<int, pair<string,string> >::iterator it = lweaponmap.begin(); it != lweaponmap.end(); it++)
+                    for(std::map<int, pair<string,string> >::iterator it = lwpnmap.begin(); it != lwpnmap.end(); it++)
                     {
                         if(it->second.second != "")
                         {
@@ -19646,7 +19668,7 @@ int onCompileScript()
                             lwpnscripts[it->first+1][0].command = 0xFFFF;
                         }
                     }
-                    for(std::map<int, pair<string,string> >::iterator it = eweaponmap.begin(); it != eweaponmap.end(); it++)
+                    for(std::map<int, pair<string,string> >::iterator it = ewpnmap.begin(); it != ewpnmap.end(); it++)
                     {
                         if(it->second.second != "")
                         {

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -19301,9 +19301,11 @@ int onCompileScript()
                     {        aslweaponscripts.push_back(name); } 
                     else if ( type == ZScript::ScriptType::link )
                     {        aslinkscripts.push_back(name); }
-                    else if ( type == ZScript::ScriptType::dmap )
+                    else if ( type == ZScript::ScriptType::player )
+                    {        aslinkscripts.push_back(name); }
+                    else if ( type == ZScript::ScriptType::dmapdata )
                     {        asdmapscripts.push_back(name); }
-                    else if ( type == ZScript::ScriptType::screen )
+                    else if ( type == ZScript::ScriptType::screendata )
                     {        asscreenscripts.push_back(name); }
                     else if ( type == ZScript::ScriptType::global )
                     {

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -19365,6 +19365,67 @@ int onCompileScript()
                     itemmap[i].first = temp;
                 }
                 
+                for(int i = 0; i < NUMSCRIPTGUYS-1; i++)
+                {
+                    if(npcmap[i].second == "")
+                        sprintf(temp, "Slot %d: <none>", i+1);
+                    else if(scripts.find(npcmap[i].second) != scripts.end())
+                        sprintf(temp, "Slot %d: %s", i+1, npcmap[i].second.c_str());
+                    else // Previously loaded script not found
+                        sprintf(temp, "Slot %d: **%s**", i+1, npcmap[i].second.c_str());
+                    npcmap[i].first = temp;
+                } 
+                for(int i = 0; i < NUMSCRIPTWEAPONS-1; i++)
+                {
+                    if(eweaponmap[i].second == "")
+                        sprintf(temp, "Slot %d: <none>", i+1);
+                    else if(scripts.find(eweaponmap[i].second) != scripts.end())
+                        sprintf(temp, "Slot %d: %s", i+1, eweaponmap[i].second.c_str());
+                    else // Previously loaded script not found
+                        sprintf(temp, "Slot %d: **%s**", i+1, eweaponmap[i].second.c_str());
+                    eweaponmap[i].first = temp;
+                }
+                for(int i = 0; i < NUMSCRIPTWEAPONS-1; i++)
+                {
+                    if(lweaponmap[i].second == "")
+                        sprintf(temp, "Slot %d: <none>", i+1);
+                    else if(scripts.find(lweaponmap[i].second) != scripts.end())
+                        sprintf(temp, "Slot %d: %s", i+1, lweaponmap[i].second.c_str());
+                    else // Previously loaded script not found
+                        sprintf(temp, "Slot %d: **%s**", i+1, lweaponmap[i].second.c_str());
+                    lweaponmap[i].first = temp;
+                }
+                for(int i = 0; i < NUMSCRIPTLINK-1; i++)
+                {
+                    if(linkmap[i].second == "")
+                        sprintf(temp, "Slot %d: <none>", i+1);
+                    else if(scripts.find(linkmap[i].second) != scripts.end())
+                        sprintf(temp, "Slot %d: %s", i+1, linkmap[i].second.c_str());
+                    else // Previously loaded script not found
+                        sprintf(temp, "Slot %d: **%s**", i+1, linkmap[i].second.c_str());
+                    linkmap[i].first = temp;
+                }
+                for(int i = 0; i < NUMSCRIPTSCREEN-1; i++)
+                {
+                    if(screenmap[i].second == "")
+                        sprintf(temp, "Slot %d: <none>", i+1);
+                    else if(scripts.find(screenmap[i].second) != scripts.end())
+                        sprintf(temp, "Slot %d: %s", i+1, screenmap[i].second.c_str());
+                    else // Previously loaded script not found
+                        sprintf(temp, "Slot %d: **%s**", i+1, screenmap[i].second.c_str());
+                    screenmap[i].first = temp;
+                }
+                for(int i = 0; i < NUMSCRIPTSDMAP-1; i++)
+                {
+                    if(dmapmap[i].second == "")
+                        sprintf(temp, "Slot %d: <none>", i+1);
+                    else if(scripts.find(dmapmap[i].second) != scripts.end())
+                        sprintf(temp, "Slot %d: %s", i+1, dmapmap[i].second.c_str());
+                    else // Previously loaded script not found
+                        sprintf(temp, "Slot %d: **%s**", i+1, dmapmap[i].second.c_str());
+                    dmapmap[i].first = temp;
+                }
+                
                 if(is_large)
                     large_dialog(assignscript_dlg);
                     
@@ -19505,7 +19566,246 @@ int onCompileScript()
                             itemscripts[it->first+1][0].command = 0xFFFF;
                         }
                     }
-                    
+                    for(std::map<int, pair<string,string> >::iterator it = npcmap.begin(); it != npcmap.end(); it++)
+                    {
+                        if(it->second.second != "")
+                        {
+                            tempfile = fopen("tmp","w");
+                            
+                            if(!tempfile)
+                            {
+                                jwin_alert("Error","Unable to create a temporary file in current directory!",NULL,NULL,"O&K",NULL,'k',0,lfont);
+                                return D_O_K;
+                            }
+                            
+                            if(output)
+                            {
+                                al_trace("\n");
+                                al_trace("%s",it->second.second.c_str());
+                                al_trace("\n");
+                            }
+                            
+                            for(vector<ZScript::Opcode *>::iterator line = scripts[it->second.second].begin(); line != scripts[it->second.second].end(); line++)
+                            {
+                                string theline = (*line)->printLine();
+                                fwrite(theline.c_str(), sizeof(char), theline.size(),tempfile);
+                                
+                                if(output)
+                                {
+                                    al_trace("%s",theline.c_str());
+                                }
+                            }
+                            
+                            fclose(tempfile);
+                            parse_script_file(&guyscripts[it->first+1],"tmp",false);
+                        }
+                        else if(guyscripts[it->first+1])
+                        {
+                            delete[] guyscripts[it->first+1];
+                            guyscripts[it->first+1] = new ffscript[1];
+                            guyscripts[it->first+1][0].command = 0xFFFF;
+                        }
+                    }
+                    for(std::map<int, pair<string,string> >::iterator it = lweaponmap.begin(); it != lweaponmap.end(); it++)
+                    {
+                        if(it->second.second != "")
+                        {
+                            tempfile = fopen("tmp","w");
+                            
+                            if(!tempfile)
+                            {
+                                jwin_alert("Error","Unable to create a temporary file in current directory!",NULL,NULL,"O&K",NULL,'k',0,lfont);
+                                return D_O_K;
+                            }
+                            
+                            if(output)
+                            {
+                                al_trace("\n");
+                                al_trace("%s",it->second.second.c_str());
+                                al_trace("\n");
+                            }
+                            
+                            for(vector<ZScript::Opcode *>::iterator line = scripts[it->second.second].begin(); line != scripts[it->second.second].end(); line++)
+                            {
+                                string theline = (*line)->printLine();
+                                fwrite(theline.c_str(), sizeof(char), theline.size(),tempfile);
+                                
+                                if(output)
+                                {
+                                    al_trace("%s",theline.c_str());
+                                }
+                            }
+                            
+                            fclose(tempfile);
+                            parse_script_file(&lwpnscripts[it->first+1],"tmp",false);
+                        }
+                        else if(lwpnscripts[it->first+1])
+                        {
+                            delete[] lwpnscripts[it->first+1];
+                            lwpnscripts[it->first+1] = new ffscript[1];
+                            lwpnscripts[it->first+1][0].command = 0xFFFF;
+                        }
+                    }
+                    for(std::map<int, pair<string,string> >::iterator it = eweaponmap.begin(); it != eweaponmap.end(); it++)
+                    {
+                        if(it->second.second != "")
+                        {
+                            tempfile = fopen("tmp","w");
+                            
+                            if(!tempfile)
+                            {
+                                jwin_alert("Error","Unable to create a temporary file in current directory!",NULL,NULL,"O&K",NULL,'k',0,lfont);
+                                return D_O_K;
+                            }
+                            
+                            if(output)
+                            {
+                                al_trace("\n");
+                                al_trace("%s",it->second.second.c_str());
+                                al_trace("\n");
+                            }
+                            
+                            for(vector<ZScript::Opcode *>::iterator line = scripts[it->second.second].begin(); line != scripts[it->second.second].end(); line++)
+                            {
+                                string theline = (*line)->printLine();
+                                fwrite(theline.c_str(), sizeof(char), theline.size(),tempfile);
+                                
+                                if(output)
+                                {
+                                    al_trace("%s",theline.c_str());
+                                }
+                            }
+                            
+                            fclose(tempfile);
+                            parse_script_file(&ewpnscripts[it->first+1],"tmp",false);
+                        }
+                        else if(ewpnscripts[it->first+1])
+                        {
+                            delete[] ewpnscripts[it->first+1];
+                            ewpnscripts[it->first+1] = new ffscript[1];
+                            ewpnscripts[it->first+1][0].command = 0xFFFF;
+                        }
+                    }
+                    for(std::map<int, pair<string,string> >::iterator it = linkmap.begin(); it != linkmap.end(); it++)
+                    {
+                        if(it->second.second != "")
+                        {
+                            tempfile = fopen("tmp","w");
+                            
+                            if(!tempfile)
+                            {
+                                jwin_alert("Error","Unable to create a temporary file in current directory!",NULL,NULL,"O&K",NULL,'k',0,lfont);
+                                return D_O_K;
+                            }
+                            
+                            if(output)
+                            {
+                                al_trace("\n");
+                                al_trace("%s",it->second.second.c_str());
+                                al_trace("\n");
+                            }
+                            
+                            for(vector<ZScript::Opcode *>::iterator line = scripts[it->second.second].begin(); line != scripts[it->second.second].end(); line++)
+                            {
+                                string theline = (*line)->printLine();
+                                fwrite(theline.c_str(), sizeof(char), theline.size(),tempfile);
+                                
+                                if(output)
+                                {
+                                    al_trace("%s",theline.c_str());
+                                }
+                            }
+                            
+                            fclose(tempfile);
+                            parse_script_file(&linkscripts[it->first+1],"tmp",false);
+                        }
+                        else if(linkscripts[it->first+1])
+                        {
+                            delete[] linkscripts[it->first+1];
+                            linkscripts[it->first+1] = new ffscript[1];
+                            linkscripts[it->first+1][0].command = 0xFFFF;
+                        }
+                    }
+                    for(std::map<int, pair<string,string> >::iterator it = dmapmap.begin(); it != dmapmap.end(); it++)
+                    {
+                        if(it->second.second != "")
+                        {
+                            tempfile = fopen("tmp","w");
+                            
+                            if(!tempfile)
+                            {
+                                jwin_alert("Error","Unable to create a temporary file in current directory!",NULL,NULL,"O&K",NULL,'k',0,lfont);
+                                return D_O_K;
+                            }
+                            
+                            if(output)
+                            {
+                                al_trace("\n");
+                                al_trace("%s",it->second.second.c_str());
+                                al_trace("\n");
+                            }
+                            
+                            for(vector<ZScript::Opcode *>::iterator line = scripts[it->second.second].begin(); line != scripts[it->second.second].end(); line++)
+                            {
+                                string theline = (*line)->printLine();
+                                fwrite(theline.c_str(), sizeof(char), theline.size(),tempfile);
+                                
+                                if(output)
+                                {
+                                    al_trace("%s",theline.c_str());
+                                }
+                            }
+                            
+                            fclose(tempfile);
+                            parse_script_file(&dmapscripts[it->first+1],"tmp",false);
+                        }
+                        else if(dmapscripts[it->first+1])
+                        {
+                            delete[] dmapscripts[it->first+1];
+                            dmapscripts[it->first+1] = new ffscript[1];
+                            dmapscripts[it->first+1][0].command = 0xFFFF;
+                        }
+                    }
+                    for(std::map<int, pair<string,string> >::iterator it = screenmap.begin(); it != screenmap.end(); it++)
+                    {
+                        if(it->second.second != "")
+                        {
+                            tempfile = fopen("tmp","w");
+                            
+                            if(!tempfile)
+                            {
+                                jwin_alert("Error","Unable to create a temporary file in current directory!",NULL,NULL,"O&K",NULL,'k',0,lfont);
+                                return D_O_K;
+                            }
+                            
+                            if(output)
+                            {
+                                al_trace("\n");
+                                al_trace("%s",it->second.second.c_str());
+                                al_trace("\n");
+                            }
+                            
+                            for(vector<ZScript::Opcode *>::iterator line = scripts[it->second.second].begin(); line != scripts[it->second.second].end(); line++)
+                            {
+                                string theline = (*line)->printLine();
+                                fwrite(theline.c_str(), sizeof(char), theline.size(),tempfile);
+                                
+                                if(output)
+                                {
+                                    al_trace("%s",theline.c_str());
+                                }
+                            }
+                            
+                            fclose(tempfile);
+                            parse_script_file(&screenscripts[it->first+1],"tmp",false);
+                        }
+                        else if(screenscripts[it->first+1])
+                        {
+                            delete[] screenscripts[it->first+1];
+                            screenscripts[it->first+1] = new ffscript[1];
+                            screenscripts[it->first+1][0].command = 0xFFFF;
+                        }
+                    }
                     unlink("tmp");
                     jwin_alert("Done!","ZScripts successfully loaded into script slots",NULL,NULL,"O&K",NULL,'k',0,lfont);
                     build_biffs_list();
@@ -19521,7 +19821,7 @@ int onCompileScript()
                     
                     return D_O_K;
                 }
-                
+                //Left off here for the day. -Z
                 case 6:
                     //<<, FFC
                 {


### PR DESCRIPTION

Changelog: Started adding new script types to the parser and implementing their slots in ZQuest.

New types are:
npc scriptm (this-> is npc)
lweapon script (this-> is lweapon)
eweapon script (this-> is eweapon)
dmapdata script (this-> is dmapdata)
screendata script (no this-> at present)
link script (no this-> at present)

Began adding `Player->` and `player script` for `Link->` and `link script`, respectively. 