### PR TITLE
Parser: `MAX_INT_ONE_LARGER` now `TRUE_INT_SIZE`

### DIFF
--- a/output/common/std_zh/std_constants.zh
+++ b/output/common/std_zh/std_constants.zh
@@ -25,17 +25,17 @@ const float SQRT_MAX			= 463.4095; //The largest square root thet ZC can return.
 ////////////////////////////
 /// ZC Minimums and Maximums
 
-const float MAX_CONSTANT		= 214747.9999 + (OPTION_VALUE(MAX_INT_ONE_LARGER) ? 0.0001 : 0);
+const float MAX_CONSTANT		= 214747.9999 + (OPTION_VALUE(TRUE_INT_SIZE) ? 0.3648 : 0);
 //const float MAX_VARIABLE		= 214748.3648; //Obviously this is truncated as a constant. Equal to ((2^31)-1)/10000
-const float MIN_CONSTANT		= -214747.9999 - (OPTION_VALUE(MAX_INT_ONE_LARGER) ? 0.0001 : 0);
+const float MIN_CONSTANT		= -214747.9999 - (OPTION_VALUE(TRUE_INT_SIZE) ? 0.3649 : 0);
 
 
 const int MAX_SCRIPTDRAWINGCOMMANDS	= 1000;
 
-const int MAX_INT = 214747 + (OPTION_VALUE(MAX_INT_ONE_LARGER) ? 1 : 0);
-const int MIN_INT = -214747 - (OPTION_VALUE(MAX_INT_ONE_LARGER) ? 1 : 0);
-const int MAX_FLOAT = 214747.9999 + (OPTION_VALUE(MAX_INT_ONE_LARGER) ? 0.0001 : 0);
-const int MIN_FLOAT = -214747.9999 - (OPTION_VALUE(MAX_INT_ONE_LARGER) ? 0.0001 : 0);
+const int MAX_INT = 214747 + (OPTION_VALUE(TRUE_INT_SIZE) ? 1 : 0);
+const int MIN_INT = -214747 - (OPTION_VALUE(TRUE_INT_SIZE) ? 1 : 0);
+const int MAX_FLOAT = 214747.9999 + (OPTION_VALUE(TRUE_INT_SIZE) ? 0.3648 : 0);
+const int MIN_FLOAT = -214747.9999 - (OPTION_VALUE(TRUE_INT_SIZE) ? 0.3649 : 0);
 
 const int MAX_COUNTER 			= 32768; //or is this 32767, counting 0?
 const int MIN_COUNTER 			= -32768; //" -32767
@@ -2603,7 +2603,7 @@ enum ffruletype
 	qr_PARSER_SHORT_CIRCUIT, //Default off.
 	qr_PARSER_BOOL_TRUE_DECIMAL, //Default off
 	qr_LINKXY_IS_FLOAT,
-	qr_PARSER_MAX_INT_ONE_LARGER, //Default on
+	qr_PARSER_TRUE_INT_SIZE, //Default on
 	qr_WPNANIMFIX, /* Not Implemented : This was in 2.50.2, but never used. */ 
 	qr_NOSCRIPTSDURINGSCROLL, /* Not Implemented : This was in 2.50.2, but never used. */
 	qr_OLDSPRITEDRAWS,

