### PR TITLE
Fix Link Scripts and LWeapon Crashes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,16 @@
 
 //Alpha 8
 
+Link's onDeath script, and Link's onWin script, can both run
+	for multiple frames.
+Fix when Link's Init script runs.
+	It now runs after Link.init(), but before setting his entry points
+	and before the opening wipe.
+	This ensures that any changes that the init script executes,
+	such as setting Link->Invisible, aren't seen by the player;
+	and that Screen->EntryX, and Screen->EntryY have the correct
+	coordinates at the start of the game, if Link's init script sets these.
+
 If the user clears an initD label to a blank link, it will reset to 
 	the default value of 'InitD[%d]'.
 Added DMap scripts, in entirety.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,13 @@
 //2.55 and 2.54 Changes
 
-//Alpha 8
-
+//Alpha 9
+Fixed crashes when creating lweapons, caused by trying to read
+	enemy* for parentID of lweapons (weapon scriot read for eweapon scripts).
+Fixed Link Death and Win scripts to run at the proper times.
 Link's onDeath script, and Link's onWin script, can both run
 	for multiple frames.
+
+//Alpha 8
 Fix when Link's Init script runs.
 	It now runs after Link.init(), but before setting his entry points
 	and before the opening wipe.

--- a/src/ending.cpp
+++ b/src/ending.cpp
@@ -212,9 +212,9 @@ void ending()
     chainlinks.clear();
     decorations.clear();
     
-    music_stop();
+    
     kill_sfx();
-    sfx(WAV_ZELDA);
+    
     Quit=0;
     //do
 	//{
@@ -238,6 +238,7 @@ void ending()
 		ZScriptVersion::RunScript(SCRIPT_LINK, SCRIPT_LINK_WIN);
 		--f; load_control_state(); goto adv;
 	}
