### PR TITLE
Feat: Add Screen Script Flag to Run on Screen init

### DIFF
--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -18931,6 +18931,8 @@ int run_script(const byte type, const word script, const long i)
 int ffscript_engine(const bool preload)
 {
     //run screen script, first
+	Z_scripterrlog("Screen Script Preload? %s \n", ( tmpscr->preloadscript ? "true" : "false"));
+	if(( preload && tmpscr->preloadscript) || !preload )
 	ZScriptVersion::RunScript(SCRIPT_SCREEN, tmpscr->script, 0);
     
     for(byte i = 0; i < MAXFFCS; i++)

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -13815,7 +13815,7 @@ void LinkClass::run_scrolling_script(int scrolldir, int cx, int sx, int sy, bool
 	ZScriptVersion::RunScript(SCRIPT_LINK, SCRIPT_LINK_ACTIVE);
     if ( dmap_doscript ) 
 	ZScriptVersion::RunScript(SCRIPT_DMAP, DMaps[currdmap].script,currdmap);
-    if ( tmpscr->script != 0 )
+    if ( tmpscr->script != 0 && tmpscr->preloadscript )
     {
 	ZScriptVersion::RunScript(SCRIPT_SCREEN, tmpscr->script, 0);    
     }

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -12794,7 +12794,23 @@ int readmapscreen(PACKFILE *f, zquestheader *Header, mapscr *temp_mapscr, zcmap 
 		}
 	}		
     }
-    
+    if ( version >= 21 )
+    {
+	if(!p_getc(&(temp_mapscr->preloadscript),f,true))
+	{
+		return qe_invalid;
+	}     
+    }
+    if ( version < 20 )
+    {
+	temp_mapscr->script = 0;
+	
+	for ( int q = 0; q < 8; q++ ) temp_mapscr->screeninitd[q] = 0;
+    }
+    if ( version < 21 )
+    {
+	temp_mapscr->preloadscript = 0;    
+    }
     //Dodongos in 2.10 used the boss roar, not the dodongo sound. -Z
     //May be any version before 2.11. -Z
     /* --not the roar, the HIT SFX

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -184,7 +184,7 @@ enum {ENC_METHOD_192B104=0, ENC_METHOD_192B105, ENC_METHOD_192B185, ENC_METHOD_2
 #define V_TILES            2 //2 is a long, max 214500 tiles (ZScript upper limit)
 #define V_COMBOS           12
 #define V_CSETS            4
-#define V_MAPS            20
+#define V_MAPS            21
 #define V_DMAPS            13
 #define V_DOORS            1
 #define V_ITEMS           44
@@ -1977,6 +1977,7 @@ struct mapscr
     word script;
     long screeninitd[8];
     byte screen_waitdraw;
+    byte preloadscript;
     unsigned long ffcswaitdraw;
     
     void zero_memory()
@@ -2136,6 +2137,7 @@ struct mapscr
 	
 	script = 0;
 	for ( int q = 0; q < 8; q++) screeninitd[q] = 0;
+	preloadscript = 0;
         
 	screen_waitdraw = 0;
 	ffcswaitdraw = 0;

--- a/src/zq_class.cpp
+++ b/src/zq_class.cpp
@@ -8511,7 +8511,10 @@ int writemapscreen(PACKFILE *f, int i, int j)
 	} 
 	    
     }
-    
+    if(!p_putc(screen.preloadscript,f))
+    {
+		return qe_invalid;
+    }
     return qe_OK;
 }
 

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -10759,6 +10759,8 @@ static DIALOG screenscript_dlg[] =
     { jwin_button_proc,       70,    202,     61,     21,    vc(14),                 vc(1),                  13,       D_EXIT,      0,    0, (void *) "OK",                                  NULL,   NULL                  },
     { jwin_button_proc,      170,    202,     61,     21,    vc(14),                 vc(1),                  27,       D_EXIT,      0,    0, (void *) "Cancel",                              NULL,   NULL                  },
     
+    { jwin_check_proc,          112+10+20+34-4,    42+30,     60,      9,    vc(14),                 vc(1),                   0,       0,           1,    0, (void *) "Run On Screen Init",   NULL,   NULL                  },
+    
     { NULL,                0,    0,    0,    0,  0,                   0,                      0,      0,          0,             0,       NULL,                           NULL,  NULL }
 };
 
@@ -10779,6 +10781,7 @@ void EditScreenScript()
 		
 	}
 	screenscript_dlg[22].d1 = script;
+	screenscript_dlg[25].flags = Map.CurrScr()->preloadscript ? D_SELECTED : 0;
 	
 	for ( int q = 0; q < 8; q++ )
 	{
@@ -10797,6 +10800,10 @@ void EditScreenScript()
 		build_biscreens_list();
 		Map.CurrScr()->script = biscreens[screenscript_dlg[22].d1].second + 1;
 		
+		if(screenscript_dlg[25].flags & D_SELECTED)
+			Map.CurrScr()->preloadscript = 1;
+		else 
+			Map.CurrScr()->preloadscript = 0;
 		
 		for(int j=0; j<8; j++)
 			Map.CurrScr()->screeninitd[j] = vbound(ffparse(initd[j]),-2147483647, 2147483647);


### PR DESCRIPTION
Changelog: Screen script now have a flag 'Run on Screen Init', that
behaves in an identical manner to ffcs.