### PR TITLE
Parser: change `RELATIONAL_OP_RETURN_DECIMAL` to `BOOL_TRUE_RETURN_DECIMAL`

### DIFF
--- a/src/parser/AST.cpp
+++ b/src/parser/AST.cpp
@@ -1007,7 +1007,7 @@ optional<long> ASTExprNot::getCompileTimeValue(
 {
 	if (!operand) return nullopt;
 	if (optional<long> value = operand->getCompileTimeValue(errorHandler, scope))
-		return *value ? 0L : 10000L;
+		return *value ? 0L : (*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) ? 1L : 10000L);
 	return nullopt;
 }
 
@@ -1145,7 +1145,7 @@ optional<long> ASTExprAnd::getCompileTimeValue(
 	if(short_circuit && !*leftValue) return 0L; //Cut it short if we already know the result, and the option is on.
 	optional<long> rightValue = right->getCompileTimeValue(errorHandler, scope);
 	if (!rightValue) return nullopt;
-	return (*leftValue && *rightValue) ? 10000L : 0L;
+	return (*leftValue && *rightValue) ? (*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) ? 1L : 10000L) : 0L;
 }
 
 // ASTExprOr
@@ -1171,7 +1171,7 @@ optional<long> ASTExprOr::getCompileTimeValue(
 	if(short_circuit && *leftValue) return 10000L; //Cut it short if we already know the result, and the option is on.
 	optional<long> rightValue = right->getCompileTimeValue(errorHandler, scope);
 	if (!rightValue) return nullopt;
-	return (*leftValue || *rightValue) ? 10000L : 0L;
+	return (*leftValue || *rightValue) ? (*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) ? 1L : 10000L) : 0L;
 }
 
 // ASTRelExpr
@@ -1202,7 +1202,7 @@ optional<long> ASTExprGT::getCompileTimeValue(
 	if (!leftValue) return nullopt;
 	optional<long> rightValue = right->getCompileTimeValue(errorHandler, scope);
 	if (!rightValue) return nullopt;
-	return (*leftValue > *rightValue) ? 10000L : 0L;
+	return (*leftValue > *rightValue) ? (*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) ? 1L : 10000L) : 0L;
 }
 
 // ASTExprGE
@@ -1226,7 +1226,7 @@ optional<long> ASTExprGE::getCompileTimeValue(
 	if (!leftValue) return nullopt;
 	optional<long> rightValue = right->getCompileTimeValue(errorHandler, scope);
 	if (!rightValue) return nullopt;
-	return (*leftValue >= *rightValue) ? 10000L : 0L;
+	return (*leftValue >= *rightValue) ? (*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) ? 1L : 10000L) : 0L;
 }
 
 // ASTExprLT
@@ -1250,7 +1250,7 @@ optional<long> ASTExprLT::getCompileTimeValue(
 	if (!leftValue) return nullopt;
 	optional<long> rightValue = right->getCompileTimeValue(errorHandler, scope);
 	if (!rightValue) return nullopt;
-	return (*leftValue < *rightValue) ? 10000L : 0L;
+	return (*leftValue < *rightValue) ? (*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) ? 1L : 10000L) : 0L;
 }
 
 // ASTExprLE
@@ -1274,7 +1274,7 @@ optional<long> ASTExprLE::getCompileTimeValue(
 	if (!leftValue) return nullopt;
 	optional<long> rightValue = right->getCompileTimeValue(errorHandler, scope);
 	if (!rightValue) return nullopt;
-	return (*leftValue <= *rightValue) ? 10000L : 0L;
+	return (*leftValue <= *rightValue) ? (*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) ? 1L : 10000L) : 0L;
 }
 
 // ASTExprEQ
@@ -1298,7 +1298,7 @@ optional<long> ASTExprEQ::getCompileTimeValue(
 	if (!leftValue) return nullopt;
 	optional<long> rightValue = right->getCompileTimeValue(errorHandler, scope);
 	if (!rightValue) return nullopt;
-	return (*leftValue == *rightValue) ? 10000L : 0L;
+	return (*leftValue == *rightValue) ? (*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) ? 1L : 10000L) : 0L;
 }
 
 // ASTExprNE
@@ -1322,7 +1322,7 @@ optional<long> ASTExprNE::getCompileTimeValue(
 	if (!leftValue) return nullopt;
 	optional<long> rightValue = right->getCompileTimeValue(errorHandler, scope);
 	if (!rightValue) return nullopt;
-	return (*leftValue != *rightValue) ? 10000L : 0L;
+	return (*leftValue != *rightValue) ? (*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) ? 1L : 10000L) : 0L;
 }
 
 // ASTAddExpr

--- a/src/parser/AST.h
+++ b/src/parser/AST.h
@@ -22,6 +22,7 @@ namespace ZScript
 #include "y.tab.hpp"
 #include "Compiler.h"
 #include "CompileOption.h"
+#include "Scope.h"
 #include "owning_ptr.h"
 #include "owning_vector.h"
 
