### PR TITLE
Fix Sprite Script RefInfo Memory Leak

### DIFF
--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -15947,10 +15947,11 @@ int run_script(const byte type, const word script, const long i)
 	    {
 			int npc_index = GuyH::getNPCIndex(i);
 			enemy *w = (enemy*)guys.spr(npc_index);
-			ri = w->refinfo;
-			if (!ri) {
-			  ri = w->refinfo = new refInfo;
-			}
+			//ri = w->refinfo;
+			//if (!ri) {
+			//  ri = w->refinfo = new refInfo;
+			//}
+		        ri = &(guys.spr(GuyH::getNPCIndex(i))->scriptData);
 			//curscript = guyscripts[script];
 			curscript = guyscripts[guys.spr(GuyH::getNPCIndex(i))->script];
 			
@@ -16023,10 +16024,11 @@ int run_script(const byte type, const word script, const long i)
 			int lwpn_index = LwpnH::getLWeaponIndex(i);
 			//ri = &(lweaponScriptData[i]);
 			weapon *w = (weapon*)Lwpns.spr(lwpn_index);
-			ri = w->refinfo;
-			if (!ri) {
-			  ri = w->refinfo = new refInfo;
-			}
+			ri = &(Lwpns.spr(LwpnH::getLWeaponIndex(i))->scriptData);
+			//ri = w->refinfo;
+			//if (!ri) {
+			//  ri = w->refinfo = new refInfo;
+			//}
 			//curscript = lwpnscripts[script];
 			curscript = lwpnscripts[Lwpns.spr(LwpnH::getLWeaponIndex(i))->weaponscript];
 			//Z_scripterrlog("FFScript is trying to run lweapon script: %d\n", curscript);
@@ -16104,10 +16106,11 @@ int run_script(const byte type, const word script, const long i)
 			int ewpn_index = EwpnH::getEWeaponIndex(i);
 			//ri = &(lweaponScriptData[i]);
 			weapon *w = (weapon*)Ewpns.spr(ewpn_index);
-			ri = w->refinfo;
-			if (!ri) {
-			  ri = w->refinfo = new refInfo;
-			}
+			ri = &(Ewpns.spr(EwpnH::getEWeaponIndex(i))->scriptData);
+			//ri = w->refinfo;
+			//if (!ri) {
+			//  ri = w->refinfo = new refInfo;
+			//}
 			curscript = ewpnscripts[Ewpns.spr(EwpnH::getEWeaponIndex(i))->weaponscript];
 			
 			
@@ -16130,10 +16133,11 @@ int run_script(const byte type, const word script, const long i)
 			int the_index = ItemH::getItemIndex(i);
 			//ri = &(lweaponScriptData[i]);
 			item *w = (item*)items.spr(the_index);
-			ri = w->refinfo;
-			if (!ri) {
-			  ri = w->refinfo = new refInfo;
-			}
+			ri = &(items.spr(ItemH::getItemIndex(i))->scriptData);
+			//ri = w->refinfo;
+			//if (!ri) {
+			//  ri = w->refinfo = new refInfo;
+			//}
 			curscript = itemspritescripts[items.spr(ItemH::getItemIndex(i))->script]; //Set the editor sprite script field to 'script'
 			
 			

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -89,7 +89,7 @@ sprite::sprite()
         dummy_float[i]=0;
         dummy_bool[i]=false;
     }
-    refinfo = 0;
+    
     //for(int i=0;i<8;i++)
     //{
     //  if(i<2) a[i]=0;
@@ -164,7 +164,6 @@ sprite::sprite(sprite const & other):
     drawstyle(other.drawstyle),
     extend(other.extend),
     wpnsprite(other.wpnsprite),
-    refinfo(other.refinfo),
     scriptData(other.scriptData),
 //ffcref(other.ffcref),
 //itemref(other.itemref),
@@ -255,7 +254,6 @@ sprite::sprite(fix X,fix Y,int T,int CS,int F,int Clk,int Yofs):
     for(int i=0; i<32; i++) miscellaneous[i] = 0;
     
     scriptcoldet = 1;
-    refinfo = 0;
     scriptData.Clear();
     //ewpnclass=0;
     //lwpnclass=0;
@@ -294,7 +292,7 @@ sprite::sprite(fix X,fix Y,int T,int CS,int F,int Clk,int Yofs):
 
 sprite::~sprite()
 {
-  delete refinfo;
+  
 }
 
 long sprite::getNextUID()

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -100,7 +100,7 @@ sprite::sprite()
     //sp=0;
     //itemclass=0;
     //ffcref=0;
-    //scriptData.Clear(); //when we have npc scripts we'll need this again, for now not.
+    scriptData.Clear(); //when we have npc scripts we'll need this again, for now not.
     doscript=1;
     for(int i=0; i<32; i++) miscellaneous[i] = 0;
     
@@ -165,7 +165,7 @@ sprite::sprite(sprite const & other):
     extend(other.extend),
     wpnsprite(other.wpnsprite),
     refinfo(other.refinfo),
-    //scriptData(other.scriptData),
+    scriptData(other.scriptData),
 //ffcref(other.ffcref),
 //itemref(other.itemref),
 //guyref(other.guyref),
@@ -256,7 +256,7 @@ sprite::sprite(fix X,fix Y,int T,int CS,int F,int Clk,int Yofs):
     
     scriptcoldet = 1;
     refinfo = 0;
-    //scriptData.Clear();
+    scriptData.Clear();
     //ewpnclass=0;
     //lwpnclass=0;
     //guyclass=0;

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -81,7 +81,6 @@ public:
     long stack[MAX_SCRIPT_REGISTERS];
     //Are you kidding? Really? 256 * sizeof(long) = 2048 bytes = 2kb of wasted memory for every sprite, and it'll never
     //even get used because item scripts only run for one frame. Gah! Maybe when we have npc scripts, not not now...
-    refInfo* refinfo;
     refInfo scriptData; //For when we have npc scripts maybe
     //long d[8];
     //long a[2];

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -82,7 +82,7 @@ public:
     //Are you kidding? Really? 256 * sizeof(long) = 2048 bytes = 2kb of wasted memory for every sprite, and it'll never
     //even get used because item scripts only run for one frame. Gah! Maybe when we have npc scripts, not not now...
     refInfo* refinfo;
-    //refInfo scriptData; //For when we have npc scripts maybe
+    refInfo scriptData; //For when we have npc scripts maybe
     //long d[8];
     //long a[2];
     //byte ffcref;


### PR DESCRIPTION
Re-coded the refInfo instance for the sprite superclass.

Refinfo now seems to work properly from the sprite class, in the class instance, without the hack from peter Hull, in ffscript.cpp that created a refInfo instance on the heap with 'new'.

The main issue with that hack, was that nothing called delete, to cull the refInfo instance, which made it an instant memory leak. 

This should resolve that, and everything *should* still work properly. 

