### PR TITLE
Parser: Allow blank scoperes, fix wrong error msg

### DIFF
--- a/src/parser/AST.cpp
+++ b/src/parser/AST.cpp
@@ -927,7 +927,7 @@ optional<long> ASTExprAssign::getCompileTimeValue(
 
 ASTExprIdentifier::ASTExprIdentifier(string const& name,
 									 LocationData const& location)
-	: ASTExpr(location), binding(NULL), constant_(false)
+	: ASTExpr(location), binding(NULL), constant_(false), noUsing(false)
 {
 	if (name != "") components.push_back(name);
 }

--- a/src/parser/AST.h
+++ b/src/parser/AST.h
@@ -998,6 +998,8 @@ namespace ZScript
 		// What this identifier refers to.
 		Datum* binding;
 		
+		bool noUsing;
+		
 	private:
 		bool constant_;
 	};

--- a/src/parser/RegistrationVisitor.cpp
+++ b/src/parser/RegistrationVisitor.cpp
@@ -226,9 +226,8 @@ void RegistrationVisitor::caseUsing(ASTUsingDecl& host, void* param)
 {
 	//Handle adding scope
 	ASTExprIdentifier* iden = host.getIdentifier();
-	vector<string> components = iden->components;
 	Scope* temp = host.always ? getRoot(*scope) : scope;
-	int numMatches = temp->useNamespace(components, iden->delimiters);
+	int numMatches = temp->useNamespace(iden->components, iden->delimiters, iden->noUsing);
 	if(numMatches > 1)
 		handleError(CompileError::TooManyUsing(&host, iden->asString()));
 	else if(numMatches == -1)

--- a/src/parser/Scope.h
+++ b/src/parser/Scope.h
@@ -77,8 +77,8 @@ namespace ZScript
 		virtual std::vector<Scope*> getChildren() const = 0;
 		virtual FileScope* getFile() const = 0;
 		virtual ScriptScope* getScript() = 0;
-		virtual int useNamespace(std::string name) = 0;
-		virtual int useNamespace(std::vector<std::string> names, std::vector<std::string> delimiters) = 0;
+		virtual int useNamespace(std::string name, bool noUsing) = 0;
+		virtual int useNamespace(std::vector<std::string> names, std::vector<std::string> delimiters, bool noUsing) = 0;
 	
 		// Lookup Local
 		virtual DataType const* getLocalDataType(std::string const& name)
@@ -181,15 +181,15 @@ namespace ZScript
 			Scope const&, std::vector<std::string> const& names, std::vector<std::string> const& delimiters);
 
 	// Find a scope with the given name in this scope.
-	Scope* lookupScope(Scope const&, std::string const& name, AST& host, CompileErrorHandler* errorHandler);
+	Scope* lookupScope(Scope const&, std::string const& name, bool noUsing, AST& host, CompileErrorHandler* errorHandler);
 
 	// Find first scope with the given ancestry in this scope.
-	Scope* lookupScope(Scope const&, std::vector<std::string> const& names, std::vector<std::string> const& delimiters, AST& host, CompileErrorHandler* errorHandler);
+	Scope* lookupScope(Scope const&, std::vector<std::string> const& names, std::vector<std::string> const& delimiters, bool noUsing, AST& host, CompileErrorHandler* errorHandler);
 
 	// Find all scopes with the given ancestry in this scope. Note than an
 	// empty name list will the current scope and its ancestry.
 	std::vector<Scope*> lookupScopes(
-			Scope const&, std::vector<std::string> const& names, std::vector<std::string> const& delimiters);
+			Scope const&, std::vector<std::string> const& names, std::vector<std::string> const& delimiters, bool noUsing);
 
 	// Get the most distant parent.
 	RootScope* getRoot(Scope const&);
@@ -207,7 +207,7 @@ namespace ZScript
 	ZClass* lookupClass(Scope const&, std::string const& name);
 
 	// Attempt to resolve name to a variable under scope.
