### PR TITLE
Using expansion: Anywhere and Always

### DIFF
--- a/src/parser/AST.cpp
+++ b/src/parser/AST.cpp
@@ -508,6 +508,9 @@ void ASTNamespace::addDeclaration(ASTDecl& declaration)
 	case ASTDecl::TYPE_NAMESPACE:
 		namespaces.push_back(static_cast<ASTNamespace*>(&declaration));
 		break;
+	case ASTDecl::TYPE_USING:
+		use.push_back(static_cast<ASTUsingDecl*>(&declaration));
+		break;
 	}
 }
 

--- a/src/parser/AST.cpp
+++ b/src/parser/AST.cpp
@@ -754,8 +754,8 @@ void ASTScriptTypeDef::execute(ASTVisitor& visitor, void* param)
 
 // ASTUsingDecl
 
-ASTUsingDecl::ASTUsingDecl(ASTExprIdentifier* iden, LocationData const& location)
-	: ASTDecl(location), identifier(iden)
+ASTUsingDecl::ASTUsingDecl(ASTExprIdentifier* iden, LocationData const& location, bool always)
+	: ASTDecl(location), identifier(iden), always(always)
 {}
 
 void ASTUsingDecl::execute(ASTVisitor& visitor, void* param)

--- a/src/parser/AST.h
+++ b/src/parser/AST.h
@@ -785,7 +785,7 @@ namespace ZScript
 	class ASTUsingDecl : public ASTDecl
 	{
 	public:
-		ASTUsingDecl(ASTExprIdentifier* iden, LocationData const& location = LocationData::NONE);
+		ASTUsingDecl(ASTExprIdentifier* iden, LocationData const& location = LocationData::NONE, bool always = false);
 		virtual ASTUsingDecl* clone() const {return new ASTUsingDecl(*this);}
 
 		virtual void execute(ASTVisitor& visitor, void* param = NULL);
@@ -793,6 +793,8 @@ namespace ZScript
 		Type getDeclarationType() const {return TYPE_USING;}
 		
 		ASTExprIdentifier* getIdentifier() const {return identifier;}
+		
+		bool always;
 		
 	private:
 		ASTExprIdentifier* identifier;

--- a/src/parser/AST.h
+++ b/src/parser/AST.h
@@ -594,6 +594,7 @@ namespace ZScript
 		owning_vector<ASTScriptTypeDef> scriptTypes;
 		owning_vector<ASTScript> scripts;
 		owning_vector<ASTNamespace> namespaces;
+		owning_vector<ASTUsingDecl> use;
 		std::string name;
 	};
 

--- a/src/parser/BuildVisitors.cpp
+++ b/src/parser/BuildVisitors.cpp
@@ -77,6 +77,11 @@ void BuildOpcodes::caseSetOption(ASTSetOption&, void*)
 	// Do nothing, not even recurse.
 }
 
+void BuildOpcodes::caseUsing(ASTUsingDecl& host, void*)
+{
+	// Do nothing, not even recurse.
+}
+
 // Statements
 
 void BuildOpcodes::caseBlock(ASTBlock &host, void *param)

--- a/src/parser/BuildVisitors.h
+++ b/src/parser/BuildVisitors.h
@@ -20,6 +20,7 @@ namespace ZScript
 	
 		virtual void caseDefault(AST& host, void* param);
 		virtual void caseSetOption(ASTSetOption& host, void* param);
+		virtual void caseUsing(ASTUsingDecl& host, void* param = NULL);
 		// Statements
 		virtual void caseBlock(ASTBlock &host, void *param);
 		virtual void caseStmtIf(ASTStmtIf &host, void *param);

--- a/src/parser/Scope.cpp
+++ b/src/parser/Scope.cpp
@@ -177,7 +177,7 @@ Datum* ZScript::lookupDatum(Scope& scope, std::string const& name, ASTExprIdenti
 		vector<NamespaceScope*> currentNamespaces = scope.getFile()->getUsingNamespaces();
 		namespaceSet.insert(currentNamespaces.begin(), currentNamespaces.end());
 	}
