### PR TITLE
Sprites Now Scale and Rotate

### DIFF
--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -453,331 +453,125 @@ void sprite::move(fix s)
  //sprite::draw() before adding scripttile and scriptflip
 
  //sprite::draw() before adding scripttile and scriptflip
+//To quote Jeff Goldblum, 'That is one big pile opf shit!'. -Z (5th April, 2019)
 void sprite::draw(BITMAP* dest)
 {
 	
-    if(!show_sprites)
-    {
-        return;
-    }
+	if(!show_sprites)
+	{
+		return;
+	}
     
-    int sx = real_x(x+xofs);
-    int sy = real_y(y+yofs)-real_z(z+zofs);
-    BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
+	int sx = real_x(x+xofs);
+	int sy = real_y(y+yofs)-real_z(z+zofs);
+	BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
     
-    if(id<0)
-        return;
+	if(id<0)
+		return;
         
-    int e = extend>=3 ? 3 : extend;
-    int flip_type = ((scriptflip > -1) ? scriptflip : flip);
-    if(clk>=0)
-    {
-        switch(e)
-        {
-            BITMAP *temp;
-            
-        case 1:
-            temp = create_bitmap_ex(8,16,32);
-            //blit(dest, temp, sx, sy-16, 0, 0, 16, 32);
-	    clear_bitmap(temp);
-	    clear_bitmap(sprBMP2);
-            
-            if(drawstyle==0 || drawstyle==3)
-            {
-                overtile16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW,0,0,cs,((scriptflip > -1) ? scriptflip : flip));
-                overtile16(temp,((scripttile > -1) ? scripttile : tile),0,16,cs,((scriptflip > -1) ? scriptflip : flip));
-            }
-            
-            if(drawstyle==1)
-            {
-                overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW,0,0,cs,((scriptflip > -1) ? scriptflip : flip),128);
-                overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile),0,16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-            }
-            
-            if(drawstyle==2)
-            {
-                overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW,0,0,((scriptflip > -1) ? scriptflip : flip));
-                overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile),0,16,((scriptflip > -1) ? scriptflip : flip));
-            }
-            
-	    if ( rotation )
+	int e = extend>=3 ? 3 : extend;
+	int flip_type = ((scriptflip > -1) ? scriptflip : flip);
+	if(clk>=0)
+	{
+		switch(e)
 		{
-			
-			if ( scale ) 
-			{
-				double new_scale = scale / 100.0;
-				rotate_scaled_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
-			}
-			else rotate_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(rotation));
-			draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
-			
-		}
-		else
-		{
-			if ( scale ) 
-			{
-				double new_scale = scale / 100.0;
-				rotate_scaled_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(0),ftofix(new_scale));
-				draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
-			}
-			else masked_blit(temp, dest, 0, 0, sx, sy-16, 16, 32);
-		}
-			
-		
-		destroy_bitmap(sprBMP2);
-	    
-            destroy_bitmap(temp);
-            break;
+			BITMAP *temp;
             
-        case 2:
-            temp = create_bitmap_ex(8,48,32);
-            //blit(dest, temp, sx-16, sy-16, 0, 0, 48, 32);
-		clear_bitmap(temp);
-	    clear_bitmap(sprBMP2);
+			case 1:
+				temp = create_bitmap_ex(8,16,32);
+				//blit(dest, temp, sx, sy-16, 0, 0, 16, 32);
+				clear_bitmap(temp);
+				clear_bitmap(sprBMP2);
             
-            if(drawstyle==0 || drawstyle==3)
-            {
-                overtile16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW,16,0,cs,((scriptflip > -1) ? scriptflip : flip));
-                overtile16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW-( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),0,0,cs,((scriptflip > -1) ? scriptflip : flip));
-                overtile16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW+( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),32,0,cs,((scriptflip > -1) ? scriptflip : flip));
-                overtile16(temp,((scripttile > -1) ? scripttile : tile),16,16,cs,((scriptflip > -1) ? scriptflip : flip));
-                overtile16(temp,((scripttile > -1) ? scripttile : tile)-( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),0,16,cs,((scriptflip > -1) ? scriptflip : flip));
-                overtile16(temp,((scripttile > -1) ? scripttile : tile)+( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),32,16,cs,((scriptflip > -1) ? scriptflip : flip));
-            }
-            
-            if(drawstyle==1)
-            {
-                overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW,16,0,cs,((scriptflip > -1) ? scriptflip : flip),128);
-                overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW-( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),0,0,cs,((scriptflip > -1) ? scriptflip : flip),128);
-                overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW+( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),32,0,cs,((scriptflip > -1) ? scriptflip : flip),128);
-                overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile),16,16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-                overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile)-( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),0,16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-                overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile)+( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),32,16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-            }
-            
-            if(drawstyle==2)
-            {
-                overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW,16,0,((scriptflip > -1) ? scriptflip : flip));
-                overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW-( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),0,0,((scriptflip > -1) ? scriptflip : flip));
-                overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW+( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),32,0,((scriptflip > -1) ? scriptflip : flip));
-                overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile),16,16,((scriptflip > -1) ? scriptflip : flip));
-                overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)-( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),0,16,((scriptflip > -1) ? scriptflip : flip));
-                overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)+( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),32,16,((scriptflip > -1) ? scriptflip : flip));
-            }
-            if ( rotation )
-		{
-			
-			if ( scale ) 
-			{
-				double new_scale = scale / 100.0;
-				rotate_scaled_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
-			}
-			else rotate_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(rotation));
-			draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
-			
-		}
-		else
-		{
-			if ( scale ) 
-			{
-				double new_scale = scale / 100.0;
-				rotate_scaled_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(0),ftofix(new_scale));
-				draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
-			}
-			else masked_blit(temp, dest, 8, 0, sx-8, sy-16, 32, 32);
-		}
-			
-		
-		destroy_bitmap(sprBMP2);
-	   
-            destroy_bitmap(temp);
-            break;
-            
-        case 3:
-        {
-            int tileToDraw;
-            
-            switch(flip_type)
-            {
-            case 1:
-	    {
-		BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
-		//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
-		clear_bitmap(sprBMP);
-		clear_bitmap(sprBMP2);
-                for(int i=0; i<tysz; i++)
-                {
-                    for(int j=txsz-1; j>=0; j--)
-                    {
-                        tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
-                        
-                        if(tileToDraw%TILES_PER_ROW<j) // Wrapped around
-                            tileToDraw+=TILES_PER_ROW*(tysz-1);
-                            
-                        if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
-                        else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-                        else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+i*16,((scriptflip > -1) ? scriptflip : flip));
-                    }
-                }
-		if ( rotation )
+				//Draw sprite tiles to the temp (scratch) bitmap.
+				if(drawstyle==0 || drawstyle==3)
 				{
-					
+					overtile16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW,0,0,cs,((scriptflip > -1) ? scriptflip : flip));
+					overtile16(temp,((scripttile > -1) ? scripttile : tile),0,16,cs,((scriptflip > -1) ? scriptflip : flip));
+				}
+            
+				if(drawstyle==1)
+				{
+					overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW,0,0,cs,((scriptflip > -1) ? scriptflip : flip),128);
+					overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile),0,16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+				}
+            
+				if(drawstyle==2)
+				{
+					overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW,0,0,((scriptflip > -1) ? scriptflip : flip));
+					overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile),0,16,((scriptflip > -1) ? scriptflip : flip));
+				}
+				//Blit to the screen...
+				if ( rotation )
+				{	
+					//First rotating and scaling as needed to a scratch-bitmap.
 					if ( scale ) 
 					{
 						double new_scale = scale / 100.0;
-						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+						rotate_scaled_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
 					}
-					else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
+					else rotate_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(rotation));
 					draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
