### PR TITLE
Add EWeapon Scripts

### DIFF
--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -14969,15 +14969,41 @@ int run_script(const byte type, const word script, const long i)
 	    //}
 	    //break;
 	    
+	    //case SCRIPT_EWPN:
+	    //{
+	//		ri = &(eweaponScriptData[i]);
+	//		curscript = ewpnscripts[script];
+	//		stack = &(Ewpns.spr(EwpnH::getEWeaponIndex(ri->ewpn))->stack);
+	//		ri->ewpn = i; //'this' pointer
+	    //}
+	    //break;
+	    
 	    case SCRIPT_EWPN:
 	    {
-			ri = &(eweaponScriptData[i]);
-			curscript = ewpnscripts[script];
-			stack = &(Ewpns.spr(EwpnH::getEWeaponIndex(ri->ewpn))->stack);
-			ri->ewpn = i; //'this' pointer
+			int ewpn_index = EwpnH::getEWeaponIndex(i);
+			//ri = &(lweaponScriptData[i]);
+			weapon *w = (weapon*)Ewpns.spr(ewpn_index);
+			ri = w->refinfo;
+			if (!ri) {
+			  ri = w->refinfo = new refInfo;
+			}
+			curscript = ewpnscripts[Ewpns.spr(EwpnH::getEWeaponIndex(i))->weaponscript];
+			
+			
+			stack = &(Ewpns.spr(EwpnH::getEWeaponIndex(i))->stack);
+			
+			weapon *wa = (weapon*)Ewpns.spr(EwpnH::getEWeaponIndex(i));
+			ri->ewpn = wa->getUID();
+			
+			for ( int q = 0; q < 8; q++ ) 
+			{
+				
+				ri->d[q] = Ewpns.spr(EwpnH::getEWeaponIndex(i))->weap_initd[q]; //w->initiald[q];
+			}
+			
 	    }
 	    break;
-		    
+	    
 	    case SCRIPT_ITEM:
 	    {
 		ri = &(itemScriptData[i]);
@@ -17075,10 +17101,19 @@ int run_script(const byte type, const word script, const long i)
 			
 			//Lwpns.spr(i)->doscript = 0;
 			//Lwpns.spr(i)->weaponscript = 0;
-			Z_scripterrlog("Cleaning up a script weapon, ID: %d\n",i);
-			Z_scripterrlog("Cleaning up a script weapon, ri->lwpn: %d\n",ri->lwpn);
+			//Z_scripterrlog("Cleaning up a script weapon, ID: %d\n",i);
+			//Z_scripterrlog("Cleaning up a script weapon, ri->lwpn: %d\n",ri->lwpn);
 			Lwpns.spr(LwpnH::getLWeaponIndex(i))->doscript = 0;
 			Lwpns.spr(LwpnH::getLWeaponIndex(i))->weaponscript = 0;
+			
+			//w->weaponscript = 0;
+			break;
+		}
+		case SCRIPT_EWPN:
+		{
+		
+			Ewpns.spr(EwpnH::getEWeaponIndex(i))->doscript = 0;
+			Ewpns.spr(EwpnH::getEWeaponIndex(i))->weaponscript = 0;
 			
 			//w->weaponscript = 0;
 			break;
@@ -19674,6 +19709,426 @@ bool FFScript::itemScriptEngine()
 	
 	return false;
 }
