### PR TITLE
Parser: Constant complete overhaul

### DIFF
--- a/src/parser/SemanticAnalyzer.cpp
+++ b/src/parser/SemanticAnalyzer.cpp
@@ -299,7 +299,7 @@ void SemanticAnalyzer::caseDataDecl(ASTDataDecl& host, void*)
 
 	// Is it a constant?
 	bool isConstant = false;
-	if (type == DataType::CONST_FLOAT)
+	if (type.isConstant())
 	{
 		// A constant without an initializer doesn't make sense.
 		if (!host.getInitializer())
@@ -504,7 +504,7 @@ void SemanticAnalyzer::caseExprAssign(ASTExprAssign& host, void*)
 	checkCast(*rtype, *ltype, &host);
 	if (breakRecursion(host)) return;	
 
-	if (*ltype == DataType::CONST_FLOAT)
+	if (ltype->isConstant())
 		handleError(CompileError::LValConst(&host, host.left->asString()));
 	if (breakRecursion(host)) return;	
 }
@@ -523,7 +523,7 @@ void SemanticAnalyzer::caseExprIdentifier(
 	// Can't write to a constant.
 	if (param == paramWrite || param == paramReadWrite)
 	{
-		if (host.binding->type == DataType::CONST_FLOAT)
+		if (host.binding->type.isConstant())
 		{
 			handleError(CompileError::LValConst(&host, host.asString()));
 			return;
@@ -708,7 +708,9 @@ void SemanticAnalyzer::caseExprCall(ASTExprCall& host, void*)
 			DataType const& from = getBaseType(*parameterTypes[i]);
 			DataType const& to = getBaseType(*function.paramTypes[i]);
 			if (from == to) continue;
-			if (from == DataType::CONST_FLOAT && to == DataType::FLOAT)
+			if ((from == DataType::CFLOAT && to == DataType::FLOAT)
+				|| (from == DataType::CBOOL && to == DataType::BOOL)
+				|| (from == DataType::CUNTYPED && to == DataType::UNTYPED))
 				continue;
 			++castCount;
 		}

--- a/src/parser/Types.cpp
+++ b/src/parser/Types.cpp
@@ -128,6 +128,9 @@ DataTypeSimple const DataType::UNTYPED(ZVARTYPEID_UNTYPED, "untyped");
 DataTypeSimple const DataType::ZVOID(ZVARTYPEID_VOID, "void");
 DataTypeSimple const DataType::FLOAT(ZVARTYPEID_FLOAT, "float");
 DataTypeSimple const DataType::BOOL(ZVARTYPEID_BOOL, "bool");
+DataTypeSimpleConst const DataType::CFLOAT(ZVARTYPEID_FLOAT, "const float");
+DataTypeSimpleConst const DataType::CBOOL(ZVARTYPEID_BOOL, "const bool");
+DataTypeSimpleConst const DataType::CUNTYPED(ZVARTYPEID_UNTYPED, "const untyped");
 DataTypeArray const DataType::STRING(FLOAT);
 DataTypeClass const DataType::GAME(ZCLASSID_GAME, "Game");
 DataTypeClass const DataType::LINK(ZCLASSID_LINK, "Link");
@@ -163,7 +166,7 @@ DataTypeClass const DataType::TUNES(ZCLASSID_TUNES, "Tunes");
 DataTypeClass const DataType::PALCYCLE(ZCLASSID_PALCYCLE, "PalCycle");
 DataTypeClass const DataType::GAMEDATA(ZCLASSID_GAMEDATA, "GameData");
 DataTypeClass const DataType::CHEATS(ZCLASSID_CHEATS, "Cheats");
-DataTypeConstFloat const DataType::CONST_FLOAT;
+//DataTypeConstFloat const DataType::CONST_FLOAT;
 
 ////////////////////////////////////////////////////////////////
 // DataType
@@ -185,7 +188,7 @@ DataType const* DataType::get(DataTypeId id)
 	case ZVARTYPEID_VOID: return &ZVOID;
 	case ZVARTYPEID_FLOAT: return &FLOAT;
 	case ZVARTYPEID_BOOL: return &BOOL;
-	case ZVARTYPEID_CONST_FLOAT: return &CONST_FLOAT;
+	//case ZVARTYPEID_CONST_FLOAT: return &CONST_FLOAT;
 	case ZVARTYPEID_GAME: return &GAME;
 	case ZVARTYPEID_LINK: return &LINK;
 	case ZVARTYPEID_SCREEN: return &SCREEN;
@@ -255,7 +258,10 @@ bool ZScript::operator>=(DataType const& lhs, DataType const& rhs)
 
 DataType const& ZScript::getNaiveType(DataType const& type)
 {
-	if (type == DataType::CONST_FLOAT) return DataType::FLOAT;
+	//Convert constants
+	if(type == DataType::CFLOAT) return DataType::FLOAT;
+	if(type == DataType::CBOOL) return DataType::BOOL;
+	if(type == DataType::CUNTYPED) return DataType::UNTYPED;
 
 	DataType const* t = &type;
 	while (DataTypeArray const* ta = dynamic_cast<DataTypeArray const*>(t))
@@ -310,9 +316,9 @@ bool DataTypeSimple::canCastTo(DataType const& target) const
 	if (simpleId == ZVARTYPEID_UNTYPED) return true;
 	if (target == UNTYPED) return true;
 	
-	if (DataTypeConstFloat const* t =
+	/*if (DataTypeConstFloat const* t =
 			dynamic_cast<DataTypeConstFloat const*>(&target))
-		return canCastTo(DataType::FLOAT);
+		return canCastTo(DataType::FLOAT);*/
 
 	if (DataTypeArray const* t =
 			dynamic_cast<DataTypeArray const*>(&target))
@@ -341,16 +347,23 @@ bool DataTypeSimple::canBeGlobal() const
 }
 
 ////////////////////////////////////////////////////////////////
+// DataTypeSimpleConst
+
+DataTypeSimpleConst::DataTypeSimpleConst(int simpleId, string const& name)
+	: DataTypeSimple(simpleId, name)
+{}
+
+////////////////////////////////////////////////////////////////
 // DataTypeConstFloat
 
-bool DataTypeConstFloat::canCastTo(DataType const& target) const
+/*bool DataTypeConstFloat::canCastTo(DataType const& target) const
 {
 	if (target == UNTYPED) return true;
 	if (target == BOOL) return true; //Not enough, it seems. Where do we check assigns to const? -Z
 	
 	if (*this == target) return true;
 	return DataType::FLOAT.canCastTo(target);
-}
+}*/
 
 ////////////////////////////////////////////////////////////////
 // DataTypeClass

--- a/src/parser/Types.h
+++ b/src/parser/Types.h
@@ -75,9 +75,9 @@ namespace ZScript
 		ZVARTYPEID_BOOL,
 		ZVARTYPEID_PRIMITIVE_END,
 
-		ZVARTYPEID_CONST_FLOAT = ZVARTYPEID_PRIMITIVE_END,
+		//ZVARTYPEID_CONST_FLOAT = ZVARTYPEID_PRIMITIVE_END,
 
-		ZVARTYPEID_CLASS_START,
+		ZVARTYPEID_CLASS_START = ZVARTYPEID_PRIMITIVE_END,
 		ZVARTYPEID_GAME = ZVARTYPEID_CLASS_START,
 		ZVARTYPEID_LINK,
 		ZVARTYPEID_SCREEN,
@@ -117,7 +117,8 @@ namespace ZScript
 	};
 
 	class DataTypeSimple;
-	class DataTypeConstFloat;
+	class DataTypeSimpleConst;
+	//class DataTypeConstFloat;
 	class DataTypeClass;
 	class DataTypeArray;
 
@@ -139,6 +140,7 @@ namespace ZScript
 		// Derived class info.
 		virtual bool isArray() const {return false;}
 		virtual bool isClass() const {return false;}
+		virtual bool isConstant() const {return false;}
 
 		// Returns <0 if <rhs, 0, if ==rhs, and >0 if >rhs.
 		int compare(DataType const& rhs) const;
@@ -154,7 +156,10 @@ namespace ZScript
 		static DataTypeSimple const ZVOID;
 		static DataTypeSimple const FLOAT;
 		static DataTypeSimple const BOOL;
-		static DataTypeConstFloat const CONST_FLOAT;
+		static DataTypeSimpleConst const CUNTYPED;
+		static DataTypeSimpleConst const CFLOAT;
+		static DataTypeSimpleConst const CBOOL;
+		//static DataTypeConstFloat const CONST_FLOAT;
 		static DataTypeArray const STRING;
 		static DataTypeClass const FFC;
 		static DataTypeClass const ITEM;
@@ -235,17 +240,29 @@ namespace ZScript
 		virtual std::string getName() const {return name;}
 		virtual bool canCastTo(DataType const& target) const;
 		virtual bool canBeGlobal() const;
+		virtual bool isConstant() const {return false;}
 
 		int getId() const {return simpleId;}
 
-	private:
+	protected:
 		int simpleId;
 		std::string name;
 
 		int selfCompare(DataType const& rhs) const;
 	};
+	
+	class DataTypeSimpleConst : public DataTypeSimple
+	{
+	public:
+		DataTypeSimpleConst(int simpleId, std::string const& name);
+		DataTypeSimpleConst* clone() const {return new DataTypeSimpleConst(*this);}
+		
+		virtual DataTypeSimpleConst* resolve(ZScript::Scope&) {return this;}
+		
+		virtual bool isConstant() const {return true;}
+	};
 
-	// Temporary while only floats can be constant.
+	/*// Temporary while only floats can be constant.
 	class DataTypeConstFloat : public DataType
 	{
 	public:
@@ -261,7 +278,7 @@ namespace ZScript
 
 	private:
 		int selfCompare(DataType const& other) const {return 0;};
-	};
+	};*/
 
 	class DataTypeClass : public DataType
 	{

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -268,6 +268,9 @@ DataType :
 	| UNTYPED {$$ = new ASTDataType(DataType::UNTYPED, @$);}
 	| ZBOOL {$$ = new ASTDataType(DataType::BOOL, @$);}
 	| ZFLOAT {$$ = new ASTDataType(DataType::FLOAT, @$);}
+	| ZCONST UNTYPED {$$ = new ASTDataType(DataType::CUNTYPED, @$);}
+	| ZCONST ZBOOL {$$ = new ASTDataType(DataType::CBOOL, @$); }
+	| ZCONST ZFLOAT {$$ = new ASTDataType(DataType::CFLOAT, @$); }
 	| BITMAP {$$ = new ASTDataType(DataType::BITMAP, @$);}
 	| CHEAT {$$ = new ASTDataType(DataType::CHEATS, @$);}
 	| COMBO {$$ = new ASTDataType(DataType::COMBOS, @$);}
@@ -297,9 +300,6 @@ DataType :
 			ASTString *name = (ASTString*)$1;
 			$$ = new ASTDataType(DataTypeUnresolved(name->getValue()), @$);
 			delete name;}
-	| ZCONST ZFLOAT {$$ = new ASTDataType(new DataTypeConstFloat(), @$); }
-	| ZCONST ZBOOL {$$ = new ASTDataType(new DataTypeConstFloat(), @$); }
-	| ZCONST UNTYPED {$$ = new ASTDataType(new DataTypeConstFloat(), @$);}
 	;
 
 ScriptTypeDef : SCRIPT TYPEDEF Script_Type IDENTIFIER {


### PR DESCRIPTION
-Removed CONST_FLOAT datatype, and entire `DataTypeConstFloat` class
-Add `DataTypeSimpleConst`, inheriting from `DataTypeSimple`
-Add to DataType, DataTypeSimple, and DataTypeSimpleConst `virtual bool isConstant();`
	This returns true if the class is DataTypeSimpleConst, false otherwise.
-Rewire everything touching Const Float to use the new constant class instances
	These are DataType::CUNTYPED, DataType::CBOOL, and DataType::CFLOAT, all DataTypeSimpleConst instances.
	These use the normal casting of DataTypeSimple with nothing special. They have no unique type ID, they are purely distinguished by the return of `isConstant()`.