-					
 				}
 				else
 				{
 					if ( scale ) 
 					{
 						double new_scale = scale / 100.0;
-						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+						rotate_scaled_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(0),ftofix(new_scale));
 						draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
 					}
-					else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+					else masked_blit(temp, dest, 0, 0, sx, sy-16, 16, 32);
 				}
-					
-			destroy_bitmap(sprBMP);
-			destroy_bitmap(sprBMP2);
-	    }
-                
-                break;
-                
-            case 2:
-	    {
-		BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
-		//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
-		clear_bitmap(sprBMP);
-		clear_bitmap(sprBMP2);
-                for(int i=tysz-1; i>=0; i--)
-                {
-                    for(int j=0; j<txsz; j++)
-                    {
-                        tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
-                        
-                        if(tileToDraw%TILES_PER_ROW<j)
-                            tileToDraw+=TILES_PER_ROW*(tysz-1);
-                            
-                        if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,sx+j*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip));
-                        else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,sx+j*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-                        else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,sx+j*16,sy+(tysz-i-1)*16,((scriptflip > -1) ? scriptflip : flip));
-                    }
-                }
-		if ( rotation )
+				//clean-up
+				destroy_bitmap(sprBMP2);
+				destroy_bitmap(temp);
+				break;
+            
+			case 2:
+				temp = create_bitmap_ex(8,48,32);
+				//blit(dest, temp, sx-16, sy-16, 0, 0, 48, 32);
+				clear_bitmap(temp);
+				clear_bitmap(sprBMP2);
+            
+				if(drawstyle==0 || drawstyle==3)
 				{
-					
-					if ( scale ) 
-					{
-						double new_scale = scale / 100.0;
-						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
-					}
-					else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
-					draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
-					
+					overtile16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW,16,0,cs,((scriptflip > -1) ? scriptflip : flip));
+					overtile16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW-( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),0,0,cs,((scriptflip > -1) ? scriptflip : flip));
+					overtile16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW+( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),32,0,cs,((scriptflip > -1) ? scriptflip : flip));
+					overtile16(temp,((scripttile > -1) ? scripttile : tile),16,16,cs,((scriptflip > -1) ? scriptflip : flip));
+					overtile16(temp,((scripttile > -1) ? scripttile : tile)-( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),0,16,cs,((scriptflip > -1) ? scriptflip : flip));
+					overtile16(temp,((scripttile > -1) ? scripttile : tile)+( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),32,16,cs,((scriptflip > -1) ? scriptflip : flip));
 				}
-				else
+            
+				if(drawstyle==1)
 				{
-					if ( scale ) 
-					{
-						double new_scale = scale / 100.0;
-						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
-						draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
-					}
-					else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+					overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW,16,0,cs,((scriptflip > -1) ? scriptflip : flip),128);
+					overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW-( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),0,0,cs,((scriptflip > -1) ? scriptflip : flip),128);
+					overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW+( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),32,0,cs,((scriptflip > -1) ? scriptflip : flip),128);
+					overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile),16,16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+					overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile)-( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),0,16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+					overtiletranslucent16(temp,((scripttile > -1) ? scripttile : tile)+( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),32,16,cs,((scriptflip > -1) ? scriptflip : flip),128);
 				}
-					
-			destroy_bitmap(sprBMP);
-			destroy_bitmap(sprBMP2);
-	    }
-                break;
-                
-            case 3:
-	    {
-		BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
-		//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
-		clear_bitmap(sprBMP);
-		clear_bitmap(sprBMP2);
-                for(int i=tysz-1; i>=0; i--)
-                {
-                    for(int j=txsz-1; j>=0; j--)
-                    {
-                        tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
-                        
-                        if(tileToDraw%TILES_PER_ROW<j)
-                            tileToDraw+=TILES_PER_ROW*(tysz-1);
-                            
-                        if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip));
-                        else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-                        else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+(tysz-i-1)*16,((scriptflip > -1) ? scriptflip : flip));
-                    }
-			    
-                }
-		if ( rotation )
+				    
+				if(drawstyle==2)
 				{
-					
-					if ( scale ) 
-					{
-						double new_scale = scale / 100.0;
-						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
-					}
-					else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
-					draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
-					
+					overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW,16,0,((scriptflip > -1) ? scriptflip : flip));
+					overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW-( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),0,0,((scriptflip > -1) ? scriptflip : flip));
+					overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)-TILES_PER_ROW+( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),32,0,((scriptflip > -1) ? scriptflip : flip));
+					overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile),16,16,((scriptflip > -1) ? scriptflip : flip));
+					overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)-( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),0,16,((scriptflip > -1) ? scriptflip : flip));
+					overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)+( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),32,16,((scriptflip > -1) ? scriptflip : flip));
 				}
