### PR TITLE
Parser: Allow MAX_INT to be 214748, with option to toggle

### DIFF
--- a/src/parser/AST.cpp
+++ b/src/parser/AST.cpp
@@ -1701,7 +1701,7 @@ optional<long> ASTNumberLiteral::getCompileTimeValue(
 	CompileErrorHandler* errorHandler, Scope* scope) const
 {
 	if (!value) return nullopt;
-    pair<long, bool> val = ScriptParser::parseLong(value->parseValue());
+    pair<long, bool> val = ScriptParser::parseLong(value->parseValue(), scope);
 
     if (!val.second && errorHandler)
 	    errorHandler->handleError(

--- a/src/parser/BuildVisitors.cpp
+++ b/src/parser/BuildVisitors.cpp
@@ -1164,7 +1164,7 @@ void BuildOpcodes::caseNumberLiteral(ASTNumberLiteral& host, void*)
         addOpcode(new OSetImmediate(new VarArgument(EXP1), new LiteralArgument(*host.getCompileTimeValue(this, scope))));
     else
     {
-        pair<long, bool> val = ScriptParser::parseLong(host.value->parseValue());
+        pair<long, bool> val = ScriptParser::parseLong(host.value->parseValue(), scope);
 
         if (!val.second)
 	        handleError(CompileError::ConstTrunc(

--- a/src/parser/CompileOption.xtable
+++ b/src/parser/CompileOption.xtable
@@ -6,3 +6,4 @@ X(	SHORT_CIRCUIT,                                qr_PARSER_SHORT_CIRCUIT,       
 X(	RELATIONAL_OP_RETURN_DECIMAL,                 qr_PARSER_RELOP_DECIMAL,            OPTTYPE_QR,                     00000)
 X(	HEADER_GUARD,                                                       0,        OPTTYPE_CONFIG,                     30000)
 X(	NO_ERROR_HALT,                                                      0,        OPTTYPE_CONFIG,                     00000)
+X(	MAX_INT_ONE_LARGER,                      qr_PARSER_MAX_INT_ONE_LARGER,            OPTTYPE_QR,                     10000)

--- a/src/parser/Compiler.h
+++ b/src/parser/Compiler.h
@@ -104,7 +104,7 @@ namespace ZScript
 		static void assemble(IntermediateData* id);
 		static void initialize();
 		static std::pair<long,bool> parseLong(
-				std::pair<std::string,std::string> parts);
+				std::pair<std::string,std::string> parts, Scope* scope);
 
 		static int const recursionLimit = 30;
 	private:

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -2697,6 +2697,7 @@ int readrules(PACKFILE *f, zquestheader *Header, bool keepdata)
 	if((tempheader.zelda_version < 0x255))
 	{
 		set_bit(quest_rules,qr_PARSER_250DIVISION,1);
+		set_bit(quest_rules,qr_PARSER_MAX_INT_ONE_LARGER,0);
 	}
 	
     if(keepdata==true)

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -849,6 +849,7 @@ enum
 	qr_PARSER_NO_LOGGING, //Default off. If on, `Trace()` does not do anything.
 	qr_PARSER_SHORT_CIRCUIT, //Default off.
 	qr_PARSER_RELOP_DECIMAL, //Default off
+	qr_PARSER_MAX_INT_ONE_LARGER, //Default on
     qr_MAX
 };
 

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -19856,13 +19856,13 @@ int onZScriptSettings()
 
 static int compiler_tab_list_global[] =
 {
-	10,11,12,13,14,15,16, 17,
+	11,12,13,14,15,16,17, 18,
 	-1
 };
 
 static int compiler_tab_list_quest[] =
 {
-    6,7,8,9,
+    6,7,8,9, 10,
 	-1
 };
 
@@ -19949,7 +19949,8 @@ static DIALOG zscript_parser_dlg[] =
     { jwin_check_proc,      10, 32+20,  185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "Disable Tracing", NULL, NULL },
     { jwin_check_proc,      10, 32+30,  185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "Short-Circuit Boolean Operations", NULL, NULL },
     { jwin_check_proc,      10, 32+40,  185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "2.50 Relational Operators Give 0.0001 For True", NULL, NULL },
-    //10
+    { jwin_check_proc,      10, 32+50,  185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "Allow constant value 214748", NULL, NULL },
+    //11
     { d_showedit_proc,      6+10,  122,   220,   16,    vc(12),  vc(1),  0,       0,          64,            0,       tempincludepath, NULL, NULL },
     { jwin_textbox_proc,    6+10,  140,   220,  60,   vc(11),  vc(1),  0,       0,          64,            0,       tempincludepath, NULL, NULL },
    
@@ -19963,7 +19964,7 @@ static DIALOG zscript_parser_dlg[] =
 		(void *) &zcompiler_header_guard_list,						 NULL,   NULL 				   },
     { jwin_text_proc,           17,     122-11,     96,      8,    vc(14),                 vc(1),                   0,       0,           0,    0, 
 		(void *) "Include Paths:",                  NULL,   NULL                  },
-    //17
+    //18
 	{ jwin_text_proc,           17+162+(MAX_INCLUDE_PATHS < 10 ? 5 : 0),     122-11,     96,      8,    vc(14),                 vc(1),                   0,       0,           0,    0, 
 		NULL,                  NULL,   NULL                  },
     
@@ -19977,6 +19978,7 @@ static int zscripparsertrules[] =
     qr_PARSER_NO_LOGGING,
     qr_PARSER_SHORT_CIRCUIT,
 	qr_PARSER_RELOP_DECIMAL,
+	qr_PARSER_MAX_INT_ONE_LARGER,
     -1
 };
 
@@ -19987,15 +19989,15 @@ int onZScriptCompilerSettings()
         
     zscript_parser_dlg[0].dp2=lfont;
     
-    zscript_parser_dlg[13].d1 = get_config_int("Compiler","NO_ERROR_HALT",0);
-    zscript_parser_dlg[15].d1 = get_config_int("Compiler","HEADER_GUARD",3);
+    zscript_parser_dlg[14].d1 = get_config_int("Compiler","NO_ERROR_HALT",0);
+    zscript_parser_dlg[16].d1 = get_config_int("Compiler","HEADER_GUARD",3);
 	char max_include[17]; //This would need to be made larger if (MAX_INCLUDE_PATHS > 99) -V
 	sprintf(max_include, "Max Includes: %d", MAX_INCLUDE_PATHS);
-    zscript_parser_dlg[17].dp = max_include;
+    zscript_parser_dlg[18].dp = max_include;
     //memset(tempincludepath,0,sizeof(tempincludepath));
     strcpy(tempincludepath,FFCore.includePathString);
     //al_trace("Include path string in editbox should be: %s\n",tempincludepath);
-    zscript_parser_dlg[10].dp = tempincludepath;
+    zscript_parser_dlg[11].dp = tempincludepath;
    
     for(int i=0; zscripparsertrules[i]!=-1; i++)
     {


### PR DESCRIPTION
#option MAX_INT_ONE_LARGER on
#option MAX_INT_ONE_LARGER off
Will be off for pre-2.55 quests by default
Should be set to be on for newly created quests, in 'qst.dat'