### PR TITLE
Fix: Improper MIDI offsets, std_zh: add MIDI_ constants

### DIFF
--- a/output/common/std_zh/std_constants.zh
+++ b/output/common/std_zh/std_constants.zh
@@ -2637,3 +2637,13 @@ enum EnemyPattern
 	PATTERN_STANDARD_RANDOM,
 	PATTERN_NO_SPAWNING
 };
+
+//MIDI values, used for 'Screen->MIDI', 'dmapdata->MIDI', 'mapdata->MIDI', 'Audio->PlayMIDI'
+enum
+{
+    MIDI_USE_DMAP = -4, //ONLY for 'Screen->MIDI' and 'mapdata->MIDI'
+    MIDI_NONE,
+    MIDI_OVERWORLD,
+    MIDI_DUNGEON,
+    MIDI_LEVEL9 //==0, cannot be played by 'Audio->PlayMIDI'
+}

--- a/src/zc_sys.cpp
+++ b/src/zc_sys.cpp
@@ -9531,7 +9531,7 @@ void play_DmapMusic()
             
         default:
             if(m>=4 && m<4+MAXCUSTOMMIDIS)
-                jukebox(m-4+ZC_MIDI_COUNT);
+                jukebox(m+MIDIOFFSET_DMAP);
             else
                 music_stop();
         }
@@ -9566,7 +9566,7 @@ void playLevelMusic()
         
     default:
         if(m>=4 && m<4+MAXCUSTOMMIDIS)
-            jukebox(m-4+ZC_MIDI_COUNT);
+            jukebox(m+MIDIOFFSET_MAPSCR);
         else
             music_stop();
     }

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -311,6 +311,14 @@ extern bool fake_pack_writing;
 #define MAXCUSTOMMIDIS        252                                 // uses bit string for midi flags, so 32 bytes
 #define MIDIFLAGS_SIZE  ((MAXCUSTOMMIDIS+7)>>3)
 #define MAXCUSTOMTUNES        252
+//Midi offsets
+//The offset from dmap/mapscr-> midi/screen_midi to currmidi
+#define MIDIOFFSET_DMAP		(ZC_MIDI_COUNT-4)
+#define MIDIOFFSET_MAPSCR	(ZC_MIDI_COUNT-4)
+//The offset from currmidi to ZScript MIDI values
+#define MIDIOFFSET_ZSCRIPT	(ZC_MIDI_COUNT-1)
+//Use together as `(MIDIOFFSET_DMAP-MIDIOFFSET_ZSCRIPT)` to go from `dmap` directly to `zscript`
+
 
 #define MAXMUSIC              256                                 // uses bit string for music flags, so 32 bytes
 #define MUSICFLAGS_SIZE       MAXMUSIC>>3


### PR DESCRIPTION
Added MIDIOFFSET_ macros to zdefs.h, and applied them where useful.
Fixed offset on r/w of Screen->MIDI, dmapdata->MIDI, and mapdata->MIDI
Added MIDI_ constants to std_zh, for use with these
...Perhaps the offsets could be cleaner, but, the values are just a mess in the first place. Why such odd offsets?