-				else
-				{
-					if ( scale ) 
-					{
-						double new_scale = scale / 100.0;
-						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
-						draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
-					}
-					else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
-				}
-					
-			destroy_bitmap(sprBMP);
-			destroy_bitmap(sprBMP2);
-	    }
-                break;
-                
-            case 0:
-	    {
-		BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
-		//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
-		clear_bitmap(sprBMP);
-		clear_bitmap(sprBMP2);
-	
-		
-		
-		for(int i=0; i<tysz; i++)
-				{
-					for(int j=0; j<txsz; j++)
-					{
-						tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
-
-						if(tileToDraw%TILES_PER_ROW<j)
-							tileToDraw+=TILES_PER_ROW*(tysz-1);
-
-						if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
-						else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-						else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,0+j*16,0+i*16,((scriptflip > -1) ? scriptflip : flip));
-					}
-				}
-				//rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, 0,ftofix(new_scale));
 				if ( rotation )
 				{
-					
+			
 					if ( scale ) 
 					{
 						double new_scale = scale / 100.0;
-						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+						rotate_scaled_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
 					}
-					else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
+					else rotate_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(rotation));
 					draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
 					
 				}
@@ -786,142 +580,359 @@ void sprite::draw(BITMAP* dest)
 					if ( scale ) 
 					{
 						double new_scale = scale / 100.0;
-						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+						rotate_scaled_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(0),ftofix(new_scale));
 						draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
 					}
-					else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+					else masked_blit(temp, dest, 8, 0, sx-8, sy-16, 32, 32);
+				}
+					
+				
+				destroy_bitmap(sprBMP2);
+				destroy_bitmap(temp);
+				break;
+            
+			case 3:
+			{
+				int tileToDraw;
+            
+				switch(flip_type)
+				{
+					case 1:
+					{
+						BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
+						//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
+						clear_bitmap(sprBMP);
+						clear_bitmap(sprBMP2);
+						for(int i=0; i<tysz; i++)
+						{
+							for(int j=txsz-1; j>=0; j--)
+							{
+								tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
+							
+								if(tileToDraw%TILES_PER_ROW<j) // Wrapped around
+									tileToDraw+=TILES_PER_ROW*(tysz-1);
+							    
+								if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
+								else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+								else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+i*16,((scriptflip > -1) ? scriptflip : flip));
+							}
+						}
+						if ( rotation )
+						{
+							if ( scale ) 
+							{
+								double new_scale = scale / 100.0;
+								rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+							}
+							else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
+							draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+							
+						}
+						else
+						{
+							if ( scale ) 
+							{
+								double new_scale = scale / 100.0;
+								rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+								draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+							}
+							else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+						}
+							
+						destroy_bitmap(sprBMP);
+						destroy_bitmap(sprBMP2);
+					} //end extend == 3 && flip == 1
+					break;
+                
+					case 2:
+					{
+						BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
+						//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
+						clear_bitmap(sprBMP);
+						clear_bitmap(sprBMP2);
+						for(int i=tysz-1; i>=0; i--)
+						{
+							for(int j=0; j<txsz; j++)
+							{
+								tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
+							
+								if(tileToDraw%TILES_PER_ROW<j)
+									tileToDraw+=TILES_PER_ROW*(tysz-1);
+							    
+								if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,sx+j*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip));
+								else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,sx+j*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+								else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,sx+j*16,sy+(tysz-i-1)*16,((scriptflip > -1) ? scriptflip : flip));
+							}
+						}
+						if ( rotation )
+						{
+							
+							if ( scale ) 
+							{
+								double new_scale = scale / 100.0;
+								rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+							}
+							else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
+							draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+							
+						}
+						else
+						{
+							if ( scale ) 
+							{
+								double new_scale = scale / 100.0;
+								rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+								draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+							}
+							else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+						}
+							
+						destroy_bitmap(sprBMP);
+						destroy_bitmap(sprBMP2);
+					}//end extend == 3 &7 flip == 2
+					break;
+                
+					case 3:
+					{
+						BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
+						//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
+						clear_bitmap(sprBMP);
+						clear_bitmap(sprBMP2);
+						for(int i=tysz-1; i>=0; i--)
+						{
+							for(int j=txsz-1; j>=0; j--)
+							{
+								tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
+							
+								if(tileToDraw%TILES_PER_ROW<j)
+									tileToDraw+=TILES_PER_ROW*(tysz-1);
+							    
+								if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip));
+								else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+								else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+(tysz-i-1)*16,((scriptflip > -1) ? scriptflip : flip));
+							}
+							    
+						}
+						if ( rotation )
+						{
+							if ( scale ) 
+							{
+								double new_scale = scale / 100.0;
+								rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+							}
+							else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
+							draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+							
+						}
+						else
+						{
+							if ( scale ) 
+							{
+								double new_scale = scale / 100.0;
+								rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+								draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+							}
+							else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+						}
+							
+						destroy_bitmap(sprBMP);
+						destroy_bitmap(sprBMP2);
+					} //end extend == 3 && flip == 3
+					break;
+                
+					case 0:
+					{
+						BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
+						//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
+						clear_bitmap(sprBMP);
+						clear_bitmap(sprBMP2);
+					
+						
+						
+						for(int i=0; i<tysz; i++)
+						{
+							for(int j=0; j<txsz; j++)
+							{
+								tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
+
+								if(tileToDraw%TILES_PER_ROW<j)
+									tileToDraw+=TILES_PER_ROW*(tysz-1);
+
+								if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
+								else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+								else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,0+j*16,0+i*16,((scriptflip > -1) ? scriptflip : flip));
+							}
+						}
+						//rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, 0,ftofix(new_scale));
+						if ( rotation )
+						{
+							
+							if ( scale ) 
+							{
+								double new_scale = scale / 100.0;
+								rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+							}
+							else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
+							draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+							
+						}
+						else
+						{
+							if ( scale ) 
+							{
+								double new_scale = scale / 100.0;
+								rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+								draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+							}
+							else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+						}
+						
+						destroy_bitmap(sprBMP);
+						destroy_bitmap(sprBMP2);
+                
+						break;
+					} //end extend == 0 && flip == 3
 				}
 				
