### PR TITLE
Parser: Option NO_ERROR_HALT added, updated default zquest.cfg

### DIFF
--- a/output/config/zquest.cfg
+++ b/output/config/zquest.cfg
@@ -68,3 +68,7 @@ force_exit = 0
 disable_direct_updating = 1
 gfx_cardw = DXAC
 gfx_card = DXAC
+
+[Compiler]
+HEADER_GUARD = 3
+NO_ERROR_HALT = 0

--- a/src/parser/ASTVisitors.h
+++ b/src/parser/ASTVisitors.h
@@ -178,7 +178,7 @@ namespace ZScript
 	class RecursiveVisitor : public ASTVisitor, public CompileErrorHandler
 	{
 	public:
-		RecursiveVisitor() : failure(false), breakNode(NULL) {}
+		RecursiveVisitor() : failure(false), breakNode(NULL), failure_skipped(false) {}
 	
 		// Mark as having failed.
 		void fail() {failure = true;}
@@ -286,6 +286,8 @@ namespace ZScript
 		virtual bool breakRecursion(AST& host, void* param = NULL) const;
 		virtual bool breakRecursion(void* param = NULL) const;
 
+		//Current scope
+		ZScript::Scope* scope;
 		// Current stack of visited nodes.
 		std::vector<AST*> recursionStack;
 
@@ -294,6 +296,9 @@ namespace ZScript
 	
 		// Set to true if any errors have occured.
 		bool failure;
+		
+		// Set to true if any errors have occured, but `NO_ERROR_HALT` was set.
+		bool failure_skipped;
 	};
 }
 

--- a/src/parser/BuildVisitors.cpp
+++ b/src/parser/BuildVisitors.cpp
@@ -14,9 +14,10 @@ using namespace ZScript;
 
 BuildOpcodes::BuildOpcodes(Scope* curScope)
 	: returnlabelid(-1), continuelabelid(-1), breaklabelid(-1), 
-	  returnRefCount(0), continueRefCount(0), breakRefCount(0), scope(curScope)
+	  returnRefCount(0), continueRefCount(0), breakRefCount(0)
 {
 	opcodeTargets.push_back(&result);
+	scope = curScope;
 }
 
 void BuildOpcodes::visit(AST& node, void* param)

--- a/src/parser/BuildVisitors.h
+++ b/src/parser/BuildVisitors.h
@@ -95,9 +95,6 @@ namespace ZScript
 	
 		void deallocateArrayRef(long arrayRef);
 		void deallocateRefsUntilCount(int count);
-
-		// Current scope.
-		ZScript::Scope* scope;
 		
 		vector<Opcode *> result;
 		int returnlabelid;

--- a/src/parser/CompileOption.h
+++ b/src/parser/CompileOption.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include "CompilerUtils.h"
+#include "parserDefs.h"
 
 namespace ZScript
 {
@@ -51,15 +52,13 @@ namespace ZScript
 		static CompileOption Invalid;
 
 		// Declare static instance for each option.
-#		define X(NAME, DEFAULTQR, DEFAULTVAL) \
+#		define X(NAME, DEFAULTQR, TYPE, DEFAULTVAL) \
 		static CompileOption OPT_##NAME;
-#		define START_GLOBAL(NUM) \
-		//
 #		include "CompileOption.xtable"
 #		undef X
-#		undef START_GLOBAL
 
 		static void initialize();
+		static void updateDefaults();
 
 		static optional<CompileOption> get(std::string const& name);
 

--- a/src/parser/CompileOption.xtable
+++ b/src/parser/CompileOption.xtable
@@ -1,9 +1,8 @@
 // Table of compile options.
-//	Name,                                                               Default QR,     Default Value
-X(	NO_LOGGING,                                               qr_PARSER_NO_LOGGING,             10000)
-X(	TRUNCATE_DIVISION_BY_LITERAL_BUG,                        qr_PARSER_250DIVISION,             00000)
-X(	SHORT_CIRCUIT,                                         qr_PARSER_SHORT_CIRCUIT,             00000)
-X(	RELATIONAL_OP_RETURN_DECIMAL,                          qr_PARSER_RELOP_DECIMAL,             00000)
-START_GLOBAL(3) //Zero-indexed index of the rule directly above it -V
-//	Name,                                                                        0,     Default Value
-X(	HEADER_GUARD,                                                                0,             30000)
+//	Name,                                                      Default QR,                  Type,             Default Value
+X(	NO_LOGGING,                                      qr_PARSER_NO_LOGGING,            OPTTYPE_QR,                     10000)
+X(	TRUNCATE_DIVISION_BY_LITERAL_BUG,               qr_PARSER_250DIVISION,            OPTTYPE_QR,                     00000)
+X(	SHORT_CIRCUIT,                                qr_PARSER_SHORT_CIRCUIT,            OPTTYPE_QR,                     00000)
+X(	RELATIONAL_OP_RETURN_DECIMAL,                 qr_PARSER_RELOP_DECIMAL,            OPTTYPE_QR,                     00000)
+X(	HEADER_GUARD,                                                       0,        OPTTYPE_CONFIG,                     30000)
+X(	NO_ERROR_HALT,                                                      0,        OPTTYPE_CONFIG,                     00000)

--- a/src/parser/SemanticAnalyzer.h
+++ b/src/parser/SemanticAnalyzer.h
@@ -86,12 +86,10 @@ namespace ZScript
 		void caseOptionValue(ASTOptionValue& host, void* = NULL);
 
 		////////////////
-		bool hasFailed() const {return failure;}
+		bool hasFailed() const {return failure || failure_skipped;}
 
 	private:
 		ZScript::Program& program;
-		// Current scope.
-		ZScript::Scope* scope;
 		// Current function return type.
 		ZScript::DataType const* returnType;
 

--- a/src/parser/parserDefs.h
+++ b/src/parser/parserDefs.h
@@ -2,10 +2,13 @@
 #define _PARSERDEFS_H_
 
 //Option values. NOTE: Result of "lookupOption" must be '/10000.0' -V
-#define OPT_OFF			0
-#define OPT_ON			1
-#define OPT_ERROR		2
-#define OPT_WARN		3
+#define OPT_OFF                     0
+#define OPT_ON                      1
+#define OPT_ERROR                   2
+#define OPT_WARN                    3
+
+#define OPTTYPE_QR                  0
+#define OPTTYPE_CONFIG              1
 
 #endif
 


### PR DESCRIPTION
HEADER_GUARD and NO_ERROR_HALT can now both be set from `zquest.cfg`, using the same token, under `[Compiler]`
NO_ERROR_HALT defaults off
If on, errors will not halt compilation; compilation will halt just before completion instead, in this case.