### PR TITLE
2.55 parser ternary working except untyped resolution

### DIFF
--- a/src/parser/AST.cpp
+++ b/src/parser/AST.cpp
@@ -1487,6 +1487,48 @@ optional<long> ASTExprRShift::getCompileTimeValue(
 	return ((*leftValue / 10000L) >> (*rightValue / 10000L)) * 10000L;
 }
 
+// ASTTernaryExpr
+
+ASTTernaryExpr::ASTTernaryExpr(ASTExpr* left, ASTExpr* middle, ASTExpr* right,
+							 LocationData const& location)
+	: ASTExpr(location), left(left), middle(middle), right(right)
+{}
+
+bool ASTTernaryExpr::isConstant() const
+{
+	if (left && !left->isConstant()) return false;
+	if (middle && !middle->isConstant()) return false;
+	if (right && !right->isConstant()) return false;
+	return true;
+}
+
+void ASTTernaryExpr::execute(ASTVisitor& visitor, void* param)
+{
+	visitor.caseExprTernary(*this, param);
+}
+
+optional<long> ASTTernaryExpr::getCompileTimeValue(
+		CompileErrorHandler* errorHandler)
+		const
+{
+	if (!left || !middle || !right) return nullopt;
+	optional<long> leftValue = left->getCompileTimeValue(errorHandler);
+	if (!leftValue) return nullopt;
+	optional<long> middleValue = middle->getCompileTimeValue(errorHandler);
+	optional<long> rightValue = right->getCompileTimeValue(errorHandler);
+	
+	if(*leftValue)
+	{
+		if(!middleValue) return nullopt;
+		return *middleValue;
+	}
+	else
+	{
+		if (!rightValue) return nullopt;
+		return *rightValue;
+	}
+}
+
 ////////////////////////////////////////////////////////////////
 // Literals
 

--- a/src/parser/AST.h
+++ b/src/parser/AST.h
@@ -1402,7 +1402,7 @@ namespace ZScript
 		owning_ptr<ASTExpr> middle;
 		owning_ptr<ASTExpr> right;
 
-		DataType const* getReadType() const {return &DataType::UNTYPED;}
+		DataType const* getReadType() const {return middle->getReadType();}
 		DataType const* getWriteType() const {return NULL;}
 	};
 

--- a/src/parser/AST.h
+++ b/src/parser/AST.h
@@ -119,6 +119,7 @@ namespace ZScript
 	class ASTShiftExpr; // virtual
 	class ASTExprLShift;
 	class ASTExprRShift;
+	class ASTTernaryExpr;
 	// Literals
 	class ASTLiteral; // virtual
 	class ASTNumberLiteral;
@@ -1378,6 +1379,28 @@ namespace ZScript
 		optional<long> getCompileTimeValue(
 				CompileErrorHandler* errorHandler = NULL)
 				const;
+	};
+	
+	class ASTTernaryExpr : public ASTExpr
+	{
+	public:
+		ASTTernaryExpr(ASTExpr* left = NULL,
+		              ASTExpr* middle = NULL,
+		              ASTExpr* right = NULL,
+		              LocationData const& location = LocationData::NONE);
+		ASTTernaryExpr* clone() const {return new ASTTernaryExpr(*this);};
+
+		bool isConstant() const;
+
+		void execute(ASTVisitor& visitor, void* param = NULL);
+
+		optional<long> getCompileTimeValue(
+				CompileErrorHandler* errorHandler = NULL)
+				const;
+
+		owning_ptr<ASTExpr> left;
+		owning_ptr<ASTExpr> middle;
+		owning_ptr<ASTExpr> right;
 	};
 
 	// Literals

--- a/src/parser/AST.h
+++ b/src/parser/AST.h
@@ -1401,6 +1401,9 @@ namespace ZScript
 		owning_ptr<ASTExpr> left;
 		owning_ptr<ASTExpr> middle;
 		owning_ptr<ASTExpr> right;
+
+		DataType const* getReadType() const {return &DataType::UNTYPED;}
+		DataType const* getWriteType() const {return NULL;}
 	};
 
 	// Literals

--- a/src/parser/ASTVisitors.cpp
+++ b/src/parser/ASTVisitors.cpp
@@ -413,6 +413,15 @@ void RecursiveVisitor::caseExprRShift(ASTExprRShift& host, void* param)
 	visit(host.right.get(), param);
 }
 
+void RecursiveVisitor::caseExprTernary(ASTTernaryExpr& host, void* param)
+{
+	visit(host.left.get(), param);
+	if (breakRecursion(host, param)) return;
+	visit(host.middle.get(), param);
+	if (breakRecursion(host, param)) return;
+	visit(host.right.get(), param);
+}
+
 // Literals
 
 void RecursiveVisitor::caseNumberLiteral(ASTNumberLiteral& host, void* param)