+
+void FFScript::eweaponScriptEngine()
+{
+	for ( int q = 0; q < Ewpns.Count(); q++ )
+	{
+		//ri->ewpn = Ewpns.spr(q)->getUID();
+		//Z_scripterrlog("lweaponScriptEngine(): UID (%d) ri->ewpn (%d)\n", Ewpns.spr(q)->getUID(), ri->ewpn);
+		//ri->ewpn = Ewpns.spr(q)->getUID();
+		weapon *wp = (weapon*)Ewpns.spr(q);
+		if ( wp->Dead() ) continue;
+		if ( Ewpns.spr(q)->weaponscript == 0 ) continue;
+		if ( Ewpns.spr(q)->doscript == 0 ) continue;
+		switch(Ewpns.spr(q)->id)
+		{
+		    case ewSword:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					//memset(w->stack, 0xFFFF, sizeof(w->stack));
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);		
+					ri->ewpn = w->getUID();
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());		
+				}
+			}
+			break;
+		    }
+		
+		    
+		    case ewFlame:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());
+					ri->ewpn = w->getUID();
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+				}
+			}
+			break;
+		    }
+		    
+		    
+		    case ewSBomb:
+		    case ewBomb:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());
+					ri->ewpn = w->getUID();
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+				}
+			}
+			break;
+		    }
+		    
+		    case ewLitBomb:
+		    case ewLitSBomb:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());
+					ri->ewpn = w->getUID();
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+				}
+			}
+			break;
+		    }
+		    
+		    case ewArrow:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);	
+					ri->ewpn = w->getUID();					
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());		
+				}
+			}
+			
+			break;
+		    }
+		    
+		    case ewRock:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+				    //al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+				    //ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+				    //ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+				    //ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);	
+				    ri->ewpn = w->getUID();
+				    ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());		
+				}
+			}
+			break;
+		    }
+		    case ewBrang:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);		
+					ri->ewpn = w->getUID();
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());		
+				}
+			}
+		
+			
+			break;
+		    }
+		    
+		    case ewMagic:
+		    {
+			//:Weapon Only
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);	
+					ri->ewpn = w->getUID();
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());		
+				}
+			}
+			break;
+		    }
+		    
+		    case ewFireball:
+		    case ewFireball2:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 && wa->ScriptGenerated ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);	
+					ri->ewpn = w->getUID();
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());		
+				}
+			}
+			break;
+		    }
+		    
+		    case ewFireTrail:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 && wa->ScriptGenerated ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);	
+					ri->ewpn = w->getUID();
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());		
+				}
+			}
+			break;
+		    }
+		    case ewWind:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 && wa->ScriptGenerated ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);	
+					ri->ewpn = w->getUID();
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());		
+				}
+			}
+			break;
+		    } 
+		    case ewFlame2:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 && wa->ScriptGenerated ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);	
+					ri->ewpn = w->getUID();
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());		
+				}
+			}
+			break;
+		    } 
+		    case ewFlame2Trail:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 && wa->ScriptGenerated ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);	
+					ri->ewpn = w->getUID();
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());		
+				}
+			}
+			break;
+		    }
+		    
+		    case ewIce:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 && wa->ScriptGenerated ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);	
+					ri->ewpn = w->getUID();
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());		
+				}
+			}
+			break;
+		    }
+		    case wScript1:
+		    case wScript2:
+		    case wScript3:
+		    case wScript4:
+		    case wScript5:
+		    case wScript6:
+		    case wScript7:
+		    case wScript8:
+		    case wScript9:
+		    case wScript10:
+		    {
+			weapon *wa = (weapon*)Ewpns.spr(q);
+			//if ( wa->Dead() ) break;
+			if ( Ewpns.spr(q)->doscript && Ewpns.spr(q)->weaponscript > 0 ) 
+			{
+				weapon *w = (weapon*)Ewpns.spr(q);
+				if ( w->Dead() )
+				{
+					Ewpns.spr(q)->doscript = 0;
+					Ewpns.spr(q)->weaponscript = 0;
+					break;
+				}
+				else
+				{
+					//al_trace("Found an lweapon index of: %d, when trying to run an lweapon script.\n",w_index);
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, index);		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, Ewpns.spr(q)->getUID());		
+					//ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, ri->ewpn);	
+					ri->ewpn = w->getUID();
+					ZScriptVersion::RunScript(SCRIPT_EWPN, Ewpns.spr(q)->weaponscript, w->getUID());		
+				}
+			}
+			break;
+		    }
+		    default: break;
+		}
+	}
+}
+
 
 int FFScript::getTime(int type)
 {

--- a/src/ffscript.h
+++ b/src/ffscript.h
@@ -161,6 +161,7 @@ long getQuestHeaderInfo(int type);
 void clearRunningItemScripts();
 bool itemScriptEngine();
 void lweaponScriptEngine();
+void eweaponScriptEngine();
 bool newScriptEngine();
 
 /*

--- a/src/guys.cpp
+++ b/src/guys.cpp
@@ -368,15 +368,21 @@ enemy::enemy(fix X,fix Y,int Id,int Clk) : sprite()
     for ( int q = 0; q < 32; q++ ) new_weapon[q] = d->new_weapon[q];
     
     script = (d->script >= 0) ? d->script : 0; //Dont assign invalid data. 
+    weaponscript = (d->weaponscript >= 0) ? d->weaponscript : 0; //Dont assign invalid data. 
     
     for ( int q = 0; q < 8; q++ ) 
     {
 	    initD[q] = d->initD[q];
+	    weap_initiald[q] = d->weap_initiald[q];
 	    //al_trace("Guys.cpp: Assigning guy.initD[%d]: %d\n",q, d->initD.initD[q]);
 	    //al_trace("Guys.cpp: Assigning guy.initD[%d] from d->initD[%d]: %d\n",q,q, d->initD[q]);
 	    //al_trace("Guys.cpp: guy.initD[%d] is: %d\n",q, initD[q]);
     }
-    for ( int q = 0; q < 2; q++ ) initA[q] = d->initA[q];
+    for ( int q = 0; q < 2; q++ ) 
+    {
+	    initA[q] = d->initA[q];
+	    weap_initiala[q] = d->weap_initiala[q];
+    }
     
     dialogue_str = 0; //set by spawn flags. 
     editorflags = d->editorflags; //set by Enemy Editor 

--- a/src/guys.h
+++ b/src/guys.h
@@ -100,6 +100,9 @@ public:
     long new_weapon[32]; //Reserved for weapon patterns and args.
     word npcscript; 
     long initD[8], initA[2];
+    word weaponscript;
+    long weap_initiald[8];
+    long weap_initiala[2];
     
     long dialogue_str; //WIll be set in spawn flags. 
     long editorflags; //Enemy editor flags 1 to 16

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -10406,8 +10406,17 @@ int readguys(PACKFILE *f, zquestheader *Header, bool keepdata)
 			sprintf(tempguy.weapon_initD_label[q],"InitD[%d]",q);
 		}
 	    }
-	    
-	    
+	    if ( guyversion >= 40 )
+	    {
+		    if(!p_igetw(&(tempguy.weaponscript),f,keepdata))
+		    {
+				return qe_invalid;
+		    } 
+	    }
+	    if ( guyversion < 40 ) 
+	    {
+		    tempguy.weaponscript = 0;
+	    }
 	    //All ports of QRs to Enemy Editor Flags go HERE! -Z
 	    
 	    

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -254,13 +254,25 @@ weapon::weapon(weapon const & other):
 	//End Weapon editor non-arrays. 
 
 {
-	if ( parentitem > -1 ) 
+	if ( parentitem > -1 ) //lweapons
 	{
 		
 		weaponscript = itemsbuf[parentitem].weaponscript; //Set the weapon script based on the item editor data.
 		for ( int q = 0; q < INITIAL_D; q++ ) 
 		{
 			weap_initd[q] = itemsbuf[parentitem].weap_initiald[q];
+			
+		}
+		
+	}
+	if ( parentid > -1 ) //eweapons
+	{
+		Z_scripterrlog("weapons.cpp created an eweapon with a parentid of: %d\n",parentid);
+		Z_scripterrlog("THat weapon should have a script of: %d\n",guysbuf[parentid].weaponscript);
+		weaponscript = guysbuf[parentid].weaponscript; //Set the weapon script based on the item editor data.
+		for ( int q = 0; q < INITIAL_D; q++ ) 
+		{
+			weap_initd[q] = guysbuf[parentid].weap_initiald[q];
 			
 		}
 		
@@ -423,6 +435,16 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
     if ( Parentitem > -1 )
     {
 	weaponscript = itemsbuf[Parentitem].weaponscript;
+    }
+    if ( prntid > -1 )
+    {
+	//Z_scripterrlog("Eweapon created with a prntid of: %d\n",prntid);
+	enemy *s = (enemy *)guys.getByUID(prntid);
+	//int parent_enemy_id = 0;
+	//parent_enemy_id = s->id & 0xFFF;
+	//Z_scripterrlog("The enemy ID that created it was: %d\n",s->id & 0xFFF);
+	//weaponscript = guysbuf[prntid].weaponscript;
+	weaponscript = guysbuf[s->id & 0xFFF].weaponscript;
     }
     
     tilemod = 0;

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -191,7 +191,7 @@ enum {ENC_METHOD_192B104=0, ENC_METHOD_192B105, ENC_METHOD_192B185, ENC_METHOD_2
 #define V_ICONS            10 //Game Icons
 #define V_GRAPHICSPACK     1
 #define V_INITDATA        19
-#define V_GUYS            39
+#define V_GUYS            40
 #define V_MIDIS            4
 #define V_CHEATS           1
 #define V_SAVEGAME        12
@@ -1641,7 +1641,8 @@ struct item_drop_object
 #define guyflagOVERRIDE_DRAW_Y_OFFSET	0x00000100
 #define guyflagOVERRIDE_DRAW_Z_OFFSET	0x00000200
 
-#define MAX_NPC_ATRIBUTES 15
+#define MAX_NPC_ATRIBUTES 31
+
 
 struct guydata
 {
@@ -1699,6 +1700,10 @@ struct guydata
     char initD_label[8][65];
     char weapon_initD_label[8][65];
     
+    word weaponscript;
+    long weap_initiald[INITIAL_D];
+    byte weap_initiala[INITIAL_A];
+    
 #define ENEMY_FLAG1   0x01
 #define ENEMY_FLAG2   0x02
 #define ENEMY_FLAG3     0x04
@@ -1717,6 +1722,7 @@ struct guydata
 #define ENEMY_FLAG16     0x8000
     
 };
+
 
 class refInfo
 {

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -2841,6 +2841,7 @@ void game_loop()
 	al_trace("game_loop is calling: %s\n", "Ewpns.animate()\n");
 	#endif
         Ewpns.animate();
+	FFCore.eweaponScriptEngine();
 	#if LOGGAMELOOP > 0
 	al_trace("game_loop is setting: %s\n", "checklink=true()\n");
 	#endif

--- a/src/zq_class.cpp
+++ b/src/zq_class.cpp
@@ -9906,6 +9906,10 @@ int writeguys(PACKFILE *f, zquestheader *Header)
 				} 
 			}
 	    }
+	    if(!p_iputw(guysbuf[i].weaponscript,f))
+            {
+                new_return(97);
+            }
 		
         }
         

--- a/src/zq_custom.cpp
+++ b/src/zq_custom.cpp
@@ -3051,6 +3051,9 @@ static int enemy_scripts_list[] =
 
 static int enemy_weapon_scripts_list[] =
 {
+	353,354,355,356,357,358,359,360,
+	361,362,363,364,365,366,367,368,
+	369,370,
 	-1
 };
 static int enemy_movement_list[] =
@@ -4617,6 +4620,20 @@ static ListData enetype_list(enetypelist, &font);
 static ListData eweapon_list(eweaponlist, &font);
 
 
+const char *eweaponscriptdroplist(int index, int *list_size)
+{
+    if(index<0)
+    {
+        *list_size = bieweapons_cnt;
+        return NULL;
+    }
+    
+    return bieweapons[index].first.c_str();
+}
+
+
+//droplist like the dialog proc, naming scheme for this stuff is awful...
+static ListData eweaponscript_list(eweaponscriptdroplist, &pfont);
 
 
 static ListData walkerspawn_list(walkerspawnlist, &font);
@@ -5293,6 +5310,7 @@ static DIALOG enedata_dlg[] =
     //{ jwin_text_proc,       6+10,  10+155+20,   24,    12,   0,        0,       0,       0,          0,             0, (void *) "D7:", NULL, NULL },
     
     //editable npc script InitD fields
+    //337
     {  jwin_edit_proc,         6+10,     10+29+20,    90,     16,    vc(12),                 vc(1),                   0,    0,          63,    0,  NULL,                                                           NULL,   NULL                 },
     {  jwin_edit_proc,         6+10,     10+47+20,    90,     16,    vc(12),                 vc(1),                   0,    0,          63,    0,  NULL,                                                           NULL,   NULL                 },
     {  jwin_edit_proc,         6+10,     10+65+20,    90,     16,    vc(12),                 vc(1),                   0,    0,          63,    0,  NULL,                                                           NULL,   NULL                 },
@@ -5312,6 +5330,7 @@ static DIALOG enedata_dlg[] =
     //{ jwin_edit_proc,       6+10,  10+155+20,   90,    16,   0,        0,       0,       0,          0,             0, 64, NULL, NULL },
    
     //NPC InitD Data fields
+    //345
     { jwin_edit_proc,      (90-24)+34+10,   10+29+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
     { jwin_edit_proc,      (90-24)+34+10,   10+47+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
     { jwin_edit_proc,      (90-24)+34+10,   10+65+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
@@ -5320,6 +5339,27 @@ static DIALOG enedata_dlg[] =
     { jwin_edit_proc,      (90-24)+34+10,  10+119+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
     { jwin_edit_proc,      (90-24)+34+10,  10+137+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
     { jwin_edit_proc,      (90-24)+34+10,  10+155+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    //353
+    {  jwin_edit_proc,         6+10,     10+29+20,    90,     16,    vc(12),                 vc(1),                   0,    0,          63,    0,  NULL,                                                           NULL,   NULL                 },
+    {  jwin_edit_proc,         6+10,     10+47+20,    90,     16,    vc(12),                 vc(1),                   0,    0,          63,    0,  NULL,                                                           NULL,   NULL                 },
+    {  jwin_edit_proc,         6+10,     10+65+20,    90,     16,    vc(12),                 vc(1),                   0,    0,          63,    0,  NULL,                                                           NULL,   NULL                 },
+    {  jwin_edit_proc,         6+10,     10+83+20,    90,     16,    vc(12),                 vc(1),                   0,    0,          63,    0,  NULL,                                                           NULL,   NULL                 },
+    {  jwin_edit_proc,         6+10,     10+101+20,    90,     16,    vc(12),                 vc(1),                   0,    0,          63,    0,  NULL,                                                           NULL,   NULL                 },
+    {  jwin_edit_proc,         6+10,     10+119+20,    90,     16,    vc(12),                 vc(1),                   0,    0,          63,    0,  NULL,                                                           NULL,   NULL                 },
+    {  jwin_edit_proc,         6+10,     10+137+20,    90,     16,    vc(12),                 vc(1),                   0,    0,          63,    0,  NULL,                                                           NULL,   NULL                 },
+    {  jwin_edit_proc,         6+10,     10+155+20,    90,     16,    vc(12),                 vc(1),                   0,    0,          63,    0,  NULL,                                                           NULL,   NULL                 },
+    
+    { jwin_edit_proc,      (90-24)+34+10,   10+29+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      (90-24)+34+10,   10+47+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      (90-24)+34+10,   10+65+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      (90-24)+34+10,   10+83+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      (90-24)+34+10,   10+101+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      (90-24)+34+10,  10+119+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      (90-24)+34+10,  10+137+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    { jwin_edit_proc,      (90-24)+34+10,  10+155+20,   72-16,    16,   vc(12),   vc(1),   0,       0,          12,             0,       NULL, NULL, NULL },
+    
+    { jwin_text_proc,           112+10+20+34+1-4,  10+29+12+7,     35,      8,    vc(14),                 vc(1),                   0,       0,           0,    0, (void *) "EWeapon Script:",                      NULL,   NULL                  },
+    { jwin_droplist_proc,       112+10+20+34-4,  10+29+20+7,     140,      16, jwin_pal[jcTEXTFG],  jwin_pal[jcTEXTBG],           0,       0,           1,    0, (void *) &eweaponscript_list,                   NULL,   NULL 				   },
     
     /*
 	  // 248 scripts
@@ -5578,6 +5618,8 @@ void edit_enemydata(int index)
     char enemynumstr[75];
     char hitx[8], hity[8], hitz[8], tiley[8], tilex[8], hitofsx[8], hitofsy[8], hitofsz[8], drawofsx[8], drawofsy[8];
 	char weapsprite[8]; char npc_initd_labels[8][65];
+	char weapon_initd_labels[8][65];
+	char weap_initdvals[8][13];
     
 	char initdvals[8][13];
     //begin npc script
@@ -5591,6 +5633,16 @@ void edit_enemydata(int index)
         }
     }
     
+    int j2 = 0; 
+    build_bieweapons_list(); //lweapon scripts lister
+    for(j2 = 0; j2 < bieweapons_cnt; j2++)
+    {
+		if(bieweapons[j2].second == guysbuf[index].weaponscript -1)
+		{
+			enedata_dlg[370].d1 = j2; 
+			break;
+		}
+    }
     
     for ( int q = 0; q < 8; q++ )
     {
@@ -5602,10 +5654,27 @@ void edit_enemydata(int index)
     
     for ( int q = 0; q < 8; q++ )
     {
+	    
+		sprintf(weap_initdvals[q],"%.4f",guysbuf[index].weap_initiald[q]/10000.0);
+	 
+		enedata_dlg[361+q].dp = weap_initdvals[q];
+    }
+    
+    for ( int q = 0; q < 8; q++ )
+    {
 	//al_trace("Enemy Editor: InitD[%d] string for the npc is: %s\n", q, guysbuf[index].initD_label[q]);
 	strcpy(npc_initd_labels[q], guysbuf[index].initD_label[q]);
 	enedata_dlg[337+q].dp = npc_initd_labels[q];
 	//sprintf();
+	    
+    }
+    
+    for ( int q = 0; q < 8; q++ )
+    {
+		//al_trace("Enemy Editor: InitD[%d] string for the npc is: %s\n", q, guysbuf[index].initD_label[q]);
+		strcpy(weapon_initd_labels[q], guysbuf[index].weapon_initD_label[q]);
+		enedata_dlg[353+q].dp = weapon_initd_labels[q];
+		//sprintf();
 	    
     }
 
@@ -6244,7 +6313,13 @@ void edit_enemydata(int index)
 	{
 		test.initD[q] = vbound(atoi(initdvals[q])*10000,-2147483647, 2147483647);
 	}
-	
+	//eweapon script
+	test.weaponscript = bieweapons[enedata_dlg[370].d1].second + 1; 
+	for ( int q = 0; q < 8; q++ )
+	{
+		test.weap_initiald[q] = vbound(atoi(weap_initdvals[q])*10000,-2147483647, 2147483647);
+		strcpy(test.weapon_initD_label[q], weapon_initd_labels[q]);
+	}
 	 
 	
         //end npc scripts


### PR DESCRIPTION

Changelog: Added EWeapon Scripts to ZQuest and to the ZC Player

Added vars to npcs for the weaponscript,m the initD, and for the InitA.
Added the Enemy Editor dialogue data to set the script and the script InitD.
Added the code to transfer data from the guys struct to the weapon, when the weapon is generated.
Added the script control code in ffscript.cpp.