### PR TITLE
Add Emulation Menu

### DIFF
--- a/src/link.h
+++ b/src/link.h
@@ -33,6 +33,7 @@
 #include "zc_custom.h"
 #include "subscr.h"
 
+
 extern movingblock mblock2;                                 //mblock[4]?
 extern sprite_list  guys, items, Ewpns, Lwpns, Sitems, chainlinks, decorations;
 

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -80,6 +80,9 @@ bool mapsread=false;
 bool fixffcs=false;
 bool fixpolsvoice=false;
 
+word quest_header_zelda_version = 0; //2.53 ONLY. In 2.55, we have an array for this in FFCore! -Z
+word quest_header_zelda_build = 0; //2.53 ONLY. In 2.55, we have an array for this in FFCore! -Z
+
 int memDBGwatch[8]= {0,0,0,0,0,0,0,0}; //So I can monitor memory crap
 
 //enum { qe_OK, qe_notfound, qe_invalid, qe_version, qe_obsolete,
@@ -325,6 +328,8 @@ int get_version_and_build(PACKFILE *f, word *version, word *build)
     memcpy(midi_flags, temp_midi_flags, MIDIFLAGS_SIZE);
     *version=tempheader.zelda_version;
     *build=tempheader.build;
+    quest_header_zelda_version = tempheader.zelda_version;
+    quest_header_zelda_build = tempheader.build;
     return 0;
 }
 
@@ -2064,7 +2069,8 @@ int readheader(PACKFILE *f, zquestheader *Header, bool keepdata)
         cvs_MD5Init(&ctx);
         cvs_MD5Update(&ctx, (const unsigned char*)temp_pwd2, (unsigned)strlen(temp_pwd2));
         cvs_MD5Final(tempheader.pwd_hash, &ctx);
-        
+	
+	
         if(tempheader.zelda_version < 0x177)                       // lacks new header stuff...
         {
             //memset(tempheader.minver,0,20);                          //   char minver[9], byte build, byte foo[10]
@@ -2322,6 +2328,10 @@ int readheader(PACKFILE *f, zquestheader *Header, bool keepdata)
         map_count=temp_map_count;
         memcpy(midi_flags, temp_midi_flags, MIDIFLAGS_SIZE);
     }
+    
+    quest_header_zelda_version = tempheader.zelda_version;
+    quest_header_zelda_build = tempheader.build;
+        
     
     return 0;
 }

--- a/src/zc_sys.cpp
+++ b/src/zc_sys.cpp
@@ -68,6 +68,10 @@ byte midi_patch_fix;
 bool midi_paused=false;
 extern int cheat_modifier_keys[4]; //two options each, default either control and either shift
 
+
+extern word quest_header_zelda_version; //2.53 ONLY. In 2.55, we have an array for this in FFCore! -Z
+extern word quest_header_zelda_build; //2.53 ONLY. In 2.55, we have an array for this in FFCore! -Z
+
 //extern movingblock mblock2; //mblock[4]?
 //extern int db;
 
@@ -6931,7 +6935,7 @@ int on192b163compatibility()
 
 static MENU compat_patch_menu[] =
 {
-    { (char *)"1.92b163 Warps",                     on192b163compatibility,                 NULL,                      0, NULL },
+    { (char *)"Flip-Flop Cancel and Wave Warps",                     on192b163compatibility,                 NULL,                      0, NULL },
     { NULL,                                 NULL,                    NULL,                      0, NULL }
 };
 
@@ -7050,7 +7054,7 @@ MENU the_menu[] =
     { (char *)"&Game",                      NULL,                    game_menu,                 0, NULL },
     { (char *)"&Settings",                  NULL,                    settings_menu,             0, NULL },
     { (char *)"&Cheat",                     NULL,                    cheat_menu,                0, NULL },