-		destroy_bitmap(sprBMP);
-		destroy_bitmap(sprBMP2);
-                
-                break;
-	    }
-            }
-            
-            case 0:
-            default:
-		{
-			if(e) break; //Don't draw if the sprite is extended. We already drew it. 
-			BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
-			//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
-			clear_bitmap(sprBMP);
-			clear_bitmap(sprBMP2);
-			if(drawstyle==0 || drawstyle==3)
-				overtile16(sprBMP,tile,0,0,cs,flip);
-			else if(drawstyle==1)
-				overtiletranslucent16(sprBMP,tile,0,0,cs,flip,128);
-			else if(drawstyle==2)
-				overtilecloaked16(sprBMP,tile,0,0,flip);
-			
-			if ( rotation )
+				//This was designed to fall-through in some cases. I tried to fix this, and it made a whopping mess.
+				//so, I left it alone anc worked with what he have. -Z ( 5th April, 2019 )
+				case 0:  //extend == 0
+				default:
 				{
+					if(e) break; //Don't draw if the sprite is extended. We already drew it. 
+					//Not doing this causes the UL corner of a larger sprite to draw, on top of an existing sprite. 
+					//IDK why that was done, but it's not going to happen, now. -Z ( 5th April, 2019 )
+					BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
+					//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
+					clear_bitmap(sprBMP);
+					clear_bitmap(sprBMP2);
+					if(drawstyle==0 || drawstyle==3)
+						overtile16(sprBMP,tile,0,0,cs,flip);
+					else if(drawstyle==1)
+						overtiletranslucent16(sprBMP,tile,0,0,cs,flip,128);
+					else if(drawstyle==2)
+						overtilecloaked16(sprBMP,tile,0,0,flip);
 					
-					if ( scale ) 
+					if ( rotation )
 					{
-						double new_scale = scale / 100.0;
-						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+						
+						if ( scale ) 
+						{
+							double new_scale = scale / 100.0;
+							rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+						}
+						else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
+						draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+						
 					}
-					else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
-					draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
-					
+					else
+					{
+						if ( scale ) 
+						{
+							double new_scale = scale / 100.0;
+							rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+							draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+						}
+						else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+					}
+					destroy_bitmap(sprBMP);
+					destroy_bitmap(sprBMP2);
+					break;
+				}
+			} //end extend == 3, and also extend == 0. Why? Because someone was more mental, than me. -Z (5th April, 2019)
+			break; //Aye, we break switch(e) here.
+			if ( temp ) 
+			{
+				//if there is still somehow data in the temp bitmap
+				destroy_bitmap(temp);
+			}
+		}
+	} //end if(clk>=0)
+	else //I'm unsure when the clk is < 0 -Z
+	{
+		if(e!=3) //if extend != 3 
+		{
+			int t  = wpnsbuf[iwSpawn].newtile;
+			int cs2 = wpnsbuf[iwSpawn].csets&15;
+            
+			if(BSZ)
+			{
+				if(clk>=-10) ++t;
+                
+				if(clk>=-5) ++t;
+			}
+			else
+			{
+				if(clk>=-12) ++t;
+                
+				if(clk>=-6) ++t;
+			}
+            
+			overtile16(dest,t,sx,sy,cs2,0);
+		}
+		else //extend == 3?
+		{
+			sprite w((fix)sx,(fix)sy,wpnsbuf[extend].newtile,wpnsbuf[extend].csets&15,0,0,0);
+			w.xofs = xofs;
+			w.yofs = yofs;
+			w.zofs = zofs;
+			w.txsz = txsz;
+			w.tysz = tysz;
+			w.extend = 3;
+            
+			if ( w.scripttile <= -1 ) 
+			{
+				if(BSZ)
+				{
+					if(clk>=-10)
+					{
+						if(tile/TILES_PER_ROW==(tile+txsz)/TILES_PER_ROW)
+							w.tile+=txsz;
+						else
+							w.tile+=txsz+(tysz-1)*TILES_PER_ROW;
+					}
+				
+					if(clk>=-5)
+					{
+						if(tile/TILES_PER_ROW==(tile+txsz)/TILES_PER_ROW)
+							w.tile+=txsz;
+						else
+							w.tile+=txsz+(tysz-1)*TILES_PER_ROW;
+					}
 				}
 				else
 				{
-					if ( scale ) 
+					if(clk>=-12)
 					{
-						double new_scale = scale / 100.0;
-						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
-						draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+						if(tile/TILES_PER_ROW==(tile+txsz)/TILES_PER_ROW)
+							w.tile+=txsz;
+						else
+							w.tile+=txsz+(tysz-1)*TILES_PER_ROW;
 					}
-					else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+			
+					if(clk>=-6)
+					{
+						if(tile/TILES_PER_ROW==(tile+txsz)/TILES_PER_ROW)
+							w.tile+=txsz;
+						else
+							w.tile+=txsz+(tysz-1)*TILES_PER_ROW;
+					}
 				}
-			destroy_bitmap(sprBMP);
-			destroy_bitmap(sprBMP2);
-			break;
+			}
+            
+			w.draw(dest);
 		}
-            }
-            break;
-        }
-    }
-    else
-    {
-        if(e!=3)
-        {
-            int t  = wpnsbuf[iwSpawn].newtile;
-            int cs2 = wpnsbuf[iwSpawn].csets&15;
-            
-            if(BSZ)
-            {
-                if(clk>=-10) ++t;
-                
-                if(clk>=-5) ++t;
-            }
-            else
-            {
-                if(clk>=-12) ++t;
-                
-                if(clk>=-6) ++t;
-            }
-            
-            overtile16(dest,t,sx,sy,cs2,0);
-        }
-        else
-        {
-            sprite w((fix)sx,(fix)sy,wpnsbuf[extend].newtile,wpnsbuf[extend].csets&15,0,0,0);
-            w.xofs = xofs;
-            w.yofs = yofs;
-            w.zofs = zofs;
-            w.txsz = txsz;
-            w.tysz = tysz;
-            w.extend = 3;
-            
-	    if ( w.scripttile <= -1 ) 
-	    {
-		    if(BSZ)
-		    {
-			if(clk>=-10)
-			{
-			    if(tile/TILES_PER_ROW==(tile+txsz)/TILES_PER_ROW)
-				w.tile+=txsz;
-			    else
-				w.tile+=txsz+(tysz-1)*TILES_PER_ROW;
-			}
-			
-			if(clk>=-5)
-			{
-			    if(tile/TILES_PER_ROW==(tile+txsz)/TILES_PER_ROW)
-				w.tile+=txsz;
-			    else
-				w.tile+=txsz+(tysz-1)*TILES_PER_ROW;
-			}
-		    }
-		    else
-		    {
-			if(clk>=-12)
-			{
-			    if(tile/TILES_PER_ROW==(tile+txsz)/TILES_PER_ROW)
-				w.tile+=txsz;
-			    else
-				w.tile+=txsz+(tysz-1)*TILES_PER_ROW;
-			}
-			
-			if(clk>=-6)
-			{
-			    if(tile/TILES_PER_ROW==(tile+txsz)/TILES_PER_ROW)
-				w.tile+=txsz;
-			    else
-				w.tile+=txsz+(tysz-1)*TILES_PER_ROW;
-			}
-		    }
-	    }
-            
-            w.draw(dest);
-        }
-    }
+	}
     
