### PR TITLE
Add All New Types to 'Compile ZScript' and Install Link Scripts

### DIFF
--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -136,7 +136,9 @@ refInfo linkScriptData;
 refInfo screenScriptData;
 refInfo dmapScriptData;
 word g_doscript = 1;
+word link_doscript = 1;
 bool global_wait = false;
+bool link_waitdraw = false;
 
 //Sprite script data
 refInfo itemScriptData[256];
@@ -162,6 +164,7 @@ long ffc_stack[32][MAX_SCRIPT_REGISTERS];
 long global_stack[GLOBAL_STACK_MAX][MAX_SCRIPT_REGISTERS];
 long item_stack[256][MAX_SCRIPT_REGISTERS];
 long ffmisc[32][16];
+long link_stack[MAX_SCRIPT_REGISTERS];
 refInfo ffcScriptData[32];
 
 void clear_ffc_stack(const byte i)
@@ -173,6 +176,11 @@ void clear_global_stack()
 {
     //memset(global_stack, 0, MAX_SCRIPT_REGISTERS * sizeof(long));
     memset(global_stack, 0, sizeof(global_stack));
+}
+
+void clear_link_stack()
+{
+    memset(link_stack, 0, MAX_SCRIPT_REGISTERS * sizeof(long));
 }
 
 //ScriptHelper
@@ -15026,7 +15034,7 @@ int run_script(const byte type, const word script, const long i)
 		    //should this become ri = &(globalScriptData[link_slot]);
 		
 		curscript = linkscripts[script];
-		stack = &global_stack[GLOBAL_STACK_LINK];
+		stack = &link_stack;
 		    //
 	    }
 	    break;
@@ -17001,6 +17009,10 @@ int run_script(const byte type, const word script, const long i)
             global_wait = true;
             break;
             
+	case SCRIPT_LINK:
+		link_waitdraw = true;
+		break;
+	
         default:
             Z_scripterrlog("Waitdraw can only be used in the active global script\n");
             break;
@@ -17017,6 +17029,10 @@ int run_script(const byte type, const word script, const long i)
 		    
 		case SCRIPT_GLOBAL:
 		    g_doscript = 0;
+		    break;
+		
+		case SCRIPT_LINK:
+		    link_doscript = 0;
 		    break;
 		    
 		case SCRIPT_ITEM:

--- a/src/ffscript.h
+++ b/src/ffscript.h
@@ -1221,6 +1221,7 @@ int ffscript_engine(const bool preload);
 
 void clear_ffc_stack(const byte i);
 void clear_global_stack();
+void clear_link_stack();
 void deallocateArray(const long ptrval);
 void clearScriptHelperData();
 

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -34,6 +34,7 @@ extern FFScript FFCore;
 extern LinkClass Link;
 extern ZModule zcm;
 extern zcmodule moduledata;
+extern refInfo linkScriptData;
 #include "mem_debug.h"
 #include "zscriptversion.h"
 #include "particles.h"
@@ -78,6 +79,14 @@ const byte lsteps[8] = { 1, 1, 2, 1, 1, 2, 1, 1 };
 static inline bool isSideview()
 {
     return (((tmpscr->flags7&fSIDEVIEW)!=0 || DMaps[currdmap].sideview != 0) && !ignoreSideview); //DMap Enable Sideview on All Screens -Z //2.54 Alpha 27
+}
+
+
+void initLinkScripts()
+{
+    link_doscript = 1;
+    linkScriptData.Clear();
+    clear_link_stack();
 }
 
 int LinkClass::DrunkClock()
@@ -4362,6 +4371,9 @@ bool LinkClass::animate(int)
             drunkclk=0;
 	    link_is_stunned = 0;
 	    FFCore.setLinkAction(dying);
+	    //initLinkScripts();
+	    //ZScriptVersion::RunScript(SCRIPT_LINK, SCRIPT_LINK_DEATH);
+	    //if ( link_doscript ) { last_hurrah = false; return false; }
             gameover();
             
             return true;
@@ -15855,6 +15867,10 @@ void LinkClass::gameover()
 	int f=0;
     
 	action=none; FFCore.setLinkAction(dying); //mayhaps a new action of 'gameover'? -Z
+	initLinkScripts();
+	ZScriptVersion::RunScript(SCRIPT_LINK, SCRIPT_LINK_DEATH);
+	//while(link_doscript) { advanceframe(true); } //Not safe. The script runs for only one frame at present.
+	
 	Playing=false;
     
 	if(!debug_enabled)
@@ -16713,3 +16729,7 @@ void LinkClass::explode(int type)
 int LinkClass::getTileModifier() { return item_tile_mod(true); } //how best to read shieldcanmodify? -Z
 void LinkClass::setTileModifier(int new_tile_mod) { /*item_tile_mod = new_tile_mod;*/ }
 /*** end of link.cpp ***/
+
+
+
+

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -51,6 +51,7 @@ extern int draw_screen_clip_rect_y1;
 extern int draw_screen_clip_rect_y2;
 //extern bool draw_screen_clip_rect_show_link;
 extern bool global_wait;
+extern bool link_waitdraw;
 
 int link_count = -1;
 int link_animation_speed = 1; //lower is faster animation
@@ -66,6 +67,7 @@ int directItemB = -1;
 int directWpn = -1;
 int whistleitem=-1;
 extern word g_doscript;
+extern word link_doscript;
 
 void playLevelMusic();
 
@@ -13139,7 +13141,8 @@ void LinkClass::run_scrolling_script(int scrolldir, int cx, int sx, int sy, bool
     
     if(g_doscript)
         ZScriptVersion::RunScript(SCRIPT_GLOBAL, GLOBAL_SCRIPT_GAME);
-        
+    if (link_doscript)
+	    ZScriptVersion::RunScript(SCRIPT_LINK, SCRIPT_LINK_ACTIVE);
     x = storex, y = storey;
 }
 
@@ -13330,7 +13333,11 @@ void LinkClass::scrollscr(int scrolldir, int destscr, int destdmap)
         ZScriptVersion::RunScript(SCRIPT_GLOBAL, GLOBAL_SCRIPT_GAME);
         global_wait=false;
     }
-    
+    if ( link_waitdraw )
+    {
+	ZScriptVersion::RunScript(SCRIPT_LINK, SCRIPT_LINK_ACTIVE);
+        link_waitdraw = false;
+    }
     do
     {
         draw_screen(tmpscr);

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -8655,12 +8655,35 @@ int readffscript(PACKFILE *f, zquestheader *Header, bool keepdata)
             globalscripts[GLOBAL_SCRIPT_CONTINUE][0].command = 0xFFFF;
         }
         
