### PR TITLE
Fix using in namespace, and using namespaces from current scope

### DIFF
--- a/src/parser/ASTVisitors.cpp
+++ b/src/parser/ASTVisitors.cpp
@@ -217,6 +217,8 @@ void RecursiveVisitor::caseNamespace(ASTNamespace& host, void* param)
 	if (breakRecursion(host, param)) return;
 	visit(host, host.scriptTypes, param);
 	if (breakRecursion(host, param)) return;
+	visit(host, host.use, param);
+	if (breakRecursion(host, param)) return;
 	visit(host, host.namespaces, param);
 	if (breakRecursion(host, param)) return;
 	visit(host, host.variables, param);

--- a/src/parser/Scope.cpp
+++ b/src/parser/Scope.cpp
@@ -503,6 +503,14 @@ int BasicScope::useNamespace(std::string name)
 			++numMatches;
 		}
 	}
+	if(Scope* scope = getChild(name))
+	{
+		if(scope->isNamespace())
+		{
+			namesp = static_cast<NamespaceScope*>(scope);
+			++numMatches;
+		}
+	}
 	for(vector<NamespaceScope*>::iterator it = usingNamespaces.begin();
 		it != usingNamespaces.end(); ++it)
 	{


### PR DESCRIPTION
Using did not work in namespace, due to an oversight.
Using could not find namespaces in the current scope, due to an oversight.
These have both been corrected.