### PR TITLE
Associate refInfo with each sprite

### DIFF
--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -14856,11 +14856,13 @@ int run_script(const byte type, const word script, const long i)
 	    {
 			int lwpn_index = LwpnH::getLWeaponIndex(i);
 			//ri = &(lweaponScriptData[i]);
-			ri = &(lweaponScriptData[LwpnH::getLWeaponIndex(i)]);
-			//weapon *w = (weapon*)Lwpns.spr(i);
+			weapon *w = (weapon*)Lwpns.spr(lwpn_index);
+			ri = w->refinfo;
+			if (!ri) {
+			  ri = w->refinfo = new refInfo;
+			}
 			//curscript = lwpnscripts[script];
 			curscript = lwpnscripts[Lwpns.spr(LwpnH::getLWeaponIndex(i))->weaponscript];
-			
 			//Z_scripterrlog("FFScript is trying to run lweapon script: %d\n", curscript);
 			//for ( int q = 0; q < 256; q++ )
 			//{

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -72,7 +72,7 @@ sprite::sprite()
         dummy_float[i]=0;
         dummy_bool[i]=false;
     }
-    
+    refinfo = 0;
     //for(int i=0;i<8;i++)
     //{
     //  if(i<2) a[i]=0;
@@ -142,6 +142,7 @@ sprite::sprite(sprite const & other):
     drawstyle(other.drawstyle),
     extend(other.extend),
     wpnsprite(other.wpnsprite),
+    refinfo(other.refinfo),
     //scriptData(other.scriptData),
 //ffcref(other.ffcref),
 //itemref(other.itemref),
@@ -226,7 +227,7 @@ sprite::sprite(fix X,fix Y,int T,int CS,int F,int Clk,int Yofs):
     for(int i=0; i<32; i++) miscellaneous[i] = 0;
     
     scriptcoldet = 1;
-    
+    refinfo = 0;
     //scriptData.Clear();
     //ewpnclass=0;
     //lwpnclass=0;
@@ -260,6 +261,7 @@ sprite::sprite(fix X,fix Y,int T,int CS,int F,int Clk,int Yofs):
 
 sprite::~sprite()
 {
+  delete refinfo;
 }
 
 long sprite::getNextUID()

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -34,6 +34,8 @@ extern int conveyclk;
 /**********************************/
 /******* Sprite Base Class ********/
 /**********************************/
+// Forward reference
+class refInfo;
 
 class sprite
 {
@@ -79,7 +81,7 @@ public:
     long stack[MAX_SCRIPT_REGISTERS];
     //Are you kidding? Really? 256 * sizeof(long) = 2048 bytes = 2kb of wasted memory for every sprite, and it'll never
     //even get used because item scripts only run for one frame. Gah! Maybe when we have npc scripts, not not now...
-    
+    refInfo* refinfo;
     //refInfo scriptData; //For when we have npc scripts maybe
     //long d[8];
     //long a[2];


### PR DESCRIPTION
As discussed with @ZoriaRPG  I believe this will prevent some of script errors seen when running lweapon scripts. 