### PR TITLE
Fix: Convert bitmap->GetPixel() to work as Graphics->GetPixel() does

### DIFF
--- a/src/parser/GlobalSymbols.cpp
+++ b/src/parser/GlobalSymbols.cpp
@@ -7982,7 +7982,7 @@ BitmapSymbols BitmapSymbols::singleton = BitmapSymbols();
 static AccessorTable BitmapTable[] =
 {
 //	  name,                     rettype,                  setorget,     var,                  num,           funcFlags,                            numParams,   params
-	{ "GetPixel",               ZVARTYPEID_UNTYPED,       FUNCTION,     0,                    1,             0,                                    4,           { ZVARTYPEID_BITMAP,    ZVARTYPEID_FLOAT,    ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 } },
+	{ "GetPixel",               ZVARTYPEID_UNTYPED,       FUNCTION,     0,                    1,             0,                                    3,           { ZVARTYPEID_BITMAP,    ZVARTYPEID_FLOAT,    ZVARTYPEID_FLOAT, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 } },
 //	{ "Create",                 ZVARTYPEID_BITMAP,        FUNCTION,     0,                    1,             0,                                    3,           {  ZVARTYPEID_BITMAP,          ZVARTYPEID_FLOAT,        ZVARTYPEID_FLOAT,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
 	{ "Rectangle",              ZVARTYPEID_VOID,          FUNCTION,     0,                    1,             0,                                    13,          {  ZVARTYPEID_BITMAP,         ZVARTYPEID_FLOAT,         ZVARTYPEID_FLOAT,         ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_BOOL,      ZVARTYPEID_FLOAT,    -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                      } },
 	{ "Circle",                 ZVARTYPEID_VOID,          FUNCTION,     0,                    1,             0,                                    12,          {  ZVARTYPEID_BITMAP,         ZVARTYPEID_FLOAT,         ZVARTYPEID_FLOAT,         ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_BOOL,      ZVARTYPEID_FLOAT,    -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           } },
@@ -8043,21 +8043,19 @@ void BitmapSymbols::generateCode()
 {
 	//void GetPixel(bitmap, layer, "filename")
 	{
-		Function* function = getFunction("GetPixel", 4);
-		
+		Function* function = getFunction("GetPixel", 3);
 		int label = function->getLabel();
 		vector<Opcode *> code;
-		Opcode *first = new OBMPGetPixel();
+		//pop off the params
+		Opcode *first = new OPopRegister(new VarArgument(INDEX));
 		first->setLabel(label);
 		code.push_back(first);
-		POP_ARGS(3, EXP2);
-		
-		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(EXP2)));
-		
+		code.push_back(new OPopRegister(new VarArgument(INDEX2)));
+		//pop pointer to EXP1
+		code.push_back(new OPopRegister(new VarArgument(EXP1)));
+		code.push_back(new OGraphicsGetpixel(new VarArgument(EXP1)));
 		code.push_back(new OReturn());
 		function->giveCode(code);
-
 	}
 	/*
 	//long Create(bitmap, int map,int scr)


### PR DESCRIPTION
Uses the same ZASM as Graphics->GetPixel(), save for not needing to pop the extra pointer to NUL. Should function perfectly identically in every situation, considering it's basically the same ZASM.
No interpreter changes were made.