-    if(show_hitboxes && !is_zquest())
-        rect(dest,x+hxofs,y+playing_field_offset+hyofs-(z+zofs),x+hxofs+hxsz-1,(y+playing_field_offset+hyofs+hysz-(z+zofs))-1,vc((id+16)%255));
+	if(show_hitboxes && !is_zquest())
+		rect(dest,x+hxofs,y+playing_field_offset+hyofs-(z+zofs),x+hxofs+hxsz-1,(y+playing_field_offset+hyofs+hysz-(z+zofs))-1,vc((id+16)%255));
+
+	if ( sprBMP2 ) 
+	{
+		//if there is still somehow data in the scaling bitmap
+		destroy_bitmap(sprBMP2);
+	}
+	
 }
 
 void sprite::old_draw(BITMAP* dest)

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -463,6 +463,7 @@ void sprite::draw(BITMAP* dest)
     
     int sx = real_x(x+xofs);
     int sy = real_y(y+yofs)-real_z(z+zofs);
+    BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
     
     if(id<0)
         return;
@@ -477,7 +478,9 @@ void sprite::draw(BITMAP* dest)
             
         case 1:
             temp = create_bitmap_ex(8,16,32);
-            blit(dest, temp, sx, sy-16, 0, 0, 16, 32);
+            //blit(dest, temp, sx, sy-16, 0, 0, 16, 32);
+	    clear_bitmap(temp);
+	    clear_bitmap(sprBMP2);
             
             if(drawstyle==0 || drawstyle==3)
             {
@@ -497,15 +500,40 @@ void sprite::draw(BITMAP* dest)
                 overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile),0,16,((scriptflip > -1) ? scriptflip : flip));
             }
             
-	    //if ( rotation != 0 ) rotate_sprite(dest, temp, sx, sy+playing_field_offset, deg_to_fixed(rotation));
-            /*else*/ masked_blit(temp, dest, 0, 0, sx, sy-16, 16, 32);
+	    if ( rotation )
+		{
+			
+			if ( scale ) 
+			{
+				double new_scale = scale / 100.0;
+				rotate_scaled_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+			}
+			else rotate_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(rotation));
+			draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+			
+		}
+		else
+		{
+			if ( scale ) 
+			{
+				double new_scale = scale / 100.0;
+				rotate_scaled_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+				draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+			}
+			else masked_blit(temp, dest, 0, 0, sx, sy-16, 16, 32);
+		}
+			
+		
+		destroy_bitmap(sprBMP2);
 	    
             destroy_bitmap(temp);
             break;
             
         case 2:
             temp = create_bitmap_ex(8,48,32);
-            blit(dest, temp, sx-16, sy-16, 0, 0, 48, 32);
+            //blit(dest, temp, sx-16, sy-16, 0, 0, 48, 32);
+		clear_bitmap(temp);
+	    clear_bitmap(sprBMP2);
             
             if(drawstyle==0 || drawstyle==3)
             {
@@ -536,9 +564,32 @@ void sprite::draw(BITMAP* dest)
                 overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)-( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),0,16,((scriptflip > -1) ? scriptflip : flip));
                 overtilecloaked16(temp,((scripttile > -1) ? scripttile : tile)+( ( scriptflip > -1 ) ? ( scriptflip ? -1 : 1 ) : ( flip?-1:1 ) ),32,16,((scriptflip > -1) ? scriptflip : flip));
             }