--- a/src/parser/ASTVisitors.h
+++ b/src/parser/ASTVisitors.h
@@ -137,6 +137,8 @@ namespace ZScript
 			caseDefault(host, param);}
 		virtual void caseExprRShift(ASTExprRShift& host, void* param = NULL) {
 			caseDefault(host, param);}
+		virtual void caseExprTernary(ASTTernaryExpr& host, void* param = NULL) {
+			caseDefault(host, param);}
 		// Literals
 		virtual void caseNumberLiteral(
 				ASTNumberLiteral& host, void* param = NULL) {
@@ -257,6 +259,7 @@ namespace ZScript
 		virtual void caseExprBitXor(ASTExprBitXor& host, void* param = NULL);
 		virtual void caseExprLShift(ASTExprLShift& host, void* param = NULL);
 		virtual void caseExprRShift(ASTExprRShift& host, void* param = NULL);
+		virtual void caseExprTernary(ASTTernaryExpr& host, void* param = NULL);
 		// Literals
 		virtual void caseNumberLiteral(
 				ASTNumberLiteral& host, void* param = NULL);

--- a/src/parser/BuildVisitors.h
+++ b/src/parser/BuildVisitors.h
@@ -68,6 +68,7 @@ namespace ZScript
 		virtual void caseExprBitXor(ASTExprBitXor &host, void *param);
 		virtual void caseExprLShift(ASTExprLShift &host, void *param);
 		virtual void caseExprRShift(ASTExprRShift &host, void *param);
+		virtual void caseExprTernary(ASTTernaryExpr &host, void *param);
 		// Literals
 		virtual void caseNumberLiteral(ASTNumberLiteral& host, void* param);
 		virtual void caseBoolLiteral(ASTBoolLiteral& host, void* param);

--- a/src/parser/SemanticAnalyzer.cpp
+++ b/src/parser/SemanticAnalyzer.cpp
@@ -900,6 +900,23 @@ void SemanticAnalyzer::caseExprRShift(ASTExprRShift& host, void*)
 	analyzeBinaryExpr(host, DataType::FLOAT, DataType::FLOAT);
 }
 
+void SemanticAnalyzer::caseExprTernary(ASTTernaryExpr& host, void*)
+{
+	visit(host.left.get());
+	if (breakRecursion(host)) return;
+	checkCast(*host.left->getReadType(), DataType::BOOL, &host);
+	if (breakRecursion(host)) return;
+	
+	visit(host.middle.get());
+	if (breakRecursion(host)) return;
+	visit(host.right.get());
+	if (breakRecursion(host)) return;
+	checkCast(*host.middle->getReadType(), *host.right->getReadType(), &host);
+	if (breakRecursion(host)) return;
+	checkCast(*host.right->getReadType(), *host.middle->getReadType(), &host);
+	if (breakRecursion(host)) return;
+}
+
 // Literals
 
 void SemanticAnalyzer::caseStringLiteral(ASTStringLiteral& host, void*)

--- a/src/parser/SemanticAnalyzer.h
+++ b/src/parser/SemanticAnalyzer.h
@@ -74,6 +74,7 @@ namespace ZScript
 		void caseExprBitXor(ASTExprBitXor& host, void* = NULL);
 		void caseExprLShift(ASTExprLShift& host, void* = NULL);
 		void caseExprRShift(ASTExprRShift& host, void* = NULL);
+		void caseExprTernary(ASTTernaryExpr& host, void* = NULL);
 		// Literals
 		void caseStringLiteral(ASTStringLiteral& host, void* = NULL);
 		void caseArrayLiteral(ASTArrayLiteral& host, void* = NULL);

--- a/src/parser/ffscript.lpp
+++ b/src/parser/ffscript.lpp
@@ -126,6 +126,7 @@ link	TOKEN( LINK );
 "]"		TOKEN( RBRACKET );
 "{"		TOKEN( LBRACE );
 "}"		TOKEN( RBRACE );
+"?"		TOKEN( QMARK ); //for ternary
 
  /* Operators (in order of operations) */
 "->"		TOKEN( ARROW );

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -862,37 +862,48 @@ Expr_14 : Expr_13 {$$ = $1;}
 	// Logical Or
 	| Expr_14 OR Expr_13 {BINARY(ASTExprOr, $$, $1, $3, @$)}
 	;
-
+	
 Expr_15 : Expr_14 {$$ = $1;}
+	//Ternary
+	| Expr_15 QMARK Expr_14 COLON Expr_14
+	{
+		ASTExpr* left = (ASTExpr*)$1;
+		ASTExpr* middle = (ASTExpr*)$3;
+		ASTExpr* right = (ASTExpr*)$5;
+		$$ = new ASTTernaryExpr(left, middle, right, @$);
+	}
+	;
+
+Expr_16 : Expr_15 {$$ = $1;}
 	// Assignment
-	| Expr_14 ASSIGN Expr_15 {BINARY(ASTExprAssign, $$, $1, $3, @$)}
+	| Expr_15 ASSIGN Expr_16 {BINARY(ASTExprAssign, $$, $1, $3, @$)}
 	// Addition Assignment
