### PR TITLE
Merge User GUI Colours and Map Grid Fix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,20 @@ ChangeLog for 2.53.0
 
 //Release 3
 
+Added User Themes
+	Added the ability for the user to define custom GUI themes for
+	ZC Player, and for ZQuest. The GUI set for the user theme is '99'.
+	The values for the theme are set in zc.cfg under [Theme] for ZC Player, and
+	in zquest.cfg under [Theme] for ZQ Editor.
+Updated Classic.zh to v1.11
+	Added ffc script ScreenGuyMusic and fuction: bool __classic_zh_ScreenGuyAlive()
+	Added arg for BossExplode ffc for enemy ID override as D7
+	( ZoriaRPG, 8th October, 2019 )
+	
+Display a grid in the mapscreen selector box in ZQ if the current
+map is an overworld palette rank (0x00, 0x10, 0x20 ...).
+	( ZoriaRPG, 6th October, 2019 )
+	
 Fix: Revert a Check for .SAV File Filenames
 	Fixed incorrect handling of save file filename checking 
 	that caused a bug where the save file was always loading the hardcode again.

--- a/output/common/Classic.zh
+++ b/output/common/Classic.zh
@@ -17,6 +17,8 @@
 	
 //1.08  //Added Eagle Dungeon Scripts from 1st.qst
 //1.09  //Added screen change tracking and compass beep
+//1.10  //Added ffc script ScreenGuyMusic and fuction: bool __classic_zh_ScreenGuyAlive()
+//1.11  //Added arg for BossExplode ffc for enemy ID override as D7
 import "ffcscript.zh"
 import "stdExtra.zh"
 import "ghost.zh"
@@ -32,12 +34,12 @@ const int __classic_zh_LASTMAP 		= 4;
 const int __classic_zh_LASTSCR 		= 5;
 
 //Version Information; time is in GMT
-const float __classic_zh_VERSION 	= 1.06;
+const float __classic_zh_VERSION 	= 1.11;
 const int __classic_zh_YEAR 		= 2019;
-const int __classic_zh_MONTH 		= 9;
-const int __classic_zh_DAY 		= 14;
-const int __classic_zh_HOUR 		= 7;
-const int __classic_zh_MINUTE 		= 11;
+const int __classic_zh_MONTH 		= 10;
+const int __classic_zh_DAY 		= 8;
+const int __classic_zh_HOUR 		= 0;
+const int __classic_zh_MINUTE 		= 26;
 
 
 const int __classic_zh_ITEM_Z2LANTERN 			= 149;
@@ -174,7 +176,7 @@ ffc script BossMusic
 
 ffc script BossExplode
 {
-	void run(int reg, int spr, int dur, int sfx, int delay, int rmin, int rmax)
+	void run(int reg, int spr, int dur, int sfx, int delay, int rmin, int rmax, int enemy_override)
 	{
 		this->Data = CMB_INVISIBLE;
 		int type;
@@ -189,7 +191,7 @@ ffc script BossExplode
 		for ( int q = Screen->NumNPCs(); q > 0; --q )
 		{
 			npc n = Screen->LoadNPC(q);
-			if ( _classic_zh__isBoss(n) ) 
+			if ( _classic_zh__isBoss(n) || n->ID == enemy_override ) 
 			{
 				boss = n; 
 				width = n->TileWidth;
@@ -852,5 +854,38 @@ void __classic_zh_CompassBeep()
 				}
 			}
 		}
+	}
+}
+
+
+//Returns if there are enemy NPCs alive on the current screen.
+bool __classic_zh_ScreenGuyAlive()
+{
+	bool alive = false; 
+	for ( int q = Screen->NumNPCs(); q > 0; --q )
+	{
+		npc n = Screen->LoadNPC(q); 
+		if ( n->Type == NPCT_GUY )
+		{
+			alive = true;
+		}
+	}
+	return alive;
+}
+
+
+ffc script ScreenGuyMusic
+{
+	void run(int reg, int mid, int trk)
+	{
+		this->Data = CMB_INVISIBLE;
+		if ( Screen->D[reg] >= _classic_zh__REG_BOSS_DEAD ) Quit(); //Don't play victory music if we return to the screen.
+		if ( trk < 1 ) trk = _classic_zh__TRK_BOSS;
+		if ( mid < 1 ) mid = _classic_zh__MIDI_VICTORY;
+		int filenm[]="Classic.nsf";
+		Waitframes(5);
+		Game->PlayEnhancedMusic(filenm,trk);
+		while(__classic_zh_ScreenGuyAlive()) Waitframe();
+		Game->PlayMIDI(Game->DMapMIDI[Game->GetCurDMap()]);	
 	}
 }