-            
-	    //if ( rotation != 0 ) rotate_sprite(temp, dest, sx-8, sy-16, deg_to_fixed(rotation));
-            /*else*/ masked_blit(temp, dest, 8, 0, sx-8, sy-16, 32, 32);
+            if ( rotation )
+		{
+			
+			if ( scale ) 
+			{
+				double new_scale = scale / 100.0;
+				rotate_scaled_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+			}
+			else rotate_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(rotation));
+			draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+			
+		}
+		else
+		{
+			if ( scale ) 
+			{
+				double new_scale = scale / 100.0;
+				rotate_scaled_sprite(sprBMP2, temp, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+				draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+			}
+			else masked_blit(temp, dest, 8, 0, sx-8, sy-16, 32, 32);
+		}
+			
+		
+		destroy_bitmap(sprBMP2);
+	   
             destroy_bitmap(temp);
             break;
             
@@ -549,6 +600,11 @@ void sprite::draw(BITMAP* dest)
             switch(flip_type)
             {
             case 1:
+	    {
+		BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
+		//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
+		clear_bitmap(sprBMP);
+		clear_bitmap(sprBMP2);
                 for(int i=0; i<tysz; i++)
                 {
                     for(int j=txsz-1; j>=0; j--)
@@ -558,15 +614,46 @@ void sprite::draw(BITMAP* dest)
                         if(tileToDraw%TILES_PER_ROW<j) // Wrapped around
                             tileToDraw+=TILES_PER_ROW*(tysz-1);
                             
-                        if(drawstyle==0 || drawstyle==3) overtile16(dest,tileToDraw,sx+(txsz-j-1)*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
-                        else if(drawstyle==1) overtiletranslucent16(dest,tileToDraw,sx+(txsz-j-1)*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-                        else if(drawstyle==2) overtilecloaked16(dest,tileToDraw,sx+(txsz-j-1)*16,sy+i*16,((scriptflip > -1) ? scriptflip : flip));
+                        if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
+                        else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+                        else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+i*16,((scriptflip > -1) ? scriptflip : flip));
                     }
                 }
+		if ( rotation )
+				{
+					
+					if ( scale ) 
+					{
+						double new_scale = scale / 100.0;
+						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+					}
+					else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
+					draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+					
+				}
+				else
+				{
+					if ( scale ) 
+					{
+						double new_scale = scale / 100.0;
+						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+						draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+					}
+					else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+				}
+					
+			destroy_bitmap(sprBMP);
+			destroy_bitmap(sprBMP2);
+	    }
                 
                 break;
                 
             case 2:
+	    {
+		BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
+		//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
+		clear_bitmap(sprBMP);
+		clear_bitmap(sprBMP2);
                 for(int i=tysz-1; i>=0; i--)
                 {
                     for(int j=0; j<txsz; j++)
@@ -576,15 +663,45 @@ void sprite::draw(BITMAP* dest)
                         if(tileToDraw%TILES_PER_ROW<j)
                             tileToDraw+=TILES_PER_ROW*(tysz-1);
                             
-                        if(drawstyle==0 || drawstyle==3) overtile16(dest,tileToDraw,sx+j*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip));
-                        else if(drawstyle==1) overtiletranslucent16(dest,tileToDraw,sx+j*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-                        else if(drawstyle==2) overtilecloaked16(dest,tileToDraw,sx+j*16,sy+(tysz-i-1)*16,((scriptflip > -1) ? scriptflip : flip));
+                        if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,sx+j*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip));
+                        else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,sx+j*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+                        else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,sx+j*16,sy+(tysz-i-1)*16,((scriptflip > -1) ? scriptflip : flip));
                     }
                 }
-                
+		if ( rotation )
+				{
+					
+					if ( scale ) 
+					{
+						double new_scale = scale / 100.0;
+						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+					}
+					else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
+					draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+					
+				}
+				else
+				{
+					if ( scale ) 
+					{
+						double new_scale = scale / 100.0;
+						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+						draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+					}
+					else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+				}
+					
+			destroy_bitmap(sprBMP);
+			destroy_bitmap(sprBMP2);
+	    }
                 break;
                 
             case 3:
+	    {
+		BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
+		//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
+		clear_bitmap(sprBMP);
+		clear_bitmap(sprBMP2);
                 for(int i=tysz-1; i>=0; i--)
                 {
                     for(int j=txsz-1; j>=0; j--)
@@ -594,98 +711,48 @@ void sprite::draw(BITMAP* dest)
                         if(tileToDraw%TILES_PER_ROW<j)
                             tileToDraw+=TILES_PER_ROW*(tysz-1);
                             
-                        if(drawstyle==0 || drawstyle==3) overtile16(dest,tileToDraw,sx+(txsz-j-1)*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip));
-                        else if(drawstyle==1) overtiletranslucent16(dest,tileToDraw,sx+(txsz-j-1)*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-                        else if(drawstyle==2) overtilecloaked16(dest,tileToDraw,sx+(txsz-j-1)*16,sy+(tysz-i-1)*16,((scriptflip > -1) ? scriptflip : flip));
+                        if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip));
+                        else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+(tysz-i-1)*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+                        else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,sx+(txsz-j-1)*16,sy+(tysz-i-1)*16,((scriptflip > -1) ? scriptflip : flip));
                     }
+			    
                 }
