### PR TITLE
Feat: Add npc->Gravity

### DIFF
--- a/src/guys.h
+++ b/src/guys.h
@@ -145,6 +145,7 @@ public:
     bool canmove(int ndir,fix s,int special);
     bool canmove(int ndir,int special);
     bool canmove(int ndir);
+    bool enemycanfall(int id);
     // 8-directional
     void newdir_8(int rate,int homing, int special,int dx1,int dy1,int dx2,int dy2);
     void newdir_8(int rate,int homing, int special);


### PR DESCRIPTION
Changelog: Added obeys_gravity checks to npcs and guys.
1. Initialise obeys_gravity for each enemy subclass, with its
	most-appropriate value (needs verification in playtests).
2. Add enemy::enemycanfall(int id).
	This is used in places where the old canfall() check needs access to
	the enemy class member variables.
	The old, global canfall(int id) remains, and is still used in a few places
		where the enemy pointer would be unknown.