### PR TITLE
Fix: Bitmap Pointers

### DIFF
--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -14212,6 +14212,14 @@ INLINE void set_drawing_command_args(const int j, const word numargs)
         script_drawing_commands[j][k] = SH::read_stack(ri->sp + (numargs - k));
 }
 
+INLINE void set_user_bitmap_command_args(const int j, const word numargs)
+{
+	//ri->bitmapref = SH::read_stack(ri->sp+numargs);
+	//Z_scripterrlog("Current drawing bitmap ref is: %d\n", ri->bitmapref );
+    for(int k = 1; k <= numargs; k++)
+        script_drawing_commands[j][k] = SH::read_stack(ri->sp + (numargs - k));
+}
+
 void do_drawing_command(const int script_command)
 {
     int j = script_drawing_commands.GetNext();
@@ -14393,22 +14401,27 @@ void do_drawing_command(const int script_command)
     }
     break;
     
-     case 	BMPRECTR:	set_drawing_command_args(j, 12); break;
-	case 	BMPCIRCLER:	set_drawing_command_args(j, 11); break;
-	case 	BMPARCR:	set_drawing_command_args(j, 14); break;
-	case 	BMPELLIPSER:	set_drawing_command_args(j, 12); break;
-	case 	BMPLINER:	set_drawing_command_args(j, 11); break;
-	case 	BMPSPLINER:	set_drawing_command_args(j, 11); break;
-	case 	BMPPUTPIXELR:	set_drawing_command_args(j, 8); break;
-	case 	BMPDRAWTILER:	set_drawing_command_args(j, 15); break;
-	case 	BMPDRAWCOMBOR:	set_drawing_command_args(j, 16); break;
-	case 	BMPFASTTILER:	set_drawing_command_args(j, 6); break;
-	case 	BMPFASTCOMBOR:	set_drawing_command_args(j, 6); break;
-	case 	BMPDRAWCHARR:	set_drawing_command_args(j, 10); break;
-	case 	BMPDRAWINTR:	set_drawing_command_args(j, 11); break;
+     case 	BMPRECTR:	
+     {
+	     
+    set_user_bitmap_command_args(j, 12); script_drawing_commands[j][17] = SH::read_stack(ri->sp+12); break;
+     }
+	case 	BMPCIRCLER:	script_drawing_commands[j][17] = SH::read_stack(ri->sp+11); set_user_bitmap_command_args(j, 11); break;
+	case 	BMPARCR:	script_drawing_commands[j][17] = SH::read_stack(ri->sp+14); set_user_bitmap_command_args(j, 14); break;
+	case 	BMPELLIPSER:	script_drawing_commands[j][17] = SH::read_stack(ri->sp+12); set_user_bitmap_command_args(j, 12); break;
+	case 	BMPLINER:	script_drawing_commands[j][17] = SH::read_stack(ri->sp+11); set_user_bitmap_command_args(j, 11); break;
+	case 	BMPSPLINER:	script_drawing_commands[j][17] = SH::read_stack(ri->sp+11); set_user_bitmap_command_args(j, 11); break;
+	case 	BMPPUTPIXELR:	script_drawing_commands[j][17] = SH::read_stack(ri->sp+8); set_user_bitmap_command_args(j, 8); break;
+	case 	BMPDRAWTILER:	script_drawing_commands[j][17] = SH::read_stack(ri->sp+15); set_user_bitmap_command_args(j, 15); break;
+	case 	BMPDRAWCOMBOR:	script_drawing_commands[j][17] = SH::read_stack(ri->sp+16); set_user_bitmap_command_args(j, 16); break;
+	case 	BMPFASTTILER:	script_drawing_commands[j][17] = SH::read_stack(ri->sp+6); set_user_bitmap_command_args(j, 6); break;
+	case 	BMPFASTCOMBOR:  script_drawing_commands[j][17] = SH::read_stack(ri->sp+6); set_user_bitmap_command_args(j, 6); break;
+	case 	BMPDRAWCHARR:	script_drawing_commands[j][17] = SH::read_stack(ri->sp+10); set_user_bitmap_command_args(j, 10); break;
+	case 	BMPDRAWINTR:	script_drawing_commands[j][17] = SH::read_stack(ri->sp+11); set_user_bitmap_command_args(j, 11); break;
 	case 	BMPDRAWSTRINGR:	
 	{
-		set_drawing_command_args(j, 9);
+		set_user_bitmap_command_args(j, 9);
+		script_drawing_commands[j][17] = SH::read_stack(ri->sp+9);
 		// Unused
 		//const int index = script_drawing_commands[j][19] = j;
 		
@@ -14418,9 +14431,10 @@ void do_drawing_command(const int script_command)
 		
 	}
 	break;
