### PR TITLE
Fix: `Always Deallocate Arrays` QR works better

### DIFF
--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -1841,7 +1841,17 @@ void deallocateArray(const long ptrval)
 
 void FFScript::deallocateAllArrays(const byte scriptType, const long UID, bool requireAlways)
 {
-	if(requireAlways && !get_bit(quest_rules, qr_ALWAYS_DEALLOCATE_ARRAYS)) return; //Keep 2.50.2 behavior if QR unchecked.
+	if(requireAlways && !get_bit(quest_rules, qr_ALWAYS_DEALLOCATE_ARRAYS))
+	{
+		//Keep 2.50.2 behavior if QR unchecked.
+		switch(scriptType)
+		{
+			case SCRIPT_FFC:
+			case SCRIPT_ITEM:
+			case SCRIPT_GLOBAL:
+				return;
+		}
+	}
 	//Z_eventlog("Attempting array deallocation from %s UID %d\n", script_types[scriptType], UID);
 	for(long i = 1; i < MAX_ZCARRAY_SIZE; i++)
 	{
@@ -1855,7 +1865,7 @@ void FFScript::deallocateAllArrays(const byte scriptType, const long UID, bool r
 
 void FFScript::deallocateAllArrays()
 {
-	if(!get_bit(quest_rules, qr_ALWAYS_DEALLOCATE_ARRAYS)) return; //Keep 2.50.2 behavior if QR unchecked.
+	//No QR check here- always deallocate on quest exit.
 	for(long i = 1; i < MAX_ZCARRAY_SIZE; i++)
 	{
 		if(localRAM[i].Size() > 0)


### PR DESCRIPTION
Now, NEW script types will deallocate regardless of the QR. Also, the deallocation on quest exit will occur regardless of QR.
Global, Item, and FFC scripts will check the QR, and if it is off, behave as in 2.50.2.
There is absolutely no reason that a new script type script should have issues with this, but, prior to this change, they could cause MAJOR array leakage if this was unchecked, which should not be allowed.