-	Datum* lookupDatum(Scope &, std::string const& name, ASTExprIdentifier& host, CompileErrorHandler* errorHandler, bool useNamespace = false);
+	Datum* lookupDatum(Scope &, std::string const& name, ASTExprIdentifier& host, CompileErrorHandler* errorHandler, bool forceSkipUsing = false);
 	Datum* lookupDatum(Scope &, ASTExprIdentifier& host, CompileErrorHandler* errorHandler);
 	
 	// Attempt to resolve name to a getter under scope.
@@ -221,9 +221,9 @@ namespace ZScript
 	
 	// Attempt to resolve name to possible functions under scope.
 	std::vector<Function*> lookupFunctions(
-			Scope&, std::string const& name, bool useNamespace = false);
+			Scope&, std::string const& name, bool noUsing = true);
 	std::vector<Function*> lookupFunctions(
-			Scope&, std::vector<std::string> const& name, std::vector<std::string> const& delimiters);
+			Scope&, std::vector<std::string> const& name, std::vector<std::string> const& delimiters, bool noUsing);
 
 	// Resolve an option value under the scope. Will only return empty if
 	// the provided option is invalid. If the option is valid but not set,
@@ -292,8 +292,8 @@ namespace ZScript
 		virtual std::vector<Scope*> getChildren() const;
 		virtual FileScope* getFile() const {return parentFile_;}
 		virtual ScriptScope* getScript();
-		virtual int useNamespace(std::string name);
-		virtual int useNamespace(std::vector<std::string> names, std::vector<std::string> delimiters);
+		virtual int useNamespace(std::string name, bool noUsing);
+		virtual int useNamespace(std::vector<std::string> names, std::vector<std::string> delimiters, bool noUsing);
 	
 		// Lookup Local
 		DataType const* getLocalDataType(std::string const& name)

--- a/src/parser/SemanticAnalyzer.cpp
+++ b/src/parser/SemanticAnalyzer.cpp
@@ -151,9 +151,8 @@ void SemanticAnalyzer::caseUsing(ASTUsingDecl& host, void*)
 	if(host.registered()) return; //Skip if already handled
 	//Handle adding scope
 	ASTExprIdentifier* iden = host.getIdentifier();
-	vector<string> components = iden->components;
 	Scope* temp = host.always ? getRoot(*scope) : scope;
-	int numMatches = temp->useNamespace(components, iden->delimiters);
+	int numMatches = temp->useNamespace(iden->components, iden->delimiters, iden->noUsing);
 	if(numMatches > 1)
 		handleError(CompileError::TooManyUsing(&host, iden->asString()));
 	else if(!numMatches)
@@ -866,8 +865,8 @@ void SemanticAnalyzer::caseExprCall(ASTExprCall& host, void* param)
 	// Grab functions with the proper name.
 	vector<Function*> functions =
 		identifier
-		? lookupFunctions(*scope, identifier->components, identifier->delimiters)
-		: lookupFunctions(*arrow->leftClass, arrow->right);
+		? lookupFunctions(*scope, identifier->components, identifier->delimiters, identifier->noUsing)
+		: lookupFunctions(*arrow->leftClass, arrow->right, true); //Never `using` arrow functions
 
 	// Filter out invalid functions.
 	for (vector<Function*>::iterator it = functions.begin();

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -1022,6 +1022,10 @@ idlist_scopres:
 		identifier->location = @$;
 		$$ = identifier;
 		delete name;}
+	| SCOPERES Ambigious_Iden_List {
+		ASTExprIdentifier* identifier = (ASTExprIdentifier*)$2;
+		identifier->noUsing = true;
+		$$ = identifier;}
 	;
 	
 idlist_dot:


### PR DESCRIPTION
Fixed returning -1 when finding too many matches for using, as it should return 2 (or greater).
Blank Scoperes Example:
when `using namespace foo`, and `foo` contains `void bar()`, and there is a global function `void bar()`, calling `bar()` gives an error. Calling `foo::bar()` will call the function within foo. Now, you can call `::bar()` to call the global function. This is implemented as per C++.