-	case 	BMPQUADR:	set_drawing_command_args(j, 15); break;
+	case 	BMPQUADR:	script_drawing_commands[j][17] = SH::read_stack(ri->sp+15); set_user_bitmap_command_args(j, 15);  break;
 	case 	BMPQUAD3DR:
 	{
+		
 		std::vector<long> *v = script_drawing_commands.GetVector();
 		v->resize(26, 0);
 		
@@ -14436,12 +14450,14 @@ void do_drawing_command(const int script_command)
 		ArrayH::getValues(script_drawing_commands[j][5] / 10000, size, 2);
 		
 		script_drawing_commands[j].SetVector(v);
+		script_drawing_commands[j][17] = SH::read_stack(ri->sp+8);
 		
 	}
 	break;
-	case 	BMPTRIANGLER:	set_drawing_command_args(j, 13); break;
+	case 	BMPTRIANGLER:	set_user_bitmap_command_args(j, 13); script_drawing_commands[j][17] = SH::read_stack(ri->sp+13); break;
 	case 	BMPTRIANGLE3DR:
 	{
+	
 		std::vector<long> *v = script_drawing_commands.GetVector();
 		v->resize(20, 0);
 		
@@ -14457,12 +14473,20 @@ void do_drawing_command(const int script_command)
 		ArrayH::getValues(script_drawing_commands[j][5] / 10000, size, 2);
 		
 		script_drawing_commands[j].SetVector(v);
+		script_drawing_commands[j][17] = SH::read_stack(ri->sp+8);
 		break;
 	}
 	//case 	BMPPOLYGONR:
-	case 	BMPDRAWLAYERR: 	set_drawing_command_args(j, 8); break;
-	case 	BMPDRAWSCREENR:	set_drawing_command_args(j, 6); break;
-	case 	BMPBLIT:	set_drawing_command_args(j, 16); break;
+	case 	BMPDRAWLAYERR: set_user_bitmap_command_args(j, 8); script_drawing_commands[j][17] = SH::read_stack(ri->sp+8); break;
+	case 	BMPDRAWSCREENR: set_user_bitmap_command_args(j, 6); script_drawing_commands[j][17] = SH::read_stack(ri->sp+6); break;
+	case 	BMPBLIT:	
+	{
+		
+		//for(int q = 0; q < 8; ++q )
+		//Z_scripterrlog("FFscript blit() ri->d[%d] is: %d\n", q, ri->d[q]);
+		script_drawing_commands[j][17] = SH::read_stack(ri->sp+16);
+		set_user_bitmap_command_args(j, 16); break;
+	}
     
     
     }
@@ -17211,6 +17235,9 @@ int run_script(const byte type, const word script, const long i)
 		case BITMAPEXR:
 		case DRAWLAYERR:
 		case DRAWSCREENR:
+			do_drawing_command(scommand);
+		    break;
+		
 		case 	BMPRECTR:	
 		case 	BMPCIRCLER:
 		case 	BMPARCR:
@@ -18147,11 +18174,17 @@ script_bitmaps scb;
 
 void FFScript::do_isvalidbitmap()
 {
-	Z_scripterrlog("isValidBitmap() bitmap pointer value is %d\n", ri->bitmapref);
-	if ( ri->bitmapref <= 0 ) set_register(sarg1, 0);
-	else if ( scb.script_created_bitmaps[ri->bitmapref-10].u_bmp ) 
+	
+	long UID = get_register(sarg1);
+	Z_scripterrlog("isValidBitmap() bitmap pointer value is %d\n", UID);
+	if ( UID <= 0 ) set_register(sarg1, 0); 
+	else if ( scb.script_created_bitmaps[UID-10].u_bmp ) 
 		set_register(sarg1, 10000);
 	else set_register(sarg1, 0);
+	
+	
+	
+	
 }
 
 void FFScript::user_bitmaps_init()