--- a/output/common/std_zh/string_functions.zh
+++ b/output/common/std_zh/string_functions.zh
@@ -663,6 +663,12 @@ int xtoa(int string, int num)
 //regardless of the most significant digit
 int ftoa(int string, int pos, float num, bool printall)
 {
+	if(OPTION_VALUE(TRUE_INT_SIZE) && num == -214748.3648)
+	{
+		int ret = ftoa(string,pos,-214748.364);
+		string[pos + ret] = '8';
+		return ret + 1;
+	}
     int oldPos=pos;
     int place=100000;
     int digit;

--- a/src/parser/AST.cpp
+++ b/src/parser/AST.cpp
@@ -1024,7 +1024,7 @@ ASTUnaryExpr::ASTUnaryExpr(LocationData const& location)
 // ASTExprNegate
 
 ASTExprNegate::ASTExprNegate(LocationData const& location)
-	: ASTUnaryExpr(location)
+	: ASTUnaryExpr(location), done(false)
 {}
 
 void ASTExprNegate::execute(ASTVisitor& visitor, void* param)
@@ -1038,7 +1038,7 @@ optional<long> ASTExprNegate::getCompileTimeValue(
 {
 	if (!operand) return nullopt;
 	if (optional<long> value = operand->getCompileTimeValue(errorHandler, scope))
-		return -*value;
+		return done ? *value : -*value;
 	return nullopt;
 }
 
@@ -1754,12 +1754,17 @@ optional<long> ASTNumberLiteral::getCompileTimeValue(
 {
 	if (!value) return nullopt;
     pair<long, bool> val = ScriptParser::parseLong(value->parseValue(), scope);
-
+	
     if (!val.second && errorHandler)
 	    errorHandler->handleError(
 			    CompileError::ConstTrunc(this, value->value.c_str()));
 
 	return val.first;
+}
+
+void ASTNumberLiteral::negate()
+{
+	if(value) value.get()->negative = true;
 }
 
 // ASTCharLiteral

--- a/src/parser/AST.h
+++ b/src/parser/AST.h
@@ -1071,6 +1071,8 @@ namespace ZScript
 				const;
 		virtual DataType const* getReadType(Scope* scope, CompileErrorHandler* errorHandler) {return &DataType::FLOAT;}
 		virtual DataType const* getWriteType(Scope* scope, CompileErrorHandler* errorHandler) {return NULL;}
+		
+		bool done;
 	};
 
 	class ASTExprNot : public ASTUnaryExpr
@@ -1603,6 +1605,8 @@ namespace ZScript
 				CompileErrorHandler* errorHandler = NULL, Scope* scope = NULL)
 				const;
 		virtual DataType const* getReadType(Scope* scope, CompileErrorHandler* errorHandler) {return &DataType::FLOAT;}
+		
+		void negate();
 	
 		owning_ptr<ASTFloat> value;
 	};