--- a/output/common/zc.cfg
+++ b/output/common/zc.cfg
@@ -1,0 +1,106 @@
+[SAVEFILE]
+save_filename=zc.sav
+
+[zeldadx]
+logo_volume=100
+heart_beep=1
+use_sfx_dat=0
+snapshot_format=3
+gui_colorset=0
+showfps=1
+title=2
+name_entry_mode=0
+throttlefps=1
+use_dwm_flush=0
+zc_win_proc_fix=0
+joystick_index=0
+js_stick_1_x_stick=0
+js_stick_1_x_axis=0
+js_stick_1_x_offset=0
+js_stick_1_y_stick=0
+js_stick_1_y_axis=1
+js_stick_1_y_offset=0
+js_stick_2_x_stick=1
+js_stick_2_x_axis=0
+js_stick_2_x_offset=0
+js_stick_2_y_stick=1
+js_stick_2_y_axis=1
+js_stick_2_y_offset=0
+analog_movement=1
+volkeys=0
+vsync=0
+translayers=1
+fastquit=0
+clicktofreeze=1
+resx=640
+resy=480
+scanlines=0
+load_last=1
+ss_enable=1
+ss_after=14
+ss_speed=2
+ss_density=3
+fullscreen=0
+doublebuffer=1
+triplebuffer=1
+color_depth=8
+frame_rest_suggest=0
+force_exit=0
+debug_console=0
+midi_patch_fix=0
+save_indicator=0
+
+[graphics]
+disable_direct_updating=1
+gfx_cardw=DXAC
+gfx_card=DXAC
+
+[CONSOLE]
+ZScript_Debugger=1
+
+[Theme]
+dvc1_r = 4
+dvc1_g = 38)
+dvc1_b = 46
+    
+dvc2_r = (16*63/255
+dvc2_g = (10*63/255
+dvc2_b = 0
+    
+dvc3_r = 17
+dvc3_g = 20
+dvc3_b = 20
+    
+dvc4_r = 13
+dvc4_g = 14
+dvc4_b = 14
+    
+dvc5_r = 0
+dvc5_g = 0
+dvc5_b = 0
+    
+dvc6_r = 13
+dvc6_g = 14
+dvc6_b = 14
+
+dvc7_r = 42
+dvc7_g = 60
+dvc7_b = 48
+
+dvc8_r = 6
+dvc8_g = 49
+dvc8_b = 35
+
+jcbox = 4
+jclight = 5
+jcmedlt = 4
+jcmeddark = 3
+jcdark = 2
+jcboxfg = 1
+jctitlel = 3
+jctitler = 5
+jctitlefg = 7
+jctextbg = 5
+jctextfg = 1
+jcselbg = 8
+jcselfg = 6

--- a/output/common/zquest.cfg
+++ b/output/common/zquest.cfg
@@ -1,0 +1,124 @@
+[Compiler]
+compile_success_sample=20
+compile_error_sample=28
+compile_finish_sample=34
+compile_audio_volume=200
+
+[zquest]
+vsync=1
+snapshot_format=3
+animation_on=1
+save_paths=1
+gui_colorset=0
+fullscreen=0
+scale=1
+small=0
+showfps=0
+mouse_scroll=0
+show_misalignments=1
+combo_brush=0
+enable_tooltips=1
+float_brush=0
+cycle_on=1
+invalid_static=0
+uncompressed_auto_saves=1
+tile_protection=1
+rulesetdialog=1
+open_last_quest=1
+open_last_quest=1
+open_last_quest=0
+open_last_quest=1
+overwrite_prevention=0
+open_last_quest=1
+open_last_quest=1
+open_last_quest=1
+auto_backup_retention=0
+auto_save_retention=9
+auto_save_interval=5
+zq_win_proc_fix=0
+showinfo=1
+show_grid=0
+grid_color=15
+brush_position=0
+scale_large=2
+showffscripts=1
+showsquares=1
+import_map_bias=0
+keyboard_repeat_delay=300
+keyboard_repeat_rate=80
+zqmusic_bufsz=64
+layer_mask=65535
+normal_duplicate_action=2
+horizontal_duplicate_action=0
+vertical_duplicate_action=0
+both_duplicate_action=0
+leech_update=500
+leech_update_tiles=1
+only_check_new_tiles_for_duplicates=0
+command01=150
+command02=151
+command03=153
+command04=152
+command05=147
+command06=149
+command07=148
+command08=0
+fps=60
+frameskip=0
+force_exit=0
+frame_rest_suggest=0
+doublebuffer=1
+triplebuffer=1
+beta_warning=~|bC~~~g
+
+[graphics]
+disable_direct_updating=1
+gfx_cardw=DXAC
+gfx_card=DXAC
+
+[Theme]
+dvc1_r = 4
+dvc1_g = 38)
+dvc1_b = 46
+    
+dvc2_r = (16*63/255
+dvc2_g = (10*63/255
+dvc2_b = 0
+    
+dvc3_r = 17
+dvc3_g = 20
+dvc3_b = 20
+    
+dvc4_r = 13
+dvc4_g = 14
+dvc4_b = 14
+    
+dvc5_r = 0
+dvc5_g = 0
+dvc5_b = 0
+    
+dvc6_r = 13
+dvc6_g = 14
+dvc6_b = 14
+
+dvc7_r = 42
+dvc7_g = 60
+dvc7_b = 48
+
+dvc8_r = 6
+dvc8_g = 49
+dvc8_b = 35
+
+jcbox = 4
+jclight = 5
+jcmedlt = 4
+jcmeddark = 3
+jcdark = 2
+jcboxfg = 1
+jctitlel = 3
+jctitler = 5
+jctitlefg = 7
+jctextbg = 5
+jctextfg = 1
+jcselbg = 8
+jcselfg = 6

--- a/src/zc_sys.cpp
+++ b/src/zc_sys.cpp
@@ -8250,6 +8250,39 @@ void system_pal()
     }
     break;
     
+    case 99:  //User Defined
+    {
+	    
+        pal[dvc(1)] = _RGB(get_config_int("Theme","dvc1_r",4),get_config_int("Theme","dvc1_g",38),get_config_int("Theme","dvc1_b",46)); //box fg is text
+        pal[dvc(2)] = _RGB(get_config_int("Theme","dvc2_r",(16*63/255)), get_config_int("Theme","dvc2_g",(10*63/255)), get_config_int("Theme","dvc2_b",0));
+        pal[dvc(3)] = _RGB(get_config_int("Theme","dvc3_r",17),get_config_int("Theme","dvc3_g",20),get_config_int("Theme","dvc3_b",20)); //slate
+        pal[dvc(4)] = _RGB(get_config_int("Theme","dvc4_r",13),get_config_int("Theme","dvc4_g",14),get_config_int("Theme","dvc4_b",14)); //menu background
+        pal[dvc(5)] = _RGB(get_config_int("Theme","dvc5_r",0),get_config_int("Theme","dvc5_g",0),get_config_int("Theme","dvc5_b",0));//menu text bg
+        pal[dvc(6)] = _RGB(get_config_int("Theme","dvc6_r",13),get_config_int("Theme","dvc6_g",14),get_config_int("Theme","dvc6_b",14));//menu selected text
+        pal[dvc(7)] = _RGB(get_config_int("Theme","dvc7_r",42),get_config_int("Theme","dvc7_g",60),get_config_int("Theme","dvc7_b",48));
+        pal[dvc(8)] = _RGB(get_config_int("Theme","dvc8_r",6),get_config_int("Theme","dvc8_g",49),get_config_int("Theme","dvc8_b",35));//highlight on selected menu text
+        
+        byte palrstart= 10*63/255, palrend=166*63/255,
+             palgstart= 36*63/255, palgend=202*63/255,
+             palbstart=106*63/255, palbend=240*63/255,
+             paldivs=7;
+       
+        jwin_pal[jcBOX]    =dvc(get_config_int("Theme","jcbox",4));
+        jwin_pal[jcLIGHT]  =dvc(get_config_int("Theme","jclight",5));
+        jwin_pal[jcMEDLT]  =dvc(get_config_int("Theme","jcmedlt",4));
+        jwin_pal[jcMEDDARK]=dvc(get_config_int("Theme","jcmeddark",3));
+        jwin_pal[jcDARK]   =dvc(get_config_int("Theme","jcdark",2));
+        jwin_pal[jcBOXFG]  =dvc(get_config_int("Theme","jcboxfg",1));
+        jwin_pal[jcTITLEL] =dvc(get_config_int("Theme","jctitlel",3));
+        jwin_pal[jcTITLER] =dvc(get_config_int("Theme","jctitler",5));
+        jwin_pal[jcTITLEFG]=dvc(get_config_int("Theme","jctitlefg",7));
+        jwin_pal[jcTEXTBG] =dvc(get_config_int("Theme","jctextbg",5));
+        jwin_pal[jcTEXTFG] =dvc(get_config_int("Theme","jctextfg",1));
+        jwin_pal[jcSELBG]  =dvc(get_config_int("Theme","jcselbg",8));
+        jwin_pal[jcSELFG]  =dvc(get_config_int("Theme","jcselfg",6));
+    }
+    break;
+    
     case 201018:  //20-oct-2018, PureZC Expo
     {
 	    //16,10,0; dark chocolate

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -100,7 +100,7 @@
 #define VERSION_BUILD       33                           //build number of this version
 #define ZELDA_VERSION_STR   "Omnius, 2.53 Release 3"               //version of the program as presented in text
 #define IS_BETA             0                        //is this a beta? (1: beta, -1: alpha)
-#define DATE_STR            "2nd October, 2019, 15:46MT"
+#define DATE_STR            "8th October, 2019, 06:40GMT"
 #define ZELDA_ABOUT_STR 	    "Zelda Classic 'Omnius' Release 3"
 #define COPYRIGHT_YEAR      "2019"     
                      //shown on title screen and in ending

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -4230,10 +4230,30 @@ void refresh(int flags)
             {
                 if(Map.Scr(i)->valid&mVALID)
                 {
-                    //vc(0)
+                   
+		    /* Level palettes ending in 0 can display in screen grid as pure black*/
+			
+		    if(((Map.Scr(i)->color)&15)>0)
+                    {
                     rectfill(menu1,(i&15)*3*BMM+minimap.x+3,(i/16)*3*BMM+minimap.y+12,
                              (i&15)*3*BMM+(is_large?8:2)+minimap.x+3,(i/16)*3*BMM+minimap.y+12+(is_large?8:2), lc1((Map.Scr(i)->color)&15));
-                             
+		    }
+		    else
+		    {
+			
+			rectfill(menu1,(i&15)*3*BMM+minimap.x+3,(i/16)*3*BMM+minimap.y+12,
+                             (i&15)*3*BMM+(is_large?8:2)+minimap.x+3,(i/16)*3*BMM+minimap.y+12+(is_large?8:2), lc1((Map.Scr(i)->color)&15));
+//                             (i&15)*3*BMM+(is_large?8:2)+minimap.x+3,(i/16)*3*BMM+minimap.y+12+(is_large?8:2), (int)(&(misc.colors.text)));
+		        safe_rect(menu1,(i&15)*3*BMM+minimap.x+3,(i/16)*3*BMM+minimap.y+12,(i&15)*3*BMM+(is_large?8:2)+minimap.x+3,(i/16)*3*BMM+minimap.y+12+(is_large?8:2),vc(15));
+			    
+		    }
+			
+		    //vc(0)
+			
+		/*
+                    rectfill(menu1,(i&15)*3*BMM+minimap.x+3,(i/16)*3*BMM+minimap.y+12,
+                             (i&15)*3*BMM+(is_large?8:2)+minimap.x+3,(i/16)*3*BMM+minimap.y+12+(is_large?8:2), lc1((Map.Scr(i)->color)&15));
+                       */      
                     if(((Map.Scr(i)->color)&15)>0)
                     {
                         if(!is_large)
@@ -4264,8 +4284,16 @@ void refresh(int flags)
             
             int s=Map.getCurrScr();
             // The white marker rect
-            safe_rect(menu1,(s&15)*3*BMM+minimap.x+3,(s/16)*3*BMM+minimap.y+12,(s&15)*3*BMM+(is_large?8:2)+minimap.x+3,(s/16)*3*BMM+minimap.y+12+(is_large?8:2),vc(15));
-            
+	    if(((Map.Scr(s)->color)&15)>0)
+	    {
+		safe_rect(menu1,(s&15)*3*BMM+minimap.x+3,(s/16)*3*BMM+minimap.y+12,(s&15)*3*BMM+(is_large?8:2)+minimap.x+3,(s/16)*3*BMM+minimap.y+12+(is_large?8:2),vc(15));
+            }
+	    else
+	    {
+		safe_rect(menu1,(s&15)*3*BMM+minimap.x+3,(s/16)*3*BMM+minimap.y+12,(s&15)*3*BMM+(is_large?8:2)+minimap.x+3,(s/16)*3*BMM+minimap.y+12+(is_large?8:2),vc(8));
+            }
+	    
+	    
             textprintf_disabled(menu1,font,minimap.x,minimap.y,jwin_pal[jcLIGHT],jwin_pal[jcMEDDARK],"M");
             textprintf_ex(menu1,font,minimap.x+8,minimap.y,jwin_pal[jcBOXFG],jwin_pal[jcBOX],"%-3d",Map.getCurrMap()+1);
             

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -22753,6 +22753,39 @@ int main(int argc,char **argv)
     }
     break;
     
+    case 99:  //User Defined
+    {
+	    
+        RAMpal[dvc(1)] = _RGB(get_config_int("Theme","dvc1_r",4),get_config_int("Theme","dvc1_g",38),get_config_int("Theme","dvc1_b",46)); //box fg is text
+        RAMpal[dvc(2)] = _RGB(get_config_int("Theme","dvc2_r",(16*63/255)), get_config_int("Theme","dvc2_g",(10*63/255)), get_config_int("Theme","dvc2_b",0));
+        RAMpal[dvc(3)] = _RGB(get_config_int("Theme","dvc3_r",17),get_config_int("Theme","dvc3_g",20),get_config_int("Theme","dvc3_b",20)); //slate
+        RAMpal[dvc(4)] = _RGB(get_config_int("Theme","dvc4_r",13),get_config_int("Theme","dvc4_g",14),get_config_int("Theme","dvc4_b",14)); //menu background
+        RAMpal[dvc(5)] = _RGB(get_config_int("Theme","dvc5_r",0),get_config_int("Theme","dvc5_g",0),get_config_int("Theme","dvc5_b",0));//menu text bg
+        RAMpal[dvc(6)] = _RGB(get_config_int("Theme","dvc6_r",13),get_config_int("Theme","dvc6_g",14),get_config_int("Theme","dvc6_b",14));//menu selected text
+        RAMpal[dvc(7)] = _RGB(get_config_int("Theme","dvc7_r",42),get_config_int("Theme","dvc7_g",60),get_config_int("Theme","dvc7_b",48));
+        RAMpal[dvc(8)] = _RGB(get_config_int("Theme","dvc8_r",6),get_config_int("Theme","dvc8_g",49),get_config_int("Theme","dvc8_b",35));//highlight on selected menu text
+        
+        byte palrstart= 10*63/255, palrend=166*63/255,
+             palgstart= 36*63/255, palgend=202*63/255,
+             palbstart=106*63/255, palbend=240*63/255,
+             paldivs=7;
+       
+        jwin_pal[jcBOX]    =dvc(get_config_int("Theme","jcbox",4));
+        jwin_pal[jcLIGHT]  =dvc(get_config_int("Theme","jclight",5));
+        jwin_pal[jcMEDLT]  =dvc(get_config_int("Theme","jcmedlt",4));
+        jwin_pal[jcMEDDARK]=dvc(get_config_int("Theme","jcmeddark",3));
+        jwin_pal[jcDARK]   =dvc(get_config_int("Theme","jcdark",2));
+        jwin_pal[jcBOXFG]  =dvc(get_config_int("Theme","jcboxfg",1));
+        jwin_pal[jcTITLEL] =dvc(get_config_int("Theme","jctitlel",3));
+        jwin_pal[jcTITLER] =dvc(get_config_int("Theme","jctitler",5));
+        jwin_pal[jcTITLEFG]=dvc(get_config_int("Theme","jctitlefg",7));
+        jwin_pal[jcTEXTBG] =dvc(get_config_int("Theme","jctextbg",5));
+        jwin_pal[jcTEXTFG] =dvc(get_config_int("Theme","jctextfg",1));
+        jwin_pal[jcSELBG]  =dvc(get_config_int("Theme","jcselbg",8));
+        jwin_pal[jcSELFG]  =dvc(get_config_int("Theme","jcselfg",6));
+    }
+    break;
+    
     
     case 201018:  //20-oct-2018, PureZC Expo
     {


### PR DESCRIPTION
Added User Themes
	Added the ability for the user to define custom GUI themes for
	ZC Player, and for ZQuest. The GUI set for the user theme is '99'.
	The values for the theme are set in zc.cfg under [Theme] for ZC Player, and
	in zquest.cfg under [Theme] for ZQ Editor.

Updated Classic.zh to v1.11
	Added ffc script ScreenGuyMusic and fuction: bool __classic_zh_ScreenGuyAlive()
	Added arg for BossExplode ffc for enemy ID override as D7

Display a grid in the mapscreen selector box in ZQ if the current
	map is an overworld palette rank (0x00, 0x10, 0x20 ...).