-	vector<NamespaceScope*> currentNamespaces = getRoot(*scope)->getUsingNamespaces();
+	vector<NamespaceScope*> currentNamespaces = getRoot(scope)->getUsingNamespaces();
 	namespaceSet.insert(currentNamespaces.begin(), currentNamespaces.end());
 	vector<NamespaceScope*> namespaces(namespaceSet.begin(), namespaceSet.end());
 	for(vector<NamespaceScope*>::iterator it = namespaces.begin();
@@ -261,7 +261,7 @@ vector<Function*> ZScript::lookupFunctions(Scope& scope, string const& name, boo
 			vector<NamespaceScope*> currentNamespaces = scope.getFile()->getUsingNamespaces();
 			namespaceSet.insert(currentNamespaces.begin(), currentNamespaces.end());
 		}
-		vector<NamespaceScope*> currentNamespaces = getRoot(*scope)->getUsingNamespaces();
+		vector<NamespaceScope*> currentNamespaces = getRoot(scope)->getUsingNamespaces();
 		namespaceSet.insert(currentNamespaces.begin(), currentNamespaces.end());
 		vector<NamespaceScope*> namespaces(namespaceSet.begin(), namespaceSet.end());
 		for(vector<NamespaceScope*>::iterator it = namespaces.begin();

--- a/src/parser/Scope.cpp
+++ b/src/parser/Scope.cpp
@@ -166,13 +166,19 @@ Datum* ZScript::lookupDatum(Scope& scope, std::string const& name, ASTExprIdenti
 	{
 		vector<NamespaceScope*> currentNamespaces = current->getUsingNamespaces();
 		namespaceSet.insert(currentNamespaces.begin(), currentNamespaces.end());
-		if(current->isFile()) foundFile = true;
+		if(current->isFile())
+		{
+			foundFile = true;
+			break; //Don't go to parent file!
+		}
 	}
 	if(!foundFile) //Get the file this is in, if it was not found through the looping. (i.e. this is within a namespace) -V
 	{
 		vector<NamespaceScope*> currentNamespaces = scope.getFile()->getUsingNamespaces();
 		namespaceSet.insert(currentNamespaces.begin(), currentNamespaces.end());
 	}
+	vector<NamespaceScope*> currentNamespaces = getRoot(*scope)->getUsingNamespaces();
+	namespaceSet.insert(currentNamespaces.begin(), currentNamespaces.end());
 	vector<NamespaceScope*> namespaces(namespaceSet.begin(), namespaceSet.end());
 	for(vector<NamespaceScope*>::iterator it = namespaces.begin();
 		it != namespaces.end(); ++it)
@@ -244,13 +250,19 @@ vector<Function*> ZScript::lookupFunctions(Scope& scope, string const& name, boo
 		{
 			vector<NamespaceScope*> currentNamespaces = current->getUsingNamespaces();
 			namespaceSet.insert(currentNamespaces.begin(), currentNamespaces.end());
-			if(current->isFile()) foundFile = true;
+			if(current->isFile())
+			{
+				foundFile = true;
+				break; //Don't go to parent file!
+			}
 		}
 		if(!foundFile) //Get the file this is in, if it was not found through the looping. (i.e. this is within a namespace) -V
 		{
 			vector<NamespaceScope*> currentNamespaces = scope.getFile()->getUsingNamespaces();
 			namespaceSet.insert(currentNamespaces.begin(), currentNamespaces.end());
 		}
+		vector<NamespaceScope*> currentNamespaces = getRoot(*scope)->getUsingNamespaces();
+		namespaceSet.insert(currentNamespaces.begin(), currentNamespaces.end());
 		vector<NamespaceScope*> namespaces(namespaceSet.begin(), namespaceSet.end());
 		for(vector<NamespaceScope*>::iterator it = namespaces.begin();
 			it != namespaces.end(); ++it)

--- a/src/parser/Scope.h
+++ b/src/parser/Scope.h
@@ -100,6 +100,7 @@ namespace ZScript
 		virtual std::vector<Function*> getLocalSetters() const = 0;
 		virtual std::map<CompileOption, CompileOptionSetting>
 				getLocalOptions() const = 0;
+		virtual std::vector<NamespaceScope*> getUsingNamespaces() const = 0;
 
 		// Add
 		virtual Scope* makeChild() = 0;
@@ -154,11 +155,11 @@ namespace ZScript
 		//
 		bool operator==(Scope* other) {return id == other->getId();}
 		
-		std::vector<NamespaceScope*> usingNamespaces;
 		
 	protected:
 		TypeStore& typeStore_;
 		optional<std::string> name_;
+		std::vector<NamespaceScope*> usingNamespaces;
 		long getId() const {return id;}
 
 	private:
@@ -309,6 +310,7 @@ namespace ZScript
 		virtual std::vector<ZScript::Function*> getLocalSetters() const;
 		virtual std::map<CompileOption, CompileOptionSetting>
 				getLocalOptions() const;
+		virtual std::vector<NamespaceScope*> getUsingNamespaces() const {return usingNamespaces;};
 
 		// Add
 		virtual Scope* makeChild();
@@ -342,8 +344,6 @@ namespace ZScript
 		// Stack
 		virtual int getLocalStackDepth() const {return stackDepth_;}
 		virtual optional<int> getLocalStackOffset(Datum const& datum) const;
-		
-		std::vector<NamespaceScope*> usingNamespaces;
 		
 	protected:
 		Scope* parent_;

--- a/src/parser/Scope.h
+++ b/src/parser/Scope.h
@@ -154,6 +154,8 @@ namespace ZScript
 		//
 		bool operator==(Scope* other) {return id == other->getId();}
 		
+		std::vector<NamespaceScope*> usingNamespaces;
+		
 	protected:
 		TypeStore& typeStore_;
 		optional<std::string> name_;

--- a/src/parser/SemanticAnalyzer.cpp
+++ b/src/parser/SemanticAnalyzer.cpp
@@ -141,7 +141,8 @@ void SemanticAnalyzer::caseUsing(ASTUsingDecl& host, void*)
 	//Handle adding scope
 	ASTExprIdentifier* iden = host.getIdentifier();
 	vector<string> components = iden->components;
-	int numMatches = scope->useNamespace(components, iden->delimiters);
+	Scope* temp = host.always ? getRoot(*scope) : scope;
+	int numMatches = temp->useNamespace(components, iden->delimiters);
 	if(numMatches > 1)
 		handleError(CompileError::TooManyUsing(&host, iden->asString()));
 	else if(!numMatches)
@@ -157,7 +158,7 @@ void SemanticAnalyzer::caseUsing(ASTUsingDecl& host, void*)
 			current = next;
 		}
 		caseNamespace(*first);
-		numMatches = scope->useNamespace(components, iden->delimiters);
+		numMatches = temp->useNamespace(components, iden->delimiters);
 	}
 	//-1 == duplicate; the namespace found had already been added to usingNamespaces for this scope! -V
 	else if(numMatches == -1)

--- a/src/parser/SemanticAnalyzer.cpp
+++ b/src/parser/SemanticAnalyzer.cpp
@@ -101,10 +101,8 @@ void SemanticAnalyzer::analyzeFunctionInternals(Function& function)
 
 void SemanticAnalyzer::caseFile(ASTFile& host, void*)
 {
-	//Set current FileScope, for use with namespaces -V
 	scope = scope->makeFileChild(host.asString());
 	RecursiveVisitor::caseFile(host);
-	//Restore previous scope
 	scope = scope->getParent();
 }
 

--- a/src/parser/ffscript.lpp
+++ b/src/parser/ffscript.lpp
@@ -93,6 +93,7 @@ OPTION_VALUE	TOKEN( OPTIONVALUE );
 enum			TOKEN( ENUM );
 namespace		TOKEN( NAMESPACE );
 using			TOKEN( USING );
+always			TOKEN( ALWAYS );
 
  /* Types */
 void		TOKEN( ZVOID );

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -332,6 +332,7 @@ Namespace_Statement :
 	| Function {$$ = $1;}
 	| Script {$$ = $1;}
 	| DataEnum SEMICOLON {$$ = $1;}
+	| Using SEMICOLON {$$ = $1;}
 	| EXPECTERROR LPAREN Expression_Constant RPAREN Namespace_Statement {
 		ASTExprConst* errorId = (ASTExprConst*)$3;
 		ASTDecl* declaration = (ASTDecl*)$5;
@@ -671,6 +672,7 @@ Statement :
 	Data SEMICOLON {$$ = $1;}
 	| DataTypeDef SEMICOLON {$$ = $1;}
 	| DataEnum SEMICOLON {$$ = $1;}
+	| Using SEMICOLON {$$ = $1;}
 	// Normal Statements
 	| Expression SEMICOLON {$$ = $1;}
 	| Statement_Block {$$ = $1;}

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -106,6 +106,7 @@ extern YYLTYPE noloc;
 %token ENUM
 %token NAMESPACE
 %token USING
+%token ALWAYS
 
  // Types
 %token ZVOID
@@ -222,6 +223,7 @@ Global_Statement :
 	| Script {$$ = $1;}
 	| DataEnum SEMICOLON {$$ = $1;}
 	| Using SEMICOLON {$$ = $1;}
+	| AlwaysUsing SEMICOLON {$$ = $1;}
 	| EXPECTERROR LPAREN Expression_Constant RPAREN Global_Statement {
 		ASTExprConst* errorId = (ASTExprConst*)$3;
 		ASTDecl* declaration = (ASTDecl*)$5;
@@ -347,7 +349,12 @@ Using :
 		ASTExprIdentifier* idlist = (ASTExprIdentifier*)$3;
 		$$ = new ASTUsingDecl(idlist, @$);
 	};
-
+	
+AlwaysUsing :
+	ALWAYS USING NAMESPACE Scoperes_Identifier_List {
+		ASTExprIdentifier* idlist = (ASTExprIdentifier*)$4;
+		$$ = new ASTUsingDecl(idlist, @$, true);
+	};
 
 ////////////////////////////////////////////////////////////////
 // Import Declaration


### PR DESCRIPTION
Allow `using namespace NAME;` in ANY scope, including FunctionScope and BasicScope (blocks)

Allow `always using namespace NAME;` in FileScopes. This using will affect EVERY file.
Note: This will likely suffer from the same issue which affects types/constants, where it may not work in parallel files. If declared in the buffer, this is not an issue; it will only not work if it is in a sibling file, rather than an ancestor or descendant.