-        for(int i = 0; i < NUMSCRIPTLINK; i++)
+	if(s_version > 10) //expanded the number of Link scripts to 5. 
         {
-            ret = read_one_ffscript(f, Header, keepdata, i, s_version, s_cversion, &linkscripts[i]);
-            
-            if(ret != 0) return qe_invalid;
+		for(int i = 0; i < NUMSCRIPTLINK; i++)
+		{
+		    ret = read_one_ffscript(f, Header, keepdata, i, s_version, s_cversion, &linkscripts[i]);
+		    
+		    if(ret != 0) return qe_invalid;
+		}
         }
+	else
+	{
+		for(int i = 0; i < NUMSCRIPTLINKOLD; i++)
+		{
+		    ret = read_one_ffscript(f, Header, keepdata, i, s_version, s_cversion, &linkscripts[i]);
+		    
+		    if(ret != 0) return qe_invalid;
+		}
+		if(linkscripts[3] != NULL)
+                delete [] linkscripts[3];
+                
+		linkscripts[3] = new ffscript[1];
+		linkscripts[3][0].command = 0xFFFF;
+		
+		if(linkscripts[4] != NULL)
+                delete [] linkscripts[4];
+                
+		linkscripts[4] = new ffscript[1];
+		linkscripts[4][0].command = 0xFFFF;
+	}
         if(s_version > 8 && s_version < 10)
         {
             

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -3933,6 +3933,9 @@ extern void removeFromItemCache(int itemid);
 #define GLOBAL_SCRIPT_END		2
 #define GLOBAL_SCRIPT_CONTINUE 	3
 
+#define SCRIPT_LINK_INIT 1
+#define SCRIPT_LINK_ACTIVE 2
+
 //Link Internal Flags
 #define LF_PAID_SWORD_COST		0x01
 #define LF_PAID_WAND_COST		0x02

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -199,7 +199,7 @@ enum {ENC_METHOD_192B104=0, ENC_METHOD_192B105, ENC_METHOD_192B185, ENC_METHOD_2
 #define V_LINKSPRITES      5
 #define V_SUBSCREEN        6
 #define V_ITEMDROPSETS     2
-#define V_FFSCRIPT         10
+#define V_FFSCRIPT         11
 #define V_SFX              7
 #define V_FAVORITES        1
 //= V_SHOPS is under V_MISC
@@ -3924,7 +3924,8 @@ extern void removeFromItemCache(int itemid);
 #define NUMSCRIPTWEAPONS	256
 #define NUMSCRIPTGLOBAL		4
 #define NUMSCRIPTGLOBALOLD	3
-#define NUMSCRIPTLINK		3
+#define NUMSCRIPTLINKOLD		3
+#define NUMSCRIPTLINK		5
 #define NUMSCRIPTSCREEN		256
 #define NUMSCRIPTSDMAP		256
 
@@ -3935,6 +3936,8 @@ extern void removeFromItemCache(int itemid);
 
 #define SCRIPT_LINK_INIT 1
 #define SCRIPT_LINK_ACTIVE 2
+#define SCRIPT_LINK_DEATH 3
+#define SCRIPT_LINK_WIN 4
 
 //Link Internal Flags
 #define LF_PAID_SWORD_COST		0x01

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -4591,6 +4591,9 @@ int main(int argc, char* argv[])
             initZScriptGlobalRAM();
             initZScriptLinkScripts();
 	    //Run global script OnExit
+            ZScriptVersion::RunScript(SCRIPT_LINK, SCRIPT_LINK_WIN);
+	    //while(link_doscript) advanceframe(true); //Not safe. The script can run for only one frame. 
+		//We need a special routine for win and death link scripts. Otherwise, they work. 
             ZScriptVersion::RunScript(SCRIPT_GLOBAL, GLOBAL_SCRIPT_END);
 		
 	    

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -19082,6 +19082,7 @@ static int as_global_list[] = { 7, 8, 9, -1}; //Why does putting 15 in here not 
 static int as_item_list[] = { 10, 11, 12, -1};
 static int as_npc_list[] = { 18, 19, 20, -1}; //npc scripts TAB
 static int as_lweapon_list[] = { 21, 22, 23, -1}; //npc scripts TAB
+static int as_eweapon_list[] = { 24, 25, 26, -1}; //npc scripts TAB
 
 static TABPANEL assignscript_tabs[] =
 {
@@ -19091,6 +19092,7 @@ static TABPANEL assignscript_tabs[] =
     { (char *)"Item",		 0,         as_item_list,   0, NULL },
     { (char *)"NPC",		 0,         as_npc_list,   0, NULL },
     { (char *)"LWeapon",		 0,         as_lweapon_list,   0, NULL },
+    { (char *)"EWeapon",		 0,         as_eweapon_list,   0, NULL },
     { NULL,                0,           NULL,         0, NULL }
 };
 
@@ -19148,6 +19150,17 @@ const char *assignlweaponlist(int index, int *list_size)
     return lwpnmap[index].first.c_str();
 }
 
+const char *assigneweaponlist(int index, int *list_size)
+{
+    if(index<0)
+    {
+        *list_size = (int)ewpnmap.size();
+        return NULL;
+    }
+    
+    return ewpnmap[index].first.c_str();
+}
+
 const char *assignffcscriptlist(int index, int *list_size)
 {
     if(index<0)
@@ -19203,6 +19216,17 @@ const char *assignlweaponscriptlist(int index, int *list_size)
     return aslweaponscripts[index].c_str();
 }
 
+const char *assigneweaponscriptlist(int index, int *list_size)
+{
+    if(index<0)
+    {
+        *list_size = (int)aseweaponscripts.size();
+        return NULL;
+    }
+    
+    return aseweaponscripts[index].c_str();
+}
+
 static ListData assignffc_list(assignffclist, &font);
 static ListData assignffcscript_list(assignffcscriptlist, &font);
 static ListData assignglobal_list(assigngloballist, &font);
@@ -19213,6 +19237,8 @@ static ListData assignnpc_list(assignnpclist, &font);
 static ListData assignnpcscript_list(assignnpcscriptlist, &font);
 static ListData assignlweapon_list(assignlweaponlist, &font);
 static ListData assignlweaponscript_list(assignlweaponscriptlist, &font);
+static ListData assigneweapon_list(assigneweaponlist, &font);
+static ListData assigneweaponscript_list(assigneweaponscriptlist, &font);
 
 static DIALOG assignscript_dlg[] =
 {
@@ -19249,6 +19275,11 @@ static DIALOG assignscript_dlg[] =
     { jwin_abclist_proc,    10,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignlweapon_list, NULL, NULL },
     { jwin_abclist_proc,    174,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignlweaponscript_list, NULL, NULL },
     //23
+    { jwin_button_proc,	  154,	93,		15,		10,		vc(14),	vc(1),	0,	D_EXIT,	0,	0,	(void *) "<<", NULL, NULL },
+    //24
+    { jwin_abclist_proc,    10,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assigneweapon_list, NULL, NULL },
+    { jwin_abclist_proc,    174,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assigneweaponscript_list, NULL, NULL },
+    //26
     { jwin_button_proc,	  154,	93,		15,		10,		vc(14),	vc(1),	0,	D_EXIT,	0,	0,	(void *) "<<", NULL, NULL },
     
     
@@ -19373,7 +19404,6 @@ static DIALOG npcscript_sel_dlg[] =
 };
 
 //lweapon scripts
-//npc script slots
 static char lweaponscript_str_buf2[32];
 
 const char *lweaponscriptlist2(int index, int *list_size)
@@ -19410,6 +19440,46 @@ static DIALOG lweaponscript_sel_dlg[] =
     { jwin_button_proc,     35,   132,  61,   21, vc(14),   vc(1),     13,       D_EXIT,     0,             0, (void *) "Load", NULL, NULL },
     { jwin_button_proc,     104,  132,  61,   21, vc(14),   vc(1),     27,       D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
     { jwin_droplist_proc,   26,   45,   146,   16, jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,       0,          1,             0, (void *) &lweaponscript_sel_dlg_list, NULL, NULL },
+    { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
+    { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
+};
+
+static char eweaponscript_str_buf2[32];
+
+const char *eweaponscriptlist2(int index, int *list_size)
+{
+    if(index>=0)
+    {
+        char buf[20];
+        bound(index,0,254);
+        
+        if(ewpnmap[index].second=="")
+            strcpy(buf, "<none>");
+        else
+        {
+            strncpy(buf, ewpnmap[index].second.c_str(), 19);
+            buf[19]='\0';
+        }
+        
+        sprintf(eweaponscript_str_buf2,"%d: %s",index+1, buf);
+        return eweaponscript_str_buf2;
+    }
+    
+    *list_size=(NUMSCRIPTWEAPONS-1);
+    return NULL;
+}
+
+
+static ListData eweaponscript_sel_dlg_list(eweaponscriptlist2, &font);
+
+static DIALOG eweaponscript_sel_dlg[] =
+{
+    { jwin_win_proc,        0,    0,    200, 159, vc(14),   vc(1),      0,       D_EXIT,     0,             0, (void *) "Choose Slot And Name", NULL, NULL },
+    { jwin_text_proc,       8,    80,   36,  8,   vc(14),   vc(1),     0,       0,          0,             0, (void *) "Name:", NULL, NULL },
+    { jwin_edit_proc,       44,   80-4, 146, 16,  vc(12),   vc(1),     0,       0,          19,            0,       NULL, NULL, NULL },
+    { jwin_button_proc,     35,   132,  61,   21, vc(14),   vc(1),     13,       D_EXIT,     0,             0, (void *) "Load", NULL, NULL },
+    { jwin_button_proc,     104,  132,  61,   21, vc(14),   vc(1),     27,       D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
+    { jwin_droplist_proc,   26,   45,   146,   16, jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,       0,          1,             0, (void *) &eweaponscript_sel_dlg_list, NULL, NULL },
     { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
     { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
 };
@@ -20217,6 +20287,26 @@ int onCompileScript()
                     else
                     {
                         lwpnmap[lind].second = aslweaponscripts[rind];
+                    }
+                    
+                    break;
+                }
+		case 26:
+                    //<<, EWeapon
+                {
+                    int lind = assignscript_dlg[24].d1;
+                    int rind = assignscript_dlg[25].d1;
+                    
+                    if(lind < 0 || rind < 0)
+                        break;
+                        
+                    if(aseweaponscripts[rind] == "<none>")
+                    {
+                        ewpnmap[lind].second = "";
+                    }
+                    else
+                    {
+                        ewpnmap[lind].second = aseweaponscripts[rind];
                     }
                     
                     break;

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -20169,6 +20169,7 @@ int onCompileScript()
                 }
                 for(int i = 0; i < NUMSCRIPTLINK-1; i++)
                 {
+			/*
                     if(linkmap[i].second == "")
                         sprintf(temp, "Slot %d: <none>", i+1);
                     else if(scripts.find(linkmap[i].second) != scripts.end())
@@ -20176,6 +20177,25 @@ int onCompileScript()
                     else // Previously loaded script not found
                         sprintf(temp, "Slot %d: **%s**", i+1, linkmap[i].second.c_str());
                     linkmap[i].first = temp;
+			*/
+		    char buffer[64];
+                    const char* format;
+                    const char* asterisks;
+                    switch(i)
+                    {
+                        case 0: format="Init: %s%s%s"; break;
+                        case 1: format="Active: %s%s%s"; break;
+                        case 2: format="onDeath: %s%s%s"; break;
+                        case 3: format="onWin: %s%s%s"; break;
+                    }
+                    if(linkmap[i].second == "")
+                        asterisks="";
+                    else if(scripts.find(linkmap[i].second) != scripts.end())
+                        asterisks="";
+                    else // Unloaded
+                        asterisks="**";
+                    snprintf(buffer, 50, format, asterisks, linkmap[i].second.c_str(), asterisks);
+                    linkmap[i].first=buffer;
                 }
                 for(int i = 0; i < NUMSCRIPTSCREEN-1; i++)
                 {

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -19084,6 +19084,7 @@ static int as_npc_list[] = { 18, 19, 20, -1}; //npc scripts TAB
 static int as_lweapon_list[] = { 21, 22, 23, -1}; //lweapon scripts TAB
 static int as_eweapon_list[] = { 24, 25, 26, -1}; //eweapon scripts TAB
 static int as_link_list[] = { 27, 28, 29, -1}; //link scripts TAB
+static int as_screen_list[] = { 30, 31, 32, -1}; //link scripts TAB
 
 static TABPANEL assignscript_tabs[] =
 {
@@ -19095,6 +19096,7 @@ static TABPANEL assignscript_tabs[] =
     { (char *)"LWeapon",		 0,         as_lweapon_list,   0, NULL },
     { (char *)"EWeapon",		 0,         as_eweapon_list,   0, NULL },
     { (char *)"Link",		 0,         as_link_list,   0, NULL },
+    { (char *)"Screen",		 0,         as_screen_list,   0, NULL },
     { NULL,                0,           NULL,         0, NULL }
 };
 
@@ -19174,6 +19176,17 @@ const char *assignlinklist(int index, int *list_size)
     return linkmap[index].first.c_str();
 }
 
+const char *assignscreenlist(int index, int *list_size)
+{
+    if(index<0)
+    {
+        *list_size = (int)screenmap.size();
+        return NULL;
+    }
+    
+    return screenmap[index].first.c_str();
+}
+
 const char *assignffcscriptlist(int index, int *list_size)
 {
     if(index<0)
@@ -19251,6 +19264,17 @@ const char *assignlinkscriptlist(int index, int *list_size)
     return aslinkscripts[index].c_str();
 }
 
+const char *assignscreenscriptlist(int index, int *list_size)
+{
+    if(index<0)
+    {
+        *list_size = (int)asscreenscripts.size();
+        return NULL;
+    }
+    
+    return asscreenscripts[index].c_str();
+}
+
 static ListData assignffc_list(assignffclist, &font);
 static ListData assignffcscript_list(assignffcscriptlist, &font);
 static ListData assignglobal_list(assigngloballist, &font);
@@ -19267,6 +19291,9 @@ static ListData assigneweaponscript_list(assigneweaponscriptlist, &font);
 static ListData assignlink_list(assignlinklist, &font);
 static ListData assignlinkscript_list(assignlinkscriptlist, &font);
 
+static ListData assignscreen_list(assignscreenlist, &font);
+static ListData assignscreenscript_list(assignscreenscriptlist, &font);
+	
 static DIALOG assignscript_dlg[] =
 {
     //						x		y		w		h		fg		bg		key	flags	d1	d2	dp
@@ -19281,7 +19308,7 @@ static DIALOG assignscript_dlg[] =
     { jwin_abclist_proc,    10,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignglobal_list, NULL, NULL },
     { jwin_abclist_proc,    174,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignglobalscript_list, NULL, NULL },
     //9
-    { jwin_button_proc,	  154,	93,		15,		10,		vc(14),	vc(1),	0,	D_EXIT,	0,	0,	(void *) "<<", NULL, NULL },
+    { jwin_button_proc,	  154,	93,	15,		10,		vc(14),	vc(1),	0,	D_EXIT,	0,	0,	(void *) "<<", NULL, NULL },
     { jwin_abclist_proc,    10,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignitem_list, NULL, NULL },
     { jwin_abclist_proc,    174,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignitemscript_list, NULL, NULL },
     //12
@@ -19312,6 +19339,11 @@ static DIALOG assignscript_dlg[] =
     { jwin_abclist_proc,    10,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignlink_list, NULL, NULL },
     { jwin_abclist_proc,    174,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignlinkscript_list, NULL, NULL },
     //29
+    { jwin_button_proc,	  154,	93,		15,		10,		vc(14),	vc(1),	0,	D_EXIT,	0,	0,	(void *) "<<", NULL, NULL },
+    //30
+    { jwin_abclist_proc,    10,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignscreen_list, NULL, NULL },
+    { jwin_abclist_proc,    174,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignscreenscript_list, NULL, NULL },
+    //32
     { jwin_button_proc,	  154,	93,		15,		10,		vc(14),	vc(1),	0,	D_EXIT,	0,	0,	(void *) "<<", NULL, NULL },
     
     
@@ -19550,6 +19582,47 @@ static DIALOG linkscript_sel_dlg[] =
     { jwin_button_proc,     35,   132,  61,   21, vc(14),   vc(1),     13,       D_EXIT,     0,             0, (void *) "Load", NULL, NULL },
     { jwin_button_proc,     104,  132,  61,   21, vc(14),   vc(1),     27,       D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
     { jwin_droplist_proc,   26,   45,   146,   16, jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,       0,          1,             0, (void *) &linkscript_sel_dlg_list, NULL, NULL },
+    { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
+    { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
+};
+
+
+
+static char screenscript_str_buf2[32];
+
+const char *screenscriptlist2(int index, int *list_size)
+{
+    if(index>=0)
+    {
+        char buf[20];
+        bound(index,0,254);
+        
+        if(screenmap[index].second=="")
+            strcpy(buf, "<none>");
+        else
+        {
+            strncpy(buf, screenmap[index].second.c_str(), 19);
+            buf[19]='\0';
+        }
+        
+        sprintf(screenscript_str_buf2,"%d: %s",index+1, buf);
+        return screenscript_str_buf2;
+    }
+    
+    *list_size=(NUMSCRIPTSCREEN-1);
+    return NULL;
+}
+
+static ListData screenscript_sel_dlg_list(screenscriptlist2, &font);
+
+static DIALOG screenscript_sel_dlg[] =
+{
+    { jwin_win_proc,        0,    0,    200, 159, vc(14),   vc(1),      0,       D_EXIT,     0,             0, (void *) "Choose Slot And Name", NULL, NULL },
+    { jwin_text_proc,       8,    80,   36,  8,   vc(14),   vc(1),     0,       0,          0,             0, (void *) "Name:", NULL, NULL },
+    { jwin_edit_proc,       44,   80-4, 146, 16,  vc(12),   vc(1),     0,       0,          19,            0,       NULL, NULL, NULL },
+    { jwin_button_proc,     35,   132,  61,   21, vc(14),   vc(1),     13,       D_EXIT,     0,             0, (void *) "Load", NULL, NULL },
+    { jwin_button_proc,     104,  132,  61,   21, vc(14),   vc(1),     27,       D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
+    { jwin_droplist_proc,   26,   45,   146,   16, jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,       0,          1,             0, (void *) &screenscript_sel_dlg_list, NULL, NULL },
     { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
     { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
 };
@@ -20399,6 +20472,26 @@ int onCompileScript()
                     else
                     {
                         linkmap[lind].second = aslinkscripts[rind];
+                    }
+                    
+                    break;
+                }
+		case 32:
+                    //<<, Screendata
+                {
+                    int lind = assignscript_dlg[30].d1;
+                    int rind = assignscript_dlg[31].d1;
+                    
+                    if(lind < 0 || rind < 0)
+                        break;
+                        
+                    if(asscreenscripts[rind] == "<none>")
+                    {
+                        screenmap[lind].second = "";
+                    }
+                    else
+                    {
+                        screenmap[lind].second = asscreenscripts[rind];
                     }
                     
                     break;

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -19081,8 +19081,9 @@ static int as_ffc_list[] = { 4, 5, 6, -1};
 static int as_global_list[] = { 7, 8, 9, -1}; //Why does putting 15 in here not place my message only on the global tab? ~Joe
 static int as_item_list[] = { 10, 11, 12, -1};
 static int as_npc_list[] = { 18, 19, 20, -1}; //npc scripts TAB
-static int as_lweapon_list[] = { 21, 22, 23, -1}; //npc scripts TAB
-static int as_eweapon_list[] = { 24, 25, 26, -1}; //npc scripts TAB
+static int as_lweapon_list[] = { 21, 22, 23, -1}; //lweapon scripts TAB
+static int as_eweapon_list[] = { 24, 25, 26, -1}; //eweapon scripts TAB
+static int as_link_list[] = { 27, 28, 29, -1}; //link scripts TAB
 
 static TABPANEL assignscript_tabs[] =
 {
@@ -19093,6 +19094,7 @@ static TABPANEL assignscript_tabs[] =
     { (char *)"NPC",		 0,         as_npc_list,   0, NULL },
     { (char *)"LWeapon",		 0,         as_lweapon_list,   0, NULL },
     { (char *)"EWeapon",		 0,         as_eweapon_list,   0, NULL },
+    { (char *)"Link",		 0,         as_link_list,   0, NULL },
     { NULL,                0,           NULL,         0, NULL }
 };
 
@@ -19161,6 +19163,17 @@ const char *assigneweaponlist(int index, int *list_size)
     return ewpnmap[index].first.c_str();
 }
 
+const char *assignlinklist(int index, int *list_size)
+{
+    if(index<0)
+    {
+        *list_size = (int)linkmap.size();
+        return NULL;
+    }
+    
+    return linkmap[index].first.c_str();
+}
+
 const char *assignffcscriptlist(int index, int *list_size)
 {
     if(index<0)
@@ -19227,6 +19240,17 @@ const char *assigneweaponscriptlist(int index, int *list_size)
     return aseweaponscripts[index].c_str();
 }
 
+const char *assignlinkscriptlist(int index, int *list_size)
+{
+    if(index<0)
+    {
+        *list_size = (int)aslinkscripts.size();
+        return NULL;
+    }
+    
+    return aslinkscripts[index].c_str();
+}
+
 static ListData assignffc_list(assignffclist, &font);
 static ListData assignffcscript_list(assignffcscriptlist, &font);
 static ListData assignglobal_list(assigngloballist, &font);
@@ -19239,6 +19263,9 @@ static ListData assignlweapon_list(assignlweaponlist, &font);
 static ListData assignlweaponscript_list(assignlweaponscriptlist, &font);
 static ListData assigneweapon_list(assigneweaponlist, &font);
 static ListData assigneweaponscript_list(assigneweaponscriptlist, &font);
+
+static ListData assignlink_list(assignlinklist, &font);
+static ListData assignlinkscript_list(assignlinkscriptlist, &font);
 
 static DIALOG assignscript_dlg[] =
 {
@@ -19280,6 +19307,11 @@ static DIALOG assignscript_dlg[] =
     { jwin_abclist_proc,    10,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assigneweapon_list, NULL, NULL },
     { jwin_abclist_proc,    174,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assigneweaponscript_list, NULL, NULL },
     //26
+    { jwin_button_proc,	  154,	93,		15,		10,		vc(14),	vc(1),	0,	D_EXIT,	0,	0,	(void *) "<<", NULL, NULL },
+    //27
+    { jwin_abclist_proc,    10,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignlink_list, NULL, NULL },
+    { jwin_abclist_proc,    174,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignlinkscript_list, NULL, NULL },
+    //29
     { jwin_button_proc,	  154,	93,		15,		10,		vc(14),	vc(1),	0,	D_EXIT,	0,	0,	(void *) "<<", NULL, NULL },
     
     
@@ -19469,7 +19501,6 @@ const char *eweaponscriptlist2(int index, int *list_size)
     return NULL;
 }
 
-
 static ListData eweaponscript_sel_dlg_list(eweaponscriptlist2, &font);
 
 static DIALOG eweaponscript_sel_dlg[] =
@@ -19483,6 +19514,47 @@ static DIALOG eweaponscript_sel_dlg[] =
     { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
     { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
 };
+
+static char linkscript_str_buf2[32];
+
+const char *linkscriptlist2(int index, int *list_size)
+{
+    if(index>=0)
+    {
+        char buf[20];
+        bound(index,0,254);
+        
+        if(linkmap[index].second=="")
+            strcpy(buf, "<none>");
+        else
+        {
+            strncpy(buf, linkmap[index].second.c_str(), 19);
+            buf[19]='\0';
+        }
+        
+        sprintf(linkscript_str_buf2,"%d: %s",index+1, buf);
+        return linkscript_str_buf2;
+    }
+    
+    *list_size=(NUMSCRIPTLINK-1);
+    return NULL;
+}
+
+static ListData linkscript_sel_dlg_list(linkscriptlist2, &font);
+
+static DIALOG linkscript_sel_dlg[] =
+{
+    { jwin_win_proc,        0,    0,    200, 159, vc(14),   vc(1),      0,       D_EXIT,     0,             0, (void *) "Choose Slot And Name", NULL, NULL },
+    { jwin_text_proc,       8,    80,   36,  8,   vc(14),   vc(1),     0,       0,          0,             0, (void *) "Name:", NULL, NULL },
+    { jwin_edit_proc,       44,   80-4, 146, 16,  vc(12),   vc(1),     0,       0,          19,            0,       NULL, NULL, NULL },
+    { jwin_button_proc,     35,   132,  61,   21, vc(14),   vc(1),     13,       D_EXIT,     0,             0, (void *) "Load", NULL, NULL },
+    { jwin_button_proc,     104,  132,  61,   21, vc(14),   vc(1),     27,       D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
+    { jwin_droplist_proc,   26,   45,   146,   16, jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,       0,          1,             0, (void *) &linkscript_sel_dlg_list, NULL, NULL },
+    { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
+    { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
+};
+
+
 
 
 int onCompileScript()
@@ -20307,6 +20379,26 @@ int onCompileScript()
                     else
                     {
                         ewpnmap[lind].second = aseweaponscripts[rind];
+                    }
+                    
+                    break;
+                }
+		case 29:
+                    //<<, Link
+                {
+                    int lind = assignscript_dlg[27].d1;
+                    int rind = assignscript_dlg[28].d1;
+                    
+                    if(lind < 0 || rind < 0)
+                        break;
+                        
+                    if(aslinkscripts[rind] == "<none>")
+                    {
+                        linkmap[lind].second = "";
+                    }
+                    else
+                    {
+                        linkmap[lind].second = aslinkscripts[rind];
                     }
                     
                     break;

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -18756,11 +18756,23 @@ script_struct biffs[NUMSCRIPTFFC]; //ff script
 int biffs_cnt = -1;
 script_struct biitems[NUMSCRIPTFFC]; //item script
 int biitems_cnt = -1;
-script_struct binpcs[NUMSCRIPTGUYS]; //item script
+script_struct binpcs[NUMSCRIPTGUYS]; //npc script
 int binpcs_cnt = -1;
 
-script_struct bilweapons[NUMSCRIPTWEAPONS]; //item script
+script_struct bilweapons[NUMSCRIPTWEAPONS]; //lweapon script
 int bilweapons_cnt = -1;
+
+script_struct bieweapons[NUMSCRIPTWEAPONS]; //eweapon script
+int bieweapons_cnt = -1;
+
+script_struct bilinks[NUMSCRIPTLINK]; //link script
+int bilinks_cnt = -1;
+
+script_struct biscreens[NUMSCRIPTSCREEN]; //screen (screendata) script
+int biscreens_cnt = -1;
+
+script_struct bidmaps[NUMSCRIPTSDMAP]; //dmap (dmapdata) script
+int bidmaps_cnt = -1;
 //static char ffscript_str_buf[32];
 
 void build_biffs_list()
@@ -18890,6 +18902,178 @@ void build_bilweapons_list()
     for(int i = 0; i < NUMSCRIPTWEAPONS; i++)
         if(bilweapons[i].first.length() > 0)
             bilweapons_cnt = i+1;
+}
+
+//eweapon scripts
+void build_bieweapons_list()
+{
+    bieweapons[0].first = "(None)";
+    bieweapons[0].second = -1;
+    bieweapons_cnt = 1;
+    
+    for(int i = 0; i < NUMSCRIPTWEAPONS - 1; i++)
+    {
+        if(ewpnmap[i].second.length()==0)
+            continue;
+            
+        std::stringstream ss;
+        ss << ewpnmap[i].second << " (" << i+1 << ")"; // The word 'slot' preceding all of the numbers is a bit cluttersome. -L.
+        bieweapons[bieweapons_cnt].first = ss.str();
+        bieweapons[bieweapons_cnt].second = i;
+        bieweapons_cnt++;
+    }
+    
+    // Blank out the rest of the list
+    for(int i=bieweapons_cnt; i<NUMSCRIPTWEAPONS; i++)
+    {
+        bieweapons[i].first="";
+        bieweapons[i].second=-1;
+    }
+    
+    //Bubble sort! (doesn't account for gaps between scripts)
+    for(int i = 0; i < bieweapons_cnt - 1; i++)
+    {
+        for(int j = i + 1; j < bieweapons_cnt; j++)
+        {
+            if(stricmp(bieweapons[i].first.c_str(),bieweapons[j].first.c_str()) > 0 && strcmp(bieweapons[j].first.c_str(),""))
+                zc_swap(bieweapons[i],bieweapons[j]);
+        }
+    }
+    
+    bieweapons_cnt = 0;
+    
+    for(int i = 0; i < NUMSCRIPTWEAPONS; i++)
+        if(bieweapons[i].first.length() > 0)
+            bieweapons_cnt = i+1;
+}
+
+//link scripts
+void build_bilinks_list()
+{
+    bilinks[0].first = "(None)";
+    bilinks[0].second = -1;
+    bilinks_cnt = 1;
+    
+    for(int i = 0; i < NUMSCRIPTLINK - 1; i++)
+    {
+        if(linkmap[i].second.length()==0)
+            continue;
+            
+        std::stringstream ss;
+        ss << linkmap[i].second << " (" << i+1 << ")"; // The word 'slot' preceding all of the numbers is a bit cluttersome. -L.
+        bilinks[bilinks_cnt].first = ss.str();
+        bilinks[bilinks_cnt].second = i;
+        bilinks_cnt++;
+    }
+    
+    // Blank out the rest of the list
+    for(int i=bilinks_cnt; i<NUMSCRIPTLINK; i++)
+    {
+        bilinks[i].first="";
+        bilinks[i].second=-1;
+    }
+    
+    //Bubble sort! (doesn't account for gaps between scripts)
+    for(int i = 0; i < bilinks_cnt - 1; i++)
+    {
+        for(int j = i + 1; j < bilinks_cnt; j++)
+        {
+            if(stricmp(bilinks[i].first.c_str(),bilinks[j].first.c_str()) > 0 && strcmp(bilinks[j].first.c_str(),""))
+                zc_swap(bilinks[i],bilinks[j]);
+        }
+    }
+    
+    bilinks_cnt = 0;
+    
+    for(int i = 0; i < NUMSCRIPTLINK; i++)
+        if(bilinks[i].first.length() > 0)
+            bilinks_cnt = i+1;
+}
+
+//dmap scripts
+void build_bidmaps_list()
+{
+    bidmaps[0].first = "(None)";
+    bidmaps[0].second = -1;
+    bidmaps_cnt = 1;
+    
+    for(int i = 0; i < NUMSCRIPTSDMAP - 1; i++)
+    {
+        if(dmapmap[i].second.length()==0)
+            continue;
+            
+        std::stringstream ss;
+        ss << dmapmap[i].second << " (" << i+1 << ")"; // The word 'slot' preceding all of the numbers is a bit cluttersome. -L.
+        bidmaps[bidmaps_cnt].first = ss.str();
+        bidmaps[bidmaps_cnt].second = i;
+        bidmaps_cnt++;
+    }
+    
+    // Blank out the rest of the list
+    for(int i=bidmaps_cnt; i<NUMSCRIPTSDMAP; i++)
+    {
+        bidmaps[i].first="";
+        bidmaps[i].second=-1;
+    }
+    
+    //Bubble sort! (doesn't account for gaps between scripts)
+    for(int i = 0; i < bidmaps_cnt - 1; i++)
+    {
+        for(int j = i + 1; j < bidmaps_cnt; j++)
+        {
+            if(stricmp(bidmaps[i].first.c_str(),bidmaps[j].first.c_str()) > 0 && strcmp(bidmaps[j].first.c_str(),""))
+                zc_swap(bidmaps[i],bidmaps[j]);
+        }
+    }
+    
+    bidmaps_cnt = 0;
+    
+    for(int i = 0; i < NUMSCRIPTSDMAP; i++)
+        if(bidmaps[i].first.length() > 0)
+            bidmaps_cnt = i+1;
+}
+
+//screen scripts
+void build_biscreens_list()
+{
+    biscreens[0].first = "(None)";
+    biscreens[0].second = -1;
+    biscreens_cnt = 1;
+    
+    for(int i = 0; i < NUMSCRIPTSCREEN - 1; i++)
+    {
+        if(screenmap[i].second.length()==0)
+            continue;
+            
+        std::stringstream ss;
+        ss << screenmap[i].second << " (" << i+1 << ")"; // The word 'slot' preceding all of the numbers is a bit cluttersome. -L.
+        biscreens[biscreens_cnt].first = ss.str();
+        biscreens[biscreens_cnt].second = i;
+        biscreens_cnt++;
+    }
+    
+    // Blank out the rest of the list
+    for(int i=biscreens_cnt; i<NUMSCRIPTSCREEN; i++)
+    {
+        biscreens[i].first="";
+        biscreens[i].second=-1;
+    }
+    
+    //Bubble sort! (doesn't account for gaps between scripts)
+    for(int i = 0; i < biscreens_cnt - 1; i++)
+    {
+        for(int j = i + 1; j < biscreens_cnt; j++)
+        {
+            if(stricmp(biscreens[i].first.c_str(),biscreens[j].first.c_str()) > 0 && strcmp(biscreens[j].first.c_str(),""))
+                zc_swap(biscreens[i],biscreens[j]);
+        }
+    }
+    
+    biscreens_cnt = 0;
+    
+    for(int i = 0; i < NUMSCRIPTSCREEN; i++)
+        if(biscreens[i].first.length() > 0)
+            biscreens_cnt = i+1;
 }
 
 

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -19084,7 +19084,8 @@ static int as_npc_list[] = { 18, 19, 20, -1}; //npc scripts TAB
 static int as_lweapon_list[] = { 21, 22, 23, -1}; //lweapon scripts TAB
 static int as_eweapon_list[] = { 24, 25, 26, -1}; //eweapon scripts TAB
 static int as_link_list[] = { 27, 28, 29, -1}; //link scripts TAB
-static int as_screen_list[] = { 30, 31, 32, -1}; //link scripts TAB
+static int as_screen_list[] = { 30, 31, 32, -1}; //screendata scripts TAB
+static int as_dmap_list[] = { 33, 34, 35, -1}; //dmapdata scripts TAB
 
 static TABPANEL assignscript_tabs[] =
 {
@@ -19096,6 +19097,7 @@ static TABPANEL assignscript_tabs[] =
     { (char *)"LWeapon",		 0,         as_lweapon_list,   0, NULL },
     { (char *)"EWeapon",		 0,         as_eweapon_list,   0, NULL },
     { (char *)"Link",		 0,         as_link_list,   0, NULL },
+    { (char *)"DMap",		 0,         as_dmap_list,   0, NULL },
     { (char *)"Screen",		 0,         as_screen_list,   0, NULL },
     { NULL,                0,           NULL,         0, NULL }
 };
@@ -19174,6 +19176,17 @@ const char *assignlinklist(int index, int *list_size)
     }
     
     return linkmap[index].first.c_str();
+}
+
+const char *assigndmaplist(int index, int *list_size)
+{
+    if(index<0)
+    {
+        *list_size = (int)dmapmap.size();
+        return NULL;
+    }
+    
+    return dmapmap[index].first.c_str();
 }
 
 const char *assignscreenlist(int index, int *list_size)
@@ -19264,6 +19277,17 @@ const char *assignlinkscriptlist(int index, int *list_size)
     return aslinkscripts[index].c_str();
 }
 
+const char *assigndmapscriptlist(int index, int *list_size)
+{
+    if(index<0)
+    {
+        *list_size = (int)asdmapscripts.size();
+        return NULL;
+    }
+    
+    return asdmapscripts[index].c_str();
+}
+
 const char *assignscreenscriptlist(int index, int *list_size)
 {
     if(index<0)
@@ -19290,6 +19314,9 @@ static ListData assigneweaponscript_list(assigneweaponscriptlist, &font);
 
 static ListData assignlink_list(assignlinklist, &font);
 static ListData assignlinkscript_list(assignlinkscriptlist, &font);
+
+static ListData assigndmap_list(assigndmaplist, &font);
+static ListData assigndmapscript_list(assigndmapscriptlist, &font);
 
 static ListData assignscreen_list(assignscreenlist, &font);
 static ListData assignscreenscript_list(assignscreenscriptlist, &font);
@@ -19344,6 +19371,11 @@ static DIALOG assignscript_dlg[] =
     { jwin_abclist_proc,    10,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignscreen_list, NULL, NULL },
     { jwin_abclist_proc,    174,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assignscreenscript_list, NULL, NULL },
     //32
+    { jwin_button_proc,	  154,	93,		15,		10,		vc(14),	vc(1),	0,	D_EXIT,	0,	0,	(void *) "<<", NULL, NULL },
+    //33
+    { jwin_abclist_proc,    10,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assigndmap_list, NULL, NULL },
+    { jwin_abclist_proc,    174,	45,		136,	105,	jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,0,0, 0, (void *)&assigndmapscript_list, NULL, NULL },
+    //35
     { jwin_button_proc,	  154,	93,		15,		10,		vc(14),	vc(1),	0,	D_EXIT,	0,	0,	(void *) "<<", NULL, NULL },
     
     
@@ -19563,6 +19595,16 @@ const char *linkscriptlist2(int index, int *list_size)
             strncpy(buf, linkmap[index].second.c_str(), 19);
             buf[19]='\0';
         }
+	
+	if(index==0)
+            sprintf(linkscript_str_buf2,"Init: %s", buf);
+            
+        if(index==1)
+            sprintf(linkscript_str_buf2,"Active: %s", buf);
+	
+	if(index==2)
+            sprintf(linkscript_str_buf2,"Death: %s", buf);
+            
         
         sprintf(linkscript_str_buf2,"%d: %s",index+1, buf);
         return linkscript_str_buf2;
@@ -19582,6 +19624,46 @@ static DIALOG linkscript_sel_dlg[] =
     { jwin_button_proc,     35,   132,  61,   21, vc(14),   vc(1),     13,       D_EXIT,     0,             0, (void *) "Load", NULL, NULL },
     { jwin_button_proc,     104,  132,  61,   21, vc(14),   vc(1),     27,       D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
     { jwin_droplist_proc,   26,   45,   146,   16, jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,       0,          1,             0, (void *) &linkscript_sel_dlg_list, NULL, NULL },
+    { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
+    { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
+};
+
+
+static char dmapscript_str_buf2[32];
+
+const char *dmapscriptlist2(int index, int *list_size)
+{
+    if(index>=0)
+    {
+        char buf[20];
+        bound(index,0,254);
+        
+        if(dmapmap[index].second=="")
+            strcpy(buf, "<none>");
+        else
+        {
+            strncpy(buf, dmapmap[index].second.c_str(), 19);
+            buf[19]='\0';
+        }
+        
+        sprintf(dmapscript_str_buf2,"%d: %s",index+1, buf);
+        return dmapscript_str_buf2;
+    }
+    
+    *list_size=(NUMSCRIPTSDMAP-1);
+    return NULL;
+}
+
+static ListData dmapscript_sel_dlg_list(dmapscriptlist2, &font);
+
+static DIALOG dmapscript_sel_dlg[] =
+{
+    { jwin_win_proc,        0,    0,    200, 159, vc(14),   vc(1),      0,       D_EXIT,     0,             0, (void *) "Choose Slot And Name", NULL, NULL },
+    { jwin_text_proc,       8,    80,   36,  8,   vc(14),   vc(1),     0,       0,          0,             0, (void *) "Name:", NULL, NULL },
+    { jwin_edit_proc,       44,   80-4, 146, 16,  vc(12),   vc(1),     0,       0,          19,            0,       NULL, NULL, NULL },
+    { jwin_button_proc,     35,   132,  61,   21, vc(14),   vc(1),     13,       D_EXIT,     0,             0, (void *) "Load", NULL, NULL },
+    { jwin_button_proc,     104,  132,  61,   21, vc(14),   vc(1),     27,       D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
+    { jwin_droplist_proc,   26,   45,   146,   16, jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],  0,       0,          1,             0, (void *) &dmapscript_sel_dlg_list, NULL, NULL },
     { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
     { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
 };
@@ -20492,6 +20574,26 @@ int onCompileScript()
                     else
                     {
                         screenmap[lind].second = asscreenscripts[rind];
+                    }
+                    
+                    break;
+                }
+		case 35:
+                    //<<, Screendata
+                {
+                    int lind = assignscript_dlg[33].d1;
+                    int rind = assignscript_dlg[34].d1;
+                    
+                    if(lind < 0 || rind < 0)
+                        break;
+                        
+                    if(asdmapscripts[rind] == "<none>")
+                    {
+                        dmapmap[lind].second = "";
+                    }
+                    else
+                    {
+                        dmapmap[lind].second = asdmapscripts[rind];
                     }
                     
                     break;

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -19586,7 +19586,7 @@ const char *linkscriptlist2(int index, int *list_size)
     if(index>=0)
     {
         char buf[20];
-        bound(index,0,254);
+        bound(index,0,3);
         
         if(linkmap[index].second=="")
             strcpy(buf, "<none>");
@@ -19606,7 +19606,7 @@ const char *linkscriptlist2(int index, int *list_size)
             sprintf(linkscript_str_buf2,"Death: %s", buf);
             
         
-        sprintf(linkscript_str_buf2,"%d: %s",index+1, buf);
+        //sprintf(linkscript_str_buf2,"%d: %s",index+1, buf);
         return linkscript_str_buf2;
     }
     

--- a/src/zquest.h
+++ b/src/zquest.h
@@ -520,6 +520,26 @@ void build_bilweapons_list();
 extern script_struct bilweapons[NUMSCRIPTWEAPONS]; //item script
 extern int bilweapons_cnt;
 
+//eweapon script list for editors
+void build_bieweapons_list();
+extern script_struct bieweapons[NUMSCRIPTWEAPONS]; //item script
+extern int bieweapons_cnt;
+
+//link script list for editors
+void build_bilinks_list();
+extern script_struct bilinks[NUMSCRIPTLINK]; //item script
+extern int bilinks_cnt;
+
+//screen script list for editors
+void build_biscreens_list();
+extern script_struct biscreens[NUMSCRIPTSCREEN]; //item script
+extern int biscreens_cnt;
+
+//dmap script list for editors
+void build_bidmaps_list();
+extern script_struct bidmaps[NUMSCRIPTSDMAP]; //item script
+extern int bidmaps_cnt;
+
 //extern script_struct biffs[NUMSCRIPTFFC];
 
 typedef struct command_struct

--- a/src/zquest.h
+++ b/src/zquest.h
@@ -517,7 +517,7 @@ extern int binpcs_cnt;
 
 //lweapon script list for editors
 void build_bilweapons_list();
-extern script_struct bilweapons[NUMSCRIPTGUYS]; //item script
+extern script_struct bilweapons[NUMSCRIPTWEAPONS]; //item script
 extern int bilweapons_cnt;
 
 //extern script_struct biffs[NUMSCRIPTFFC];


### PR DESCRIPTION

Changelog: Added the following script types to the 'Compile ZScript' dialogue in ZQuest:
eweapon, link, dmapdata (DMap), screendata (Screen)

You can compile all of these, and assign them to slots.

Installed Link scripts into ZC, and expanded their number.

They work in a similar manner to global scripts, and may call Waitdraw().
At present, these are the viable slots:
Init (1)
Active (2)
onDeath (3)
onWin (4)

Slots 1, 3 and 4 can run for only one frame at this time.