### PR TITLE
Fix memory leak identified by valgrind

### DIFF
--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -13581,7 +13581,6 @@ int readtiles(PACKFILE *f, tiledata *buf, zquestheader *Header, word version, wo
 		for ( int q = ZC250MAXTILES; q < NEWMAXTILES; ++q )
 		{
 			
-			buf[q].data=(byte *)zc_malloc(tilesize(tf4Bit));
 			//memcpy(buf[q].data,temp_tile,tilesize(buf[q].format));
 			reset_tile(buf,q,tf4Bit);
 			

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -86,7 +86,7 @@ std::map<int, pair<string, string> > lwpnmap;
 std::map<int, pair<string, string> > linkmap;
 std::map<int, pair<string, string> > dmapmap;
 std::map<int, pair<string, string> > screenmap;
-
+void free_newtilebuf();
 bool combosread=false;
 bool mapsread=false;
 bool fixffcs=false;
@@ -1231,6 +1231,7 @@ int get_qst_buffers()
     memrequested+=(NEWMAXTILES*(sizeof(tiledata)+tilesize(tf4Bit)));
     Z_message("Allocating tile buffer (%s)... ", byte_conversion2(NEWMAXTILES*(sizeof(tiledata)+tilesize(tf4Bit)),memrequested,-1,-1));
     
+    free_newtilebuf();
     if((newtilebuf=(tiledata*)zc_malloc(NEWMAXTILES*sizeof(tiledata)))==NULL)
         return 0;
         
@@ -1315,6 +1316,7 @@ void free_newtilebuf()
                 zc_free(newtilebuf[i].data);
                 
         zc_free(newtilebuf);
+	newtilebuf = 0;
     }
 }
 
@@ -1328,6 +1330,7 @@ void free_grabtilebuf()
                 if(grabtilebuf[i].data) zc_free(grabtilebuf[i].data);
                 
             zc_free(grabtilebuf);
+	    grabtilebuf = 0;
         }
     }
 }


### PR DESCRIPTION
Before:
```
==17404== LEAK SUMMARY:
==17404==    definitely lost: 38,123,144 bytes in 297,838 blocks
==17404==    indirectly lost: 104 bytes in 4 blocks
==17404==      possibly lost: 15,360 bytes in 120 blocks
==17404==    still reachable: 34,086,105 bytes in 17,493 blocks
==17404==                       of which reachable via heuristic:
==17404==                         newarray           : 33,551,584 bytes in 1 blocks
```
after
```
==17816== LEAK SUMMARY:
==17816==    definitely lost: 144 bytes in 25 blocks
==17816==    indirectly lost: 104 bytes in 4 blocks
==17816==      possibly lost: 0 bytes in 0 blocks
==17816==    still reachable: 34,085,789 bytes in 17,502 blocks
==17816==                       of which reachable via heuristic:
==17816==                         newarray           : 33,551,584 bytes in 1 blocks
```