--- a/src/parser/BuildVisitors.cpp
+++ b/src/parser/BuildVisitors.cpp
@@ -791,9 +791,9 @@ void BuildOpcodes::caseExprCall(ASTExprCall& host, void* param)
 
 void BuildOpcodes::caseExprNegate(ASTExprNegate& host, void* param)
 {
-    if (host.getCompileTimeValue(NULL, scope))
+    if (optional<long> val = host.getCompileTimeValue(NULL, scope))
     {
-        addOpcode(new OSetImmediate(new VarArgument(EXP1), new LiteralArgument(*host.getCompileTimeValue(this, scope))));
+        addOpcode(new OSetImmediate(new VarArgument(EXP1), new LiteralArgument(*val)));
         return;
     }
 

--- a/src/parser/ByteCode.cpp
+++ b/src/parser/ByteCode.cpp
@@ -17,13 +17,13 @@ string LiteralArgument::toString()
 {
     char temp[128];
     string sign = value < 0 ? "-" : "";
-    sprintf(temp,"%ld", abs(value)/10000);
+    sprintf(temp,"%ld", abs(value/10000));
     string first = string(temp);
     
     if(value % 10000 == 0)
         return sign + first;
         
-    sprintf(temp,"%ld", abs(value)%10000);
+    sprintf(temp,"%ld", abs(value%10000));
     string second = string(temp);
     
     while(second.length() < 4)

--- a/src/parser/CompileOption.xtable
+++ b/src/parser/CompileOption.xtable
@@ -6,5 +6,5 @@ X(	SHORT_CIRCUIT,                                qr_PARSER_SHORT_CIRCUIT,       
 X(	BOOL_TRUE_RETURN_DECIMAL,                 qr_PARSER_BOOL_TRUE_DECIMAL,            OPTTYPE_QR,                     00000)
 X(	HEADER_GUARD,                                                       0,        OPTTYPE_CONFIG,                     30000)
 X(	NO_ERROR_HALT,                                                      0,        OPTTYPE_CONFIG,                     00000)
-X(	MAX_INT_ONE_LARGER,                      qr_PARSER_MAX_INT_ONE_LARGER,            OPTTYPE_QR,                     10000)
+X(	TRUE_INT_SIZE,                                qr_PARSER_TRUE_INT_SIZE,            OPTTYPE_QR,                     10000)
 X(	FORCE_INLINE,                                  qr_PARSER_FORCE_INLINE,            OPTTYPE_QR,                     00000)

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -553,7 +553,7 @@ pair<long,bool> ScriptParser::parseLong(pair<string, string> parts, Scope* scope
 	bool negative=false;
 	pair<long, bool> rval;
 	rval.second=true;
-	bool intOneLarger = *lookupOption(*scope, CompileOption::OPT_MAX_INT_ONE_LARGER) != 0;
+	bool intOneLarger = *lookupOption(*scope, CompileOption::OPT_TRUE_INT_SIZE) != 0;
     
 	if(parts.first.data()[0]=='-')
 	{
@@ -574,17 +574,12 @@ pair<long,bool> ScriptParser::parseLong(pair<string, string> parts, Scope* scope
 	}
     
 	int firstpart = atoi(parts.first.c_str());
-    bool noDec = false;
 	if(intOneLarger) //MAX_INT should be 214748, but if that is the value, there should be no float component. -V
 	{
 		if(firstpart > 214748)
 		{
 			firstpart = 214748;
 			rval.second = false;
-		}
-		else if(firstpart == 214748)
-		{
-			noDec = true;
 		}
 	}
 	else if(firstpart > 214747)
@@ -616,11 +611,12 @@ pair<long,bool> ScriptParser::parseLong(pair<string, string> parts, Scope* scope
 	  fpart += atoi(tmp);
 	  }*/
 	  
-	if(fpart && noDec)
+	if(intOneLarger && firstpart == 214748 && (negative ? fpart > 3648 : fpart > 3647))
 	{
-		fpart = 0;
+		fpart = negative ? 3648 : 3647;
 		rval.second = false;
 	}
+	
 	
 	rval.first = intval + fpart;
 	if(negative)

--- a/src/parser/SemanticAnalyzer.cpp
+++ b/src/parser/SemanticAnalyzer.cpp
@@ -1034,6 +1034,11 @@ void SemanticAnalyzer::caseExprCall(ASTExprCall& host, void* param)
 
 void SemanticAnalyzer::caseExprNegate(ASTExprNegate& host, void*)
 {
+	if(ASTNumberLiteral* lit = dynamic_cast<ASTNumberLiteral*>(host.operand.get()))
+	{
+		lit->negate();
+		host.done = true;
+	}
 	analyzeUnaryExpr(host, DataType::FLOAT);
 }
 

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -2777,7 +2777,7 @@ int readrules(PACKFILE *f, zquestheader *Header, bool keepdata)
 	if((tempheader.zelda_version < 0x255))
 	{
 		set_bit(quest_rules,qr_PARSER_250DIVISION,1);
-		set_bit(quest_rules,qr_PARSER_MAX_INT_ONE_LARGER,0);
+		set_bit(quest_rules,qr_PARSER_TRUE_INT_SIZE,0);
 		set_bit(quest_rules,qr_PARSER_FORCE_INLINE,0);
 	}
 	

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -854,7 +854,7 @@ enum
 	qr_PARSER_SHORT_CIRCUIT, //Default off.
 	qr_PARSER_BOOL_TRUE_DECIMAL, //Default off
 	qr_LINKXY_IS_FLOAT,
-	qr_PARSER_MAX_INT_ONE_LARGER, //Default on
+	qr_PARSER_TRUE_INT_SIZE, //Default on
 	qr_WPNANIMFIX, /* Not Implemented : This was in 2.50.2, but never used. */ 
 	qr_NOSCRIPTSDURINGSCROLL, /* Not Implemented : This was in 2.50.2, but never used. */
 	qr_OLDSPRITEDRAWS,

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -20502,7 +20502,7 @@ static DIALOG zscript_parser_dlg[] =
     { jwin_text_proc,           17,     122-11,     96,      8,    vc(14),                 vc(1),                   0,       0,           0,    0, 
 		(void *) "Include Paths:",                  NULL,   NULL                  },
     //17
-    { jwin_check_proc,      10, 32+50,  185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "Allow Constant Value 214748", NULL, NULL },
+    { jwin_check_proc,      10, 32+50,  185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "True MAX_INT sizing", NULL, NULL },
    
     { jwin_text_proc,           86,     38+38,     96,      8,    vc(14),                 vc(1),                   0,       0,           0,    0, 
 		(void *) ": Max Include Paths",                  NULL,   NULL                  },
@@ -20532,7 +20532,7 @@ static int zscripparsertrules[] =
 	NULL, //this dialogue index is used by global settings
 	NULL, //this dialogue index is used by global settings
 	NULL, //this dialogue index is used by global settings
-	qr_PARSER_MAX_INT_ONE_LARGER,
+	qr_PARSER_TRUE_INT_SIZE,
 	NULL, //this dialogue index is used by global settings
 	NULL, //this dialogue index is used by global settings
 	NULL, //this dialogue index is used by global settings


### PR DESCRIPTION
This allows `214748.3647`/`-214748.3648`
All appropriate constants in std_constants have been updated.
Also, `ftoa` has been patched to not bug out on constants of `MIN_CONSTANT`. A variable of MIN_CONSTANT will potentially still have issues, but those were also present before this commit.