-	| Expr_14 PLUSASSIGN Expr_15 {SHORTCUT(ASTExprPlus, $$, $1, $3, @$, @3)}
+	| Expr_15 PLUSASSIGN Expr_16 {SHORTCUT(ASTExprPlus, $$, $1, $3, @$, @3)}
 	// Subtraction Assignment
-	| Expr_14 MINUSASSIGN Expr_15 {SHORTCUT(ASTExprMinus, $$, $1, $3, @$, @3)}
+	| Expr_15 MINUSASSIGN Expr_16 {SHORTCUT(ASTExprMinus, $$, $1, $3, @$, @3)}
 	// Multiplication Assignment
-	| Expr_14 TIMESASSIGN Expr_15 {SHORTCUT(ASTExprTimes, $$, $1, $3, @$, @3)}
+	| Expr_15 TIMESASSIGN Expr_16 {SHORTCUT(ASTExprTimes, $$, $1, $3, @$, @3)}
 	// Division Assignment
-	| Expr_14 DIVIDEASSIGN Expr_15 {SHORTCUT(ASTExprDivide, $$, $1, $3, @$, @3)}
+	| Expr_15 DIVIDEASSIGN Expr_16 {SHORTCUT(ASTExprDivide, $$, $1, $3, @$, @3)}
 	// Modulus Assignment
-	| Expr_14 MODULOASSIGN Expr_15 {SHORTCUT(ASTExprModulo, $$, $1, $3, @$, @3)}
+	| Expr_15 MODULOASSIGN Expr_16 {SHORTCUT(ASTExprModulo, $$, $1, $3, @$, @3)}
 	// Left Shift Assignment
-	| Expr_14 LSHIFTASSIGN Expr_15 {SHORTCUT(ASTExprLShift, $$, $1, $3, @$, @3)}
+	| Expr_15 LSHIFTASSIGN Expr_16 {SHORTCUT(ASTExprLShift, $$, $1, $3, @$, @3)}
 	// Right Shift Assignment
-	| Expr_14 RSHIFTASSIGN Expr_15 {SHORTCUT(ASTExprRShift, $$, $1, $3, @$, @3)}
+	| Expr_15 RSHIFTASSIGN Expr_16 {SHORTCUT(ASTExprRShift, $$, $1, $3, @$, @3)}
 	// Bitwise And Assignment
-	| Expr_14 BITANDASSIGN Expr_15 {SHORTCUT(ASTExprBitAnd, $$, $1, $3, @$, @3)}
+	| Expr_15 BITANDASSIGN Expr_16 {SHORTCUT(ASTExprBitAnd, $$, $1, $3, @$, @3)}
 	// Bitwise Xor Assignment
-	| Expr_14 BITXORASSIGN Expr_15 {SHORTCUT(ASTExprBitXor, $$, $1, $3, @$, @3)}
+	| Expr_15 BITXORASSIGN Expr_16 {SHORTCUT(ASTExprBitXor, $$, $1, $3, @$, @3)}
 	// Bitwise Or Assignment
-	| Expr_14 BITORASSIGN Expr_15 {SHORTCUT(ASTExprBitOr, $$, $1, $3, @$, @3)}
+	| Expr_15 BITORASSIGN Expr_16 {SHORTCUT(ASTExprBitOr, $$, $1, $3, @$, @3)}
 	// Logical And Assignment
-	| Expr_14 ANDASSIGN Expr_15 {SHORTCUT(ASTExprAnd, $$, $1, $3, @$, @3)}
+	| Expr_15 ANDASSIGN Expr_16 {SHORTCUT(ASTExprAnd, $$, $1, $3, @$, @3)}
 	// Logical Or Assignment
-	| Expr_14 ORASSIGN Expr_15 {SHORTCUT(ASTExprOr, $$, $1, $3, @$, @3)}
+	| Expr_15 ORASSIGN Expr_16 {SHORTCUT(ASTExprOr, $$, $1, $3, @$, @3)}
 		 ;
 
-Expression : Expr_15 {$$ = $1;};
+Expression : Expr_16 {$$ = $1;};
 
 Expression_Constant :
 	Expression {

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -148,6 +148,7 @@ extern YYLTYPE noloc;
 %token RBRACKET
 %token LBRACE
 %token RBRACE
+%token QMARK
 
  // Operators
 %token ARROW

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -865,7 +865,7 @@ Expr_14 : Expr_13 {$$ = $1;}
 	
 Expr_15 : Expr_14 {$$ = $1;}
 	//Ternary
-	| Expr_15 QMARK Expr_14 COLON Expr_14
+	| Expr_14 QMARK Expr_15 COLON Expr_15
 	{
 		ASTExpr* left = (ASTExpr*)$1;
 		ASTExpr* middle = (ASTExpr*)$3;


### PR DESCRIPTION
If the middle is untyped, and the right is not, the right becomes untyped. Aside from this, no issues noted.