### PR TITLE
Feat: qr_SMARTDROPS

### DIFF
--- a/src/zc_items.cpp
+++ b/src/zc_items.cpp
@@ -75,6 +75,14 @@ int select_dropitem(int item_set, int x, int y)
             {
                 current_chance=0;
             }
+			
+			if(get_bit(quest_rules, qr_SMARTDROPS))
+			{
+				if(itemsbuf[current_item].amount > 0 && game->get_maxcounter(itemsbuf[current_item].count) == 0)
+				{
+					current_chance = 0;
+				}
+			}
         }
         
         total_chance+=current_chance;
@@ -103,6 +111,14 @@ int select_dropitem(int item_set, int x, int y)
             current_chance=0;
         }
         
+		if(get_bit(quest_rules, qr_SMARTDROPS))
+		{
+			if(itemsbuf[current_item].amount > 0 && game->get_maxcounter(itemsbuf[current_item].count) == 0)
+			{
+				current_chance = 0;
+			}
+		}
+		
         if(current_chance>0&&item_chance<=current_chance)
         {
             drop_item=current_item;

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -846,6 +846,7 @@ enum
 	qr_SIDEVIEWTRIFORCECELLAR, qr_OUTOFBOUNDSENEMIES,
 	qr_EPILEPSY,
 	qr_SCRIPT_FRIENDLY_ENEMY_TYPES,
+	qr_SMARTDROPS,
 	
 	
 	//ZScript Parser //room for 20 of these

--- a/src/zq_rules.cpp
+++ b/src/zq_rules.cpp
@@ -253,6 +253,7 @@ static DIALOG itemrules_dlg[] =
     //30
     { d_dummy_proc,      10, 21+500, 185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "Melee Weapons Require Magic Cost", NULL, NULL },
     { jwin_check_proc,      10, 21+120, 185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "Broken Magic Book Costs", NULL, NULL },
+    { jwin_check_proc,      10, 21+130, 185,    9,    vc(14),   vc(1),      0,      0,          1,             0, (void *) "Reroll Useless Drops", NULL, NULL },
    
     
     { NULL,                  0,    0,     0,    0,    0,        0,          0,      0,          0,             0,       NULL, NULL, NULL }
@@ -265,7 +266,7 @@ static int itemrules[] =
     qr_FIREPROOFLINK, qr_OUCHBOMBS, qr_RINGAFFECTDAMAGE, qr_QUICKSWORD, qr_SLASHFLIPFIX,
     qr_NOWANDMELEE, qr_NOITEMMELEE, qr_BRANGPICKUP, qr_HEARTSREQUIREDFIX, qr_4TRI, qr_3TRI,
     qr_SLOWCHARGINGWALK, qr_LENSHINTS, qr_RAFTLENS, qr_LENSSEESENEMIES,
-    qr_NONBUBBLEMEDICINE, qr_NONBUBBLEFAIRIES, qr_NONBUBBLETRIFORCE, qr_ITEMBUBBLE, qr_MELEEMAGICCOST, qr_BROKENBOOKCOST, -1
+    qr_NONBUBBLEMEDICINE, qr_NONBUBBLEFAIRIES, qr_NONBUBBLETRIFORCE, qr_ITEMBUBBLE, qr_MELEEMAGICCOST, qr_BROKENBOOKCOST, qr_SMARTDROPS, -1
 };
 
 int onItemRules()


### PR DESCRIPTION
Makes it so that if you have no counter max for a counter, items that refill that counter will not drop, and will be rerolled instead.