-                
+		if ( rotation )
+				{
+					
+					if ( scale ) 
+					{
+						double new_scale = scale / 100.0;
+						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+					}
+					else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
+					draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+					
+				}
+				else
+				{
+					if ( scale ) 
+					{
+						double new_scale = scale / 100.0;
+						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+						draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+					}
+					else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+				}
+					
+			destroy_bitmap(sprBMP);
+			destroy_bitmap(sprBMP2);
+	    }
                 break;
                 
             case 0:
 	    {
 		BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
-		BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
+		//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
 		clear_bitmap(sprBMP);
 		clear_bitmap(sprBMP2);
-		/*
-		if ( rotation )
-		{
-			
-				
-			
-				double new_scale = scale / 100.0;
-				for(int i=0; i<tysz; i++)
-				{
-					for(int j=0; j<txsz; j++)
-					{
-						tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
-
-						if(tileToDraw%TILES_PER_ROW<j)
-							tileToDraw+=TILES_PER_ROW*(tysz-1);
-
-						if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
-						else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-						else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,0+j*16,0+i*16,((scriptflip > -1) ? scriptflip : flip));
-					}
-				}
-				if ( scale!=0 ) rotate_sprite(sprBMP2, sprBMP, 0, 0, rotation);
-				
-				draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
-				
-			
-			
-		}
-		*/
-		/*
-		else
-		{
-			if ( scale != 0 )
-			{
-				
-			
-				double new_scale = scale / 100.0;
-				for(int i=0; i<tysz; i++)
-				{
-					for(int j=0; j<txsz; j++)
-					{
-						tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
-
-						if(tileToDraw%TILES_PER_ROW<j)
-							tileToDraw+=TILES_PER_ROW*(tysz-1);
-
-						if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
-						else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-						else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,0+j*16,0+i*16,((scriptflip > -1) ? scriptflip : flip));
-					}
-				}
-				rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, 0,ftofix(new_scale));
-				
-				draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
-				
-			}
-			else
-			{
-				for(int i=0; i<tysz; i++)
-				{
-					for(int j=0; j<txsz; j++)
-					{
-						tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
-
-						if(tileToDraw%TILES_PER_ROW<j)
-							tileToDraw+=TILES_PER_ROW*(tysz-1);
-
-						if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,sx+j*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
-						else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,sx+j*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-						else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,sx+j*16,sy+i*16,((scriptflip > -1) ? scriptflip : flip));
-					}
-				}
-				draw_sprite(dest, sprBMP, x, y+playing_field_offset);
-				
-			}
-			
-		}
-		*/
+	
+		
 		
 		for(int i=0; i<tysz; i++)
 				{
@@ -737,11 +804,16 @@ void sprite::draw(BITMAP* dest)
 		{
 			if(e) break; //Don't draw if the sprite is extended. We already drew it. 
 			BITMAP* sprBMP = create_bitmap_ex(8,16,16);
+			BITMAP* sprBMP3 = create_bitmap_ex(8,256,256);
 			clear_bitmap(sprBMP);
-			BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
+			//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
 			clear_bitmap(sprBMP2);
+			clear_bitmap(sprBMP3);
+			
 			if ( rotation )
 			{
+				clear_bitmap(sprBMP);
+				clear_bitmap(sprBMP3);
 				if(drawstyle==0 || drawstyle==3)
 					overtile16(sprBMP,tile,0,0,cs,flip);
 				else if(drawstyle==1)
@@ -752,13 +824,13 @@ void sprite::draw(BITMAP* dest)
 				{
 					double new_scale = scale / 100.0;
 					
-					rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, 0,ftofix(new_scale));
+					rotate_scaled_sprite(sprBMP3, sprBMP, 0, 0, 0,ftofix(new_scale));
 					//al_trace("Sprite scale is %f\n",new_scale);
-					rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+					rotate_scaled_sprite(sprBMP3, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
 					
 				}
-				else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
-				draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+				else rotate_sprite(sprBMP3, sprBMP, 0, 0, deg_to_fixed(rotation));
+				draw_sprite(dest, sprBMP3, x, y+playing_field_offset);
 			}
 			
 			else
@@ -775,9 +847,9 @@ void sprite::draw(BITMAP* dest)
 				
 					double new_scale = scale / 100.0;
 					
-					rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, 0,ftofix(new_scale));
+					rotate_scaled_sprite(sprBMP3, sprBMP, 0, 0, 0,ftofix(new_scale));
 					
-					draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+					draw_sprite(dest, sprBMP3, x, y+playing_field_offset);
 					
 					
 				}
@@ -793,6 +865,7 @@ void sprite::draw(BITMAP* dest)
 			}
 			destroy_bitmap(sprBMP);
 			destroy_bitmap(sprBMP2);
+			destroy_bitmap(sprBMP3);
 			break;
 		}
             }

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -603,27 +603,139 @@ void sprite::draw(BITMAP* dest)
                 break;
                 
             case 0:
