### PR TITLE
Fix type issues

### DIFF
--- a/src/parser/SemanticAnalyzer.cpp
+++ b/src/parser/SemanticAnalyzer.cpp
@@ -1018,7 +1018,7 @@ void SemanticAnalyzer::caseExprEQ(ASTExprEQ& host, void*)
 	RecursiveVisitor::caseExprEQ(host);
 	if (breakRecursion(host)) return;
 
-	checkCast(*host.right->getReadType(scope, this), *host.left->getReadType(scope, this), &host);
+	checkCast(*host.right->getReadType(scope, this), *host.left->getReadType(scope, this), &host, true);
 	if (breakRecursion(host)) return;
 }
 
@@ -1027,7 +1027,7 @@ void SemanticAnalyzer::caseExprNE(ASTExprNE& host, void*)
 	RecursiveVisitor::caseExprNE(host);
 	if (breakRecursion(host)) return;
 
-	checkCast(*host.right->getReadType(scope, this), *host.left->getReadType(scope, this), &host);
+	checkCast(*host.right->getReadType(scope, this), *host.left->getReadType(scope, this), &host, true);
 	if (breakRecursion(host)) return;
 }
 
@@ -1190,9 +1190,10 @@ void SemanticAnalyzer::caseOptionValue(ASTOptionValue& host, void*)
 }
 
 void SemanticAnalyzer::checkCast(
-		DataType const& sourceType, DataType const& targetType, AST* node)
+		DataType const& sourceType, DataType const& targetType, AST* node, bool twoWay)
 {
 	if (sourceType.canCastTo(targetType)) return;
+	if (twoWay && targetType.canCastTo(sourceType)) return;
 	handleError(
 		CompileError::IllegalCast(
 			node, sourceType.getName(), targetType.getName()));

--- a/src/parser/SemanticAnalyzer.cpp
+++ b/src/parser/SemanticAnalyzer.cpp
@@ -1018,7 +1018,7 @@ void SemanticAnalyzer::caseExprEQ(ASTExprEQ& host, void*)
 	RecursiveVisitor::caseExprEQ(host);
 	if (breakRecursion(host)) return;
 
-	checkCast(*host.right->getReadType(scope, this), *host.left->getReadType(scope, this));
+	checkCast(*host.right->getReadType(scope, this), *host.left->getReadType(scope, this), &host);
 	if (breakRecursion(host)) return;
 }
 
@@ -1027,7 +1027,7 @@ void SemanticAnalyzer::caseExprNE(ASTExprNE& host, void*)
 	RecursiveVisitor::caseExprNE(host);
 	if (breakRecursion(host)) return;
 
-	checkCast(*host.right->getReadType(scope, this), *host.left->getReadType(scope, this));
+	checkCast(*host.right->getReadType(scope, this), *host.left->getReadType(scope, this), &host);
 	if (breakRecursion(host)) return;
 }
 

--- a/src/parser/SemanticAnalyzer.h
+++ b/src/parser/SemanticAnalyzer.h
@@ -98,7 +98,8 @@ namespace ZScript
 		// Signal a compile error if source can't be cast to target.
 		void checkCast(ZScript::DataType const& sourceType,
 		               ZScript::DataType const& targetType,
-		               AST* node = NULL);
+		               AST* node = NULL,
+		               bool twoWay = false);
 
 		void analyzeFunctionInternals(ZScript::Function& function);
 


### PR DESCRIPTION
`==` and `!=` failed to properly report type-checking errors

`==` and `!=` only checked `right caststo left`, not `left caststo right`; either should be valid for these operations. (i.e. `1 == true` should be valid, as `true == 1` is valid)