@@ -1590,7 +1591,7 @@ namespace ZScript
 		optional<long> getCompileTimeValue(
 				CompileErrorHandler* errorHandler = NULL, Scope* scope = NULL)
 				const {
-			return value ? 10000L : 0L;}
+					return value ? (*ZScript::lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) ? 1L : 10000L) : 0L;}
 		virtual DataType const* getReadType(Scope* scope, CompileErrorHandler* errorHandler) {return &DataType::BOOL;}
 	
 		bool value;

--- a/src/parser/BuildVisitors.cpp
+++ b/src/parser/BuildVisitors.cpp
@@ -674,7 +674,7 @@ void BuildOpcodes::caseExprNot(ASTExprNot& host, void* param)
     visit(host.operand.get(), param);
     addOpcode(new OCompareImmediate(new VarArgument(EXP1), new LiteralArgument(0)));
     addOpcode(new OSetTrue(new VarArgument(EXP1)));
-	if(*lookupOption(*scope, CompileOption::OPT_RELATIONAL_OP_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
+	if(*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
 }
 
 void BuildOpcodes::caseExprBitNot(ASTExprBitNot& host, void* param)
@@ -785,7 +785,7 @@ void BuildOpcodes::caseExprAnd(ASTExprAnd& host, void* param)
 		ocode->setLabel(skip);
 		addOpcode(ocode);
 		addOpcode(new OSetMore(new VarArgument(EXP1)));
-		if(*lookupOption(*scope, CompileOption::OPT_RELATIONAL_OP_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
+		if(*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
 	}
 	else
 	{
@@ -802,7 +802,7 @@ void BuildOpcodes::caseExprAnd(ASTExprAnd& host, void* param)
 		addOpcode(new OAddRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
 		addOpcode(new OCompareImmediate(new VarArgument(EXP1), new LiteralArgument(2)));
 		addOpcode(new OSetMore(new VarArgument(EXP1)));
-		if(*lookupOption(*scope, CompileOption::OPT_RELATIONAL_OP_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
+		if(*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
 	}
 }
 
@@ -829,7 +829,7 @@ void BuildOpcodes::caseExprOr(ASTExprOr& host, void* param)
 		Opcode* ocode = new OSetMore(new VarArgument(EXP1));
 		if(short_circuit) ocode->setLabel(skip);
 		addOpcode(ocode);
-		if(*lookupOption(*scope, CompileOption::OPT_RELATIONAL_OP_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
+		if(*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
 	}
 	else
 	{
@@ -844,7 +844,7 @@ void BuildOpcodes::caseExprOr(ASTExprOr& host, void* param)
 		addOpcode(new OAddRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
 		addOpcode(new OCompareImmediate(new VarArgument(EXP1), new LiteralArgument(1)));
 		addOpcode(new OSetMore(new VarArgument(EXP1)));		
-		if(*lookupOption(*scope, CompileOption::OPT_RELATIONAL_OP_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
+		if(*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
 	}
 }
 
@@ -865,7 +865,7 @@ void BuildOpcodes::caseExprGT(ASTExprGT& host, void* param)
     addOpcode(new OSetLess(new VarArgument(EXP1)));
     addOpcode(new OCompareImmediate(new VarArgument(EXP1), new LiteralArgument(0)));
     addOpcode(new OSetTrue(new VarArgument(EXP1)));
-	if(*lookupOption(*scope, CompileOption::OPT_RELATIONAL_OP_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
+	if(*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
 }
 
 void BuildOpcodes::caseExprGE(ASTExprGE& host, void* param)
@@ -883,7 +883,7 @@ void BuildOpcodes::caseExprGE(ASTExprGE& host, void* param)
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OCompareRegister(new VarArgument(EXP2), new VarArgument(EXP1)));
     addOpcode(new OSetMore(new VarArgument(EXP1)));
-	if(*lookupOption(*scope, CompileOption::OPT_RELATIONAL_OP_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
+	if(*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
 }
 
 void BuildOpcodes::caseExprLT(ASTExprLT& host, void* param)
@@ -903,7 +903,7 @@ void BuildOpcodes::caseExprLT(ASTExprLT& host, void* param)
     addOpcode(new OSetMore(new VarArgument(EXP1)));
     addOpcode(new OCompareImmediate(new VarArgument(EXP1), new LiteralArgument(0)));
     addOpcode(new OSetTrue(new VarArgument(EXP1)));
-	if(*lookupOption(*scope, CompileOption::OPT_RELATIONAL_OP_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
+	if(*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
 }
 
 void BuildOpcodes::caseExprLE(ASTExprLE& host, void* param)
@@ -921,7 +921,7 @@ void BuildOpcodes::caseExprLE(ASTExprLE& host, void* param)
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OCompareRegister(new VarArgument(EXP2), new VarArgument(EXP1)));
     addOpcode(new OSetLess(new VarArgument(EXP1)));
-	if(*lookupOption(*scope, CompileOption::OPT_RELATIONAL_OP_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
+	if(*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
 }
 
 void BuildOpcodes::caseExprEQ(ASTExprEQ& host, void* param)
@@ -949,7 +949,7 @@ void BuildOpcodes::caseExprEQ(ASTExprEQ& host, void* param)
 
     addOpcode(new OCompareRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
     addOpcode(new OSetTrue(new VarArgument(EXP1)));
-	if(*lookupOption(*scope, CompileOption::OPT_RELATIONAL_OP_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
+	if(*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
 }
 
 void BuildOpcodes::caseExprNE(ASTExprNE& host, void* param)
@@ -977,7 +977,7 @@ void BuildOpcodes::caseExprNE(ASTExprNE& host, void* param)
 
     addOpcode(new OCompareRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
     addOpcode(new OSetFalse(new VarArgument(EXP1)));
-	if(*lookupOption(*scope, CompileOption::OPT_RELATIONAL_OP_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
+	if(*lookupOption(*scope, CompileOption::OPT_BOOL_TRUE_RETURN_DECIMAL) == 0) addOpcode(new OMultImmediate(new VarArgument(EXP1), new LiteralArgument(100000000)));
 }
 
 void BuildOpcodes::caseExprPlus(ASTExprPlus& host, void* param)

--- a/src/parser/CompileOption.xtable
+++ b/src/parser/CompileOption.xtable
@@ -3,7 +3,7 @@
 X(	NO_LOGGING,                                      qr_PARSER_NO_LOGGING,            OPTTYPE_QR,                     10000)
 X(	TRUNCATE_DIVISION_BY_LITERAL_BUG,               qr_PARSER_250DIVISION,            OPTTYPE_QR,                     00000)
 X(	SHORT_CIRCUIT,                                qr_PARSER_SHORT_CIRCUIT,            OPTTYPE_QR,                     00000)
-X(	RELATIONAL_OP_RETURN_DECIMAL,                 qr_PARSER_RELOP_DECIMAL,            OPTTYPE_QR,                     00000)
+X(	BOOL_TRUE_RETURN_DECIMAL,                 qr_PARSER_BOOL_TRUE_DECIMAL,            OPTTYPE_QR,                     00000)
 X(	HEADER_GUARD,                                                       0,        OPTTYPE_CONFIG,                     30000)
 X(	NO_ERROR_HALT,                                                      0,        OPTTYPE_CONFIG,                     00000)
 X(	MAX_INT_ONE_LARGER,                      qr_PARSER_MAX_INT_ONE_LARGER,            OPTTYPE_QR,                     10000)

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -847,7 +847,7 @@ enum
 	qr_PARSER_250DIVISION = 80*8, //2.50 integer division bug emulation
 	qr_PARSER_NO_LOGGING, //Default off. If on, `Trace()` does not do anything.
 	qr_PARSER_SHORT_CIRCUIT, //Default off.
-	qr_PARSER_RELOP_DECIMAL, //Default off
+	qr_PARSER_BOOL_TRUE_DECIMAL, //Default off
 	qr_LINKXY_IS_FLOAT,
 	qr_PARSER_MAX_INT_ONE_LARGER, //Default on
 	qr_WPNANIMFIX, /* Not Implemented : This was in 2.50.2, but never used. */ 

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -20095,7 +20095,7 @@ static DIALOG zscript_parser_dlg[] =
     { jwin_check_proc,      10, 32+10,  185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "2.50 Division Truncation", NULL, NULL },
     { jwin_check_proc,      10, 32+20,  185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "Disable Tracing", NULL, NULL },
     { jwin_check_proc,      10, 32+30,  185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "Short-Circuit Boolean Operations", NULL, NULL },
-    { jwin_check_proc,      10, 32+40,  185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "2.50 Relational Operators Give 0.0001 For True", NULL, NULL },
+    { jwin_check_proc,      10, 32+40,  185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "2.50 Value of Boolean 'true' is 0.0001", NULL, NULL },
     //10
     { d_showedit_proc,      6+10,  122,   220,   16,    vc(12),  vc(1),  0,       0,          64,            0,       tempincludepath, NULL, NULL },
     { jwin_textbox_proc,    6+10,  140,   220,  60,   vc(11),  vc(1),  0,       0,          64,            0,       tempincludepath, NULL, NULL },
@@ -20132,7 +20132,7 @@ static int zscripparsertrules[] =
 	qr_PARSER_250DIVISION,
 	qr_PARSER_NO_LOGGING,
 	qr_PARSER_SHORT_CIRCUIT,
-	qr_PARSER_RELOP_DECIMAL,
+	qr_PARSER_BOOL_TRUE_DECIMAL,
 	NULL, //this dialogue index is used by global settings
 	NULL, //this dialogue index is used by global settings
 	NULL, //this dialogue index is used by global settings


### PR DESCRIPTION
Now, instead of just relational operators, it also includes `true` itself.
Also, the option previously failed to affect constant expressions; this has been fixed.