+	if ( f == 0 ) { sfx(WAV_ZELDA); music_stop(); }
         if(f==363)
         {
             //363  WIPE complete, DOT out, A/B items out

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -4202,7 +4202,7 @@ case SCREENCATCH:
 	    //Z_scripterrlog("GetLinkExtend rid->[1] is (%i), trying to use for '%s'\n", state, "state");
 	    //Z_scripterrlog("GetLinkExtend rid->[0] is (%i), trying to use for '%s'\n", dir, "dir");
 	
-		Lwpns.add(new weapon((fix)0,(fix)0,(fix)0,ID,0,0,0,itemid,false,1,Link.getUID()));
+		Lwpns.add(new weapon((fix)0,(fix)0,(fix)0,ID,0,0,0,itemid,false,1,Link.getUID(),1));
 		ri->lwpn = Lwpns.spr(Lwpns.Count() - 1)->getUID();
 		
 		/* Z_scripterrlog("CreateLWeaponDx ri->d[0] is (%i), trying to use for '%s'\n", ID, "ID");
@@ -13441,7 +13441,7 @@ void do_createlweapon(const bool v)
     if(BC::checkWeaponID(ID, "Screen->CreateLWeapon") != SH::_NoError)
         return;
         
-    Lwpns.add(new weapon((fix)0,(fix)0,(fix)0,ID,0,0,0,-1,false,1,Link.getUID()));
+    Lwpns.add(new weapon((fix)0,(fix)0,(fix)0,ID,0,0,0,-1,false,1,Link.getUID(),1));
 		
     //addLwpn(0, 0, 0, ID, 0, 0, 0, Link.getUID());
     

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -4376,6 +4376,25 @@ bool LinkClass::animate(int)
 	    //initLinkScripts();
 	    //ZScriptVersion::RunScript(SCRIPT_LINK, SCRIPT_LINK_DEATH);
 	    //if ( link_doscript ) { last_hurrah = false; return false; }
+		initLinkScripts(); //Get ready to run his death script.
+		int fc = 0;
+		BITMAP *subscrbmp = create_bitmap_ex(8, framebuf->w, framebuf->h);
+				clear_bitmap(subscrbmp);
+		do
+		{
+			if ( link_doscript ) 
+			{
+				ZScriptVersion::RunScript(SCRIPT_LINK, SCRIPT_LINK_WIN);
+				load_control_state(); 
+				
+			}
+			draw_screen(tmpscr);
+			blit(subscrbmp,framebuf,0,0,0,0,256,passive_subscreen_height);
+			advanceframe(true);
+			if (!link_doscript ) ++fc;
+			
+		}
+		while(fc < 1 );
             gameover();
             
             return true;
@@ -15882,25 +15901,25 @@ void LinkClass::gameover()
 	int f=0;
     
 	action=none; FFCore.setLinkAction(dying); //mayhaps a new action of 'gameover'? -Z
-	initLinkScripts(); //Get ready to run his death script.
+	
 	kill_sfx();  //call before the onDeath script.
 	
-	do
-	{
+	//do
+	//{
 		
-		ZScriptVersion::RunScript(SCRIPT_LINK, SCRIPT_LINK_DEATH);
-		FFCore.Waitframe();
-	}while(link_doscript);
+	//	ZScriptVersion::RunScript(SCRIPT_LINK, SCRIPT_LINK_DEATH);
+	//	FFCore.Waitframe();
+	//}while(link_doscript);
 	//ZScriptVersion::RunScript(SCRIPT_LINK, SCRIPT_LINK_DEATH);
 	//while(link_doscript) { advanceframe(true); } //Not safe. The script runs for only one frame at present.
 	
-	Playing=false;
+	//Playing=false;
     
 	if(!debug_enabled)
 	{
 		Paused=false;
 	}
-    
+    /*
 	game->set_deaths(zc_min(game->get_deaths()+1,999));
 	dir=down;
 	music_stop();
@@ -15910,14 +15929,7 @@ void LinkClass::gameover()
     
 	for(int i=0; i<32; i++) miscellaneous[i] = 0;
     
-	//get rid off all sprites but Link
-	guys.clear();
-	items.clear();
-	Ewpns.clear();
-	Lwpns.clear();
-	Sitems.clear();
-	chainlinks.clear();
-	decorations.clear();
+	
     
 	playing_field_offset=56; // otherwise, red_shift() may go past the bottom of the screen
 	quakeclk=wavy=0;
@@ -15935,9 +15947,66 @@ void LinkClass::gameover()
 	clear_bitmap(subscrbmp);
 	put_passive_subscr(subscrbmp, &QMisc, 0, passive_subscreen_offset, false, sspUP);
 	QMisc.colors.link_dot = tmp_link_dot;
+    */
     
+	BITMAP *subscrbmp = create_bitmap_ex(8, framebuf->w, framebuf->h);
+				clear_bitmap(subscrbmp);
+				//get rid off all sprites but Link
+				guys.clear();
+				items.clear();
+				Ewpns.clear();
+				Lwpns.clear();
+				Sitems.clear();
+				chainlinks.clear();
+				decorations.clear();
+				Playing = false;
+					
+				game->set_deaths(zc_min(game->get_deaths()+1,999));
+				dir=down;
+				music_stop();
+				
+				attackclk=hclk=superman=0;
+				scriptcoldet = 1;
+			    
+				for(int i=0; i<32; i++) miscellaneous[i] = 0;
+			    
+				
+			    
+				playing_field_offset=56; // otherwise, red_shift() may go past the bottom of the screen
+				quakeclk=wavy=0;
+			    
+				//in original Z1, Link marker vanishes at death.
+				//code in subscr.cpp, put_passive_subscr checks the following value.
+				//color 255 is a GUI color, so quest makers shouldn't be using this value.
+				//Also, subscreen is static after death in Z1.
+				int tmp_link_dot = QMisc.colors.link_dot;
+				QMisc.colors.link_dot = 255;
+				//doesn't work
+				//scrollbuf is tampered with by draw_screen()
+				//put_passive_subscr(scrollbuf, &QMisc, 256, passive_subscreen_offset, false, false);//save this and reuse it.
+				
+				put_passive_subscr(subscrbmp, &QMisc, 0, passive_subscreen_offset, false, sspUP);
+				QMisc.colors.link_dot = tmp_link_dot;
+        bool clearedit = false;
 	do
 	{
+		//if ( link_doscript ) 
+		//{
+		//	ZScriptVersion::RunScript(SCRIPT_LINK, SCRIPT_LINK_WIN);
+			//if ( f ) --f; 
+		//	load_control_state(); //goto adv;
+		//}
+		//else
+		//{
+		//	if ( !clearedit )
+		//	{
+				
+				
+		//		clearedit = true;
+				
+		//	}
+		//}
+		//else Playing = false;
 		if(f<254)
 		{
 			if(f<=32)
@@ -16180,9 +16249,10 @@ void LinkClass::gameover()
 			sfx(WAV_MSG);
 			break;
 		}
-        
+		//adv:
 		advanceframe(true);
 		++f;
+		//if (!link_doscript ) ++f;
 	}
 	while(f<353 && !Quit);
     

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -436,7 +436,9 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
     {
 	weaponscript = itemsbuf[Parentitem].weaponscript;
     }
-    if ( prntid > -1 )
+    
+    if ( isLW ) goto skip_eweapon_script;
+    if ( prntid > -1 && prntid != Link.getUID()  ) //eweapon scripts
     {
 	//Z_scripterrlog("Eweapon created with a prntid of: %d\n",prntid);
 	enemy *s = (enemy *)guys.getByUID(prntid);
@@ -446,7 +448,7 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
 	//weaponscript = guysbuf[prntid].weaponscript;
 	weaponscript = guysbuf[s->id & 0xFFF].weaponscript;
     }
-    
+    skip_eweapon_script:
     tilemod = 0;
     drawlayer = 0;
     family_class = family_level = 0;

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -99,11 +99,11 @@
 #define ZC_VERSION 25500 //Version ID for ZScript Game->Version
 #define VERSION_BUILD       41                              //build number of this version
 //31 == 2.53.0 , leaving 32-39 for bugfixes, and jumping to 40. 
-#define ZELDA_VERSION_STR   "AEternal (v2.55) Alpha 8"                    //version of the program as presented in text
-#define IS_BETA             -8                         //is this a beta? (1: beta, -1: alpha)
-#define VERSION_BETA        8
+#define ZELDA_VERSION_STR   "AEternal (v2.55) Alpha 9"                    //version of the program as presented in text
+#define IS_BETA             -9                         //is this a beta? (1: beta, -1: alpha)
+#define VERSION_BETA        9
 #define DATE_STR            "20th December, 2018"
-#define ZELDA_ABOUT_STR 	    "ZC Player 'AEternal', Alpha 8"
+#define ZELDA_ABOUT_STR 	    "ZC Player 'AEternal', Alpha 9"
 #define COPYRIGHT_YEAR      "2018"                          //shown on title screen and in ending
 
 #define MIN_VERSION         0x0184


### PR DESCRIPTION

Changelog: 
Fixed crashes when creating lweapons, caused by trying to read
	enemy* for parentID of lweapons (weapon scriot read for eweapon scripts).
Fixed Link Death and Win scripts to run at the proper times.
Link's onDeath script, and Link's onWin script, can both run
	for multiple frames.
Version is now Alpha 9