@@ -18194,7 +18227,7 @@ long FFScript::do_create_bitmap()
 	
 	if ( highest_valid_user_bitmap() >= (MAX_USER_BITMAPS-1) )
 	{
-		ri->bitmapref = 0;
+		//ri->bitmapref = 0;
 		Z_scripterrlog("Script attempted to create a bitmap, but no bitmaps are available. Setting ri->bitmapref to: %d\n", ri->bitmapref);
 		return id;
 	}
@@ -18213,11 +18246,11 @@ long FFScript::do_create_bitmap()
 			if ( id == 0 )
 			{
 				Z_scripterrlog("FFCore.do_create_bitmap() id is %d\n", id);
-				ri->bitmapref = -2;
+				return -2; //ri->bitmapref = -2;
 			}
 			else
 			{
-				ri->bitmapref = id+10; 
+				return id+10; //ri->bitmapref = id+10; 
 				
 				Z_eventlog("Script created bitmap ID %d, pointer (%d) with height of %d and width of %d\n", id, ri->bitmapref, h,w);
 	

--- a/src/parser/GlobalSymbols.cpp
+++ b/src/parser/GlobalSymbols.cpp
@@ -7359,7 +7359,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(12, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
 		code.push_back(new OReturn());
         
 		function->giveCode(code);
@@ -7374,7 +7374,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(11, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7389,7 +7389,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(14, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7404,7 +7404,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(12, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7419,7 +7419,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(11, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7434,7 +7434,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(11, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7449,7 +7449,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(8, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7464,7 +7464,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(10, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7479,7 +7479,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(11, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7494,7 +7494,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(15, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7509,7 +7509,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(16, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7524,7 +7524,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(15, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7540,7 +7540,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(6, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7556,7 +7556,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(13, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7572,7 +7572,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(8, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7587,7 +7587,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(8, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7603,7 +7603,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(6, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7618,7 +7618,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(6, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7633,7 +7633,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(9, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7648,7 +7648,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(8, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7663,7 +7663,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(first);
 		POP_ARGS(6, EXP2);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(NUL)));
+		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
 		code.push_back(new OReturn());
 		function->giveCode(code);
@@ -7685,7 +7685,7 @@ void BitmapSymbols::generateCode()
 		code.push_back(new OReturn());
 		function->giveCode(code);
 	}
-	//bool isValid(item)
+	//bool isValid(bitmap)
 	{
 		Function* function = getFunction("isValid");
 		int label = function->getLabel();

--- a/src/script_drawing.cpp
+++ b/src/script_drawing.cpp
@@ -3664,6 +3664,8 @@ inline void do_drawtriangle3dr(BITMAP *bmp, int i, int *sdci, int xoffset, int y
 
 inline void bmp_do_rectr(BITMAP *bmp, int *sdci, int xoffset, int yoffset)
 {
+	Z_scripterrlog("bmp_do_rectr ri->bitmapref is: %d\n", ri->bitmapref);
+	//Z_scripterrlog("rect sdci[13] is: %d\n", sdci[13]);
     //sdci[1]=layer
     //sdci[2]=x
     //sdci[3]=y
@@ -3680,12 +3682,12 @@ inline void bmp_do_rectr(BITMAP *bmp, int *sdci, int xoffset, int yoffset)
     {
         return;
     }
-    if ( ri->bitmapref <= 0 ) 
+    if ( sdci[17] <= 0 ) 
     {
-	Z_scripterrlog("bitmap->Rectangle() wanted to write to an invalid bitmap id: %d. Aborting.\n", ri->bitmapref);
+	Z_scripterrlog("bitmap->Rectangle() wanted to write to an invalid bitmap id: %d. Aborting.\n", sdci[17]);
 	return;
     }
-    BITMAP *refbmp = FFCore.GetScriptBitmap(ri->bitmapref-10);
+    BITMAP *refbmp = FFCore.GetScriptBitmap(sdci[17]-10);
 	if ( refbmp == NULL ) return;
     
     int x1=sdci[2]/10000;
@@ -3783,6 +3785,7 @@ inline void bmp_do_rectr(BITMAP *bmp, int *sdci, int xoffset, int yoffset)
 
 inline void bmp_do_circler(BITMAP *bmp, int *sdci, int xoffset, int yoffset)
 {
+	Z_scripterrlog("bmp_do_circler ri->bitmapref is: %d\n", ri->bitmapref);
     //sdci[1]=layer
     //sdci[2]=x
     //sdci[3]=y
@@ -5064,6 +5067,7 @@ inline void bmp_do_drawintr(BITMAP *bmp, int *sdci, int xoffset, int yoffset)
 
 inline void bmp_do_drawstringr(BITMAP *bmp, int i, int *sdci, int xoffset, int yoffset)
 {
+	Z_scripterrlog("bmp_do_drawstringr ri->bitmapref is: %d\n", ri->bitmapref);
     //sdci[1]=layer
     //sdci[2]=x
     //sdci[3]=y
@@ -5073,13 +5077,13 @@ inline void bmp_do_drawstringr(BITMAP *bmp, int i, int *sdci, int xoffset, int y
     //sdci[7]=format_option
     //sdci[8]=string
     //sdci[9]=opacity
-    if ( ri->bitmapref <= 0 )
+    if ( sdci[17] <= 0 )
     {
 	Z_scripterrlog("bitmap->DrawString() wanted to write to an invalid bitmap id: %d. Aborting.\n", ri->bitmapref);
 	return;
     }
 	
-	BITMAP *refbmp = FFCore.GetScriptBitmap(ri->bitmapref-10);
+	BITMAP *refbmp = FFCore.GetScriptBitmap(sdci[17]-10);
 	if ( refbmp == NULL ) return;
     
     std::string* str = (std::string*)script_drawing_commands[i].GetPtr();
@@ -5150,12 +5154,13 @@ inline void bmp_do_drawquadr(BITMAP *bmp, int *sdci, int xoffset, int yoffset)
     //sdci[13]=flip
     //sdci[14]=tile/combo
     //sdci[15]=polytype
-    if ( ri->bitmapref <= 0 )
+	Z_scripterrlog("bitmap quad pointer: %d\n", sdci[17]);
+    if ( sdci[17] <= 0 )
     {
-	Z_scripterrlog("bitmap->Quad() wanted to write to an invalid bitmap id: %d. Aborting.\n", ri->bitmapref);
+	Z_scripterrlog("bitmap->Quad() wanted to write to an invalid bitmap id: %d. Aborting.\n", sdci[17]);
 	return;
     }
-	BITMAP *refbmp = FFCore.GetScriptBitmap(ri->bitmapref-10);
+	BITMAP *refbmp = FFCore.GetScriptBitmap(sdci[17]-10);
 	if ( refbmp == NULL ) return;
     
     int x1 = sdci[2]/10000;
@@ -5427,7 +5432,7 @@ inline void bmp_do_drawbitmapexr(BITMAP *bmp, int *sdci, int xoffset, int yoffse
 	bool masked = (sdci[16] != 0);
 	
 	int ref = 0;
-	ref = ri->bitmapref;
+	ref = sdci[17];
 	//Z_scripterrlog("bitmap->blit() ref id this frame is: %d\n", ref);
 	ref -=10;
 	//Z_scripterrlog("bitmap->blit() modified ref id this frame is: %d\n", ref);


### PR DESCRIPTION
Changelog: Bitmap drawing now respects the correct bitmap pointers.
The bitmap pointer value is now always stored in sdci[17].

This fixes all bitmap draw functions, as far as I can tell. Stuff such as Quad3D may need more extensive testing.

This also fixes Debug->SP to read/write the correct values. 