-    { (char *)"&Compatibility",                      NULL,                    compat_patch_menu,                 0, NULL },
+    { (char *)"&Emulation",                      NULL,                    compat_patch_menu,                 0, NULL },
     { (char *)"&Misc",                      NULL,                    misc_menu,                 0, NULL },
     
     { NULL,                                 NULL,                    NULL,                      0, NULL }
@@ -7060,7 +7064,7 @@ MENU the_menu2[] =
 {
     { (char *)"&Game",                      NULL,                    game_menu,                 0, NULL },
     { (char *)"&Settings",                  NULL,                    settings_menu,             0, NULL },
-    { (char *)"&Compatibility",                      NULL,                    compat_patch_menu,                 0, NULL },
+    { (char *)"&Emulation",                      NULL,                    compat_patch_menu,                 0, NULL },
     { (char *)"&Misc",                      NULL,                    misc_menu,                 0, NULL },
     { NULL,                                 NULL,                    NULL,                      0, NULL }
 };
@@ -8007,8 +8011,11 @@ void System()
         name_entry_mode_menu[1].flags = (NameEntryMode==1)?D_SELECTED:0;
         name_entry_mode_menu[2].flags = (NameEntryMode==2)?D_SELECTED:0;
 	//menu flags here
+	al_trace("Quest was made in: %d\n",quest_header_zelda_version);
 	
-	compat_patch_menu[0].flags =(zc_192b163_compatibility)?D_SELECTED:0;
+	compat_patch_menu[0].flags = ( quest_header_zelda_version >= 0x210 ) ? D_DISABLED : ((zc_192b163_compatibility)?D_SELECTED:0);
+	
+	//compat_patch_menu[0].flags =(zc_192b163_compatibility)?D_SELECTED:0;
 	misc_menu[12].flags =(zconsole)?D_SELECTED:0;
         
         /*

--- a/src/zc_sys.cpp
+++ b/src/zc_sys.cpp
@@ -8011,7 +8011,7 @@ void System()
         name_entry_mode_menu[1].flags = (NameEntryMode==1)?D_SELECTED:0;
         name_entry_mode_menu[2].flags = (NameEntryMode==2)?D_SELECTED:0;
 	//menu flags here
-	al_trace("Quest was made in: %d\n",quest_header_zelda_version);
+	//al_trace("Quest was made in: %d\n",quest_header_zelda_version);
 	
 	compat_patch_menu[0].flags = ( quest_header_zelda_version >= 0x210 ) ? D_DISABLED : ((zc_192b163_compatibility)?D_SELECTED:0);
 	

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -96,6 +96,8 @@ int passive_subscreen_height=56;
 int original_playing_field_offset=56;
 int playing_field_offset=original_playing_field_offset;
 int passive_subscreen_offset=0;
+extern word quest_header_zelda_version; //2.53 ONLY. In 2.55, we have an array for this in FFCore! -Z
+extern word quest_header_zelda_build; //2.53 ONLY. In 2.55, we have an array for this in FFCore! -Z
 extern int directItem;
 extern int directItemA;
 extern int directItemB;

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -159,6 +159,8 @@ int zq_scale_small, zq_scale_large, zq_scale;
 bool halt=false;
 bool show_sprites=true;
 bool show_hitboxes = false;
+extern word quest_header_zelda_version; //2.53 ONLY. In 2.55, we have an array for this in FFCore! -Z
+extern word quest_header_zelda_build; //2.53 ONLY. In 2.55, we have an array for this in FFCore! -Z
 
 // Used to find FFC script names
 extern std::map<int, pair<string,string> > ffcmap;


### PR DESCRIPTION

Changelog: Added a new menu to ZC 'Emulation'.

This menu is for settings that the player may want to, or may need to enable on a per-quest basis, during play; and that the player may also need to enable or disable during play as a toggle.

For the most part, it'll cover issues where a bug was fixed, but some quests may need/rely on that bug. 

Further, i discovered that the quest header for 1.92 quests contains 'build' metadata, so we may bve able to use that after all. 