-                for(int i=0; i<tysz; i++)
-                {
-                    for(int j=0; j<txsz; j++)
-                    {
-                        tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
-                        
-                        if(tileToDraw%TILES_PER_ROW<j)
-                            tileToDraw+=TILES_PER_ROW*(tysz-1);
-                            
-                        if(drawstyle==0 || drawstyle==3) overtile16(dest,tileToDraw,sx+j*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
-                        else if(drawstyle==1) overtiletranslucent16(dest,tileToDraw,sx+j*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
-                        else if(drawstyle==2) overtilecloaked16(dest,tileToDraw,sx+j*16,sy+i*16,((scriptflip > -1) ? scriptflip : flip));
-                    }
-                }
+	    {
+		BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
+		BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
+		clear_bitmap(sprBMP);
+		clear_bitmap(sprBMP2);
+		/*
+		if ( rotation )
+		{
+			
+				
+			
+				double new_scale = scale / 100.0;
+				for(int i=0; i<tysz; i++)
+				{
+					for(int j=0; j<txsz; j++)
+					{
+						tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
+
+						if(tileToDraw%TILES_PER_ROW<j)
+							tileToDraw+=TILES_PER_ROW*(tysz-1);
+
+						if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
+						else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+						else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,0+j*16,0+i*16,((scriptflip > -1) ? scriptflip : flip));
+					}
+				}
+				if ( scale!=0 ) rotate_sprite(sprBMP2, sprBMP, 0, 0, rotation);
+				
+				draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+				
+			
+			
+		}
+		*/
+		/*
+		else
+		{
+			if ( scale != 0 )
+			{
+				
+			
+				double new_scale = scale / 100.0;
+				for(int i=0; i<tysz; i++)
+				{
+					for(int j=0; j<txsz; j++)
+					{
+						tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
+
+						if(tileToDraw%TILES_PER_ROW<j)
+							tileToDraw+=TILES_PER_ROW*(tysz-1);
+
+						if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
+						else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+						else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,0+j*16,0+i*16,((scriptflip > -1) ? scriptflip : flip));
+					}
+				}
+				rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, 0,ftofix(new_scale));
+				
+				draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+				
+			}
+			else
+			{
+				for(int i=0; i<tysz; i++)
+				{
+					for(int j=0; j<txsz; j++)
+					{
+						tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
+
+						if(tileToDraw%TILES_PER_ROW<j)
+							tileToDraw+=TILES_PER_ROW*(tysz-1);
+
+						if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,sx+j*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
+						else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,sx+j*16,sy+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+						else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,sx+j*16,sy+i*16,((scriptflip > -1) ? scriptflip : flip));
+					}
+				}
+				draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+				
+			}
+			
+		}
+		*/
+		
+		for(int i=0; i<tysz; i++)
+				{
+					for(int j=0; j<txsz; j++)
+					{
+						tileToDraw=((scripttile > -1) ? scripttile : tile)+(i*TILES_PER_ROW)+j;
+
+						if(tileToDraw%TILES_PER_ROW<j)
+							tileToDraw+=TILES_PER_ROW*(tysz-1);
+
+						if(drawstyle==0 || drawstyle==3) overtile16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip));
+						else if(drawstyle==1) overtiletranslucent16(sprBMP,tileToDraw,0+j*16,0+i*16,cs,((scriptflip > -1) ? scriptflip : flip),128);
+						else if(drawstyle==2) overtilecloaked16(sprBMP,tileToDraw,0+j*16,0+i*16,((scriptflip > -1) ? scriptflip : flip));
+					}
+				}
+				//rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, 0,ftofix(new_scale));
+				if ( rotation )
+				{
+					
+					if ( scale ) 
+					{
+						double new_scale = scale / 100.0;
+						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+					}
+					else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
+					draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+					
+				}
+				else
+				{
+					if ( scale ) 
+					{
+						double new_scale = scale / 100.0;
+						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+						draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+					}
+					else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
+				}
+				
+		destroy_bitmap(sprBMP);
+		destroy_bitmap(sprBMP2);
                 
                 break;
+	    }
             }
             
             case 0:
             default:
 		{
+			if(e) break; //Don't draw if the sprite is extended. We already drew it. 
 			BITMAP* sprBMP = create_bitmap_ex(8,16,16);
 			clear_bitmap(sprBMP);
 			BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -803,69 +803,41 @@ void sprite::draw(BITMAP* dest)
             default:
 		{
 			if(e) break; //Don't draw if the sprite is extended. We already drew it. 
-			BITMAP* sprBMP = create_bitmap_ex(8,16,16);
-			BITMAP* sprBMP3 = create_bitmap_ex(8,256,256);
-			clear_bitmap(sprBMP);
+			BITMAP* sprBMP = create_bitmap_ex(8,txsz*16,tysz*16);
 			//BITMAP* sprBMP2 = create_bitmap_ex(8,256,256);
+			clear_bitmap(sprBMP);
 			clear_bitmap(sprBMP2);
-			clear_bitmap(sprBMP3);
+			if(drawstyle==0 || drawstyle==3)
+				overtile16(sprBMP,tile,0,0,cs,flip);
+			else if(drawstyle==1)
+				overtiletranslucent16(sprBMP,tile,0,0,cs,flip,128);
+			else if(drawstyle==2)
+				overtilecloaked16(sprBMP,tile,0,0,flip);
 			
 			if ( rotation )
-			{
-				clear_bitmap(sprBMP);
-				clear_bitmap(sprBMP3);
-				if(drawstyle==0 || drawstyle==3)
-					overtile16(sprBMP,tile,0,0,cs,flip);
-				else if(drawstyle==1)
-					overtiletranslucent16(sprBMP,tile,0,0,cs,flip,128);
-				else if(drawstyle==2)
-					overtilecloaked16(sprBMP,tile,0,0,flip);
-				if ( scale != 0 ) 
 				{
-					double new_scale = scale / 100.0;
 					
-					rotate_scaled_sprite(sprBMP3, sprBMP, 0, 0, 0,ftofix(new_scale));
-					//al_trace("Sprite scale is %f\n",new_scale);
-					rotate_scaled_sprite(sprBMP3, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
-					
-				}
-				else rotate_sprite(sprBMP3, sprBMP, 0, 0, deg_to_fixed(rotation));
-				draw_sprite(dest, sprBMP3, x, y+playing_field_offset);
-			}
-			
-			else
-			{
-			
-				if ( scale != 0 )
-				{
-					if(drawstyle==0 || drawstyle==3)
-						overtile16(sprBMP,tile,0,0,cs,flip);
-					else if(drawstyle==1)
-						overtiletranslucent16(sprBMP,tile,0,0,cs,flip,128);
-					else if(drawstyle==2)
-						overtilecloaked16(sprBMP,tile,0,0,flip);
-				
-					double new_scale = scale / 100.0;
-					
-					rotate_scaled_sprite(sprBMP3, sprBMP, 0, 0, 0,ftofix(new_scale));
-					
-					draw_sprite(dest, sprBMP3, x, y+playing_field_offset);
-					
+					if ( scale ) 
+					{
+						double new_scale = scale / 100.0;
+						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation),ftofix(new_scale));
+					}
+					else rotate_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(rotation));
+					draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
 					
 				}
 				else
 				{
-					if(drawstyle==0 || drawstyle==3)
-					    overtile16(dest,tile,sx,sy,cs,flip);
-					else if(drawstyle==1)
-					    overtiletranslucent16(dest,tile,sx,sy,cs,flip,128);
-					else if(drawstyle==2)
-					    overtilecloaked16(dest,tile,sx,sy,flip);
+					if ( scale ) 
+					{
+						double new_scale = scale / 100.0;
+						rotate_scaled_sprite(sprBMP2, sprBMP, 0, 0, deg_to_fixed(0),ftofix(new_scale));
+						draw_sprite(dest, sprBMP2, x, y+playing_field_offset);
+					}
+					else draw_sprite(dest, sprBMP, x, y+playing_field_offset);
 				}
-			}
 			destroy_bitmap(sprBMP);
 			destroy_bitmap(sprBMP2);
-			destroy_bitmap(sprBMP3);
 			break;
 		}
             }


### PR DESCRIPTION
All sprites now support scaling and rotation, in all extend and flip modes.

This includes a partial rewrite of sprite::draw. It may have a performance hit, but only time will tell. 