### PR TITLE
Port: Mouse cursor and Layer Checkbox gui work

### DIFF
--- a/src/jwin.h
+++ b/src/jwin.h
@@ -71,9 +71,10 @@ enum {
 /* color indices */
 enum
 {
-    jcBOX, jcLIGHT, jcMEDLT, jcMEDDARK, jcDARK, jcBOXFG,
-    jcTITLEL, jcTITLER, jcTITLEFG, jcTEXTBG, jcTEXTFG, jcSELBG, jcSELFG,
-    jcMAX
+	jcBOX, jcLIGHT, jcMEDLT, jcMEDDARK, jcDARK, jcBOXFG,
+	jcTITLEL, jcTITLER, jcTITLEFG, jcTEXTBG, jcTEXTFG, jcSELBG, jcSELFG,
+	jcCURSORMISC, jcCURSOROUTLINE, jcCURSORLIGHT, jcCURSORDARK,
+	jcMAX
 };
 
 /* a copy of the default color scheme; do what you want with this */

--- a/src/zc_sys.cpp
+++ b/src/zc_sys.cpp
@@ -674,6 +674,45 @@ void show_saving(BITMAP *target)
 
 //----------------------------------------------------------------
 
+//Handles converting the mouse sprite from the .dat file
+void load_mouse()
+{
+	system_pal();
+	for(int j = 0; j < 4; ++j)
+	{
+		BITMAP* tmpbmp = create_bitmap_ex(8,16,16);
+		clear_bitmap(tmpbmp);
+		blit((BITMAP*)data[BMP_MOUSE].dat,tmpbmp,1,j*17+1,0,0,16,16);
+		//BITMAP* tmpbmp = (BITMAP*)data[BMP_MOUSE].dat;
+		for(int x = 0; x < 16; ++x)
+		{
+			for(int y = 0; y < 16; ++y)
+			{
+				int color = getpixel(tmpbmp, x, y);
+				switch(color)
+				{
+					case dvc(1):
+						color = jwin_pal[jcCURSORMISC];
+						break;
+					case dvc(2):
+						color = jwin_pal[jcCURSOROUTLINE];
+						break;
+					case dvc(3):
+						color = jwin_pal[jcCURSORLIGHT];
+						break;
+					case dvc(5):
+						color = jwin_pal[jcCURSORDARK];
+						break;
+				}
+				if(color!=0)Z_message("Pixel %d,%d == %d\n",x,y,color);
+				putpixel(zcmouse[j], x, y, color);
+			}
+		}
+		destroy_bitmap(tmpbmp);
+	}
+	game_pal();
+}
+
 // sets the video mode and initializes the palette and mouse sprite
 bool game_vid_mode(int mode,int wait)
 {
@@ -685,7 +724,8 @@ bool game_vid_mode(int mode,int wait)
     scrx = (resx-320)>>1;
     scry = (resy-240)>>1;
     
-    set_mouse_sprite((BITMAP*)data[BMP_MOUSE].dat);
+	load_mouse();
+    set_mouse_sprite(zcmouse[0]);
     
     for(int i=240; i<256; i++)
         RAMpal[i]=((RGB*)data[PAL_GUI].dat)[i];
@@ -8592,6 +8632,10 @@ void system_pal()
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(8);
         jwin_pal[jcSELFG]  =dvc(6);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     
@@ -8633,6 +8677,10 @@ void system_pal()
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(9);
         jwin_pal[jcSELFG]  =dvc(7);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     
@@ -8672,6 +8720,10 @@ void system_pal()
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(8);
         jwin_pal[jcSELFG]  =dvc(6);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     
@@ -8712,6 +8764,10 @@ void system_pal()
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(9);
         jwin_pal[jcSELFG]  =dvc(7);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     
@@ -8751,6 +8807,10 @@ void system_pal()
         jwin_pal[jcTEXTFG] =dvc(7);
         jwin_pal[jcSELBG]  =dvc(8);
         jwin_pal[jcSELFG]  =dvc(6);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     
@@ -8784,6 +8844,10 @@ void system_pal()
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(8);
         jwin_pal[jcSELFG]  =dvc(6);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     
@@ -8822,6 +8886,10 @@ void system_pal()
 		jwin_pal[jcTEXTFG] =dvc(get_config_int("Theme","jctextfg",1));
 		jwin_pal[jcSELBG]  =dvc(get_config_int("Theme","jcselbg",8));
 		jwin_pal[jcSELFG]  =dvc(get_config_int("Theme","jcselfg",6));
+		jwin_pal[jcCURSORMISC] = dvc(get_config_int("Theme","jccursormisc",1));
+		jwin_pal[jcCURSOROUTLINE] = dvc(get_config_int("Theme","jccursoroutline",2));
+		jwin_pal[jcCURSORLIGHT] = dvc(get_config_int("Theme","jccursorlight",3));
+		jwin_pal[jcCURSORDARK] = dvc(get_config_int("Theme","jccursordark",5));
 	}
 	else
 	{
@@ -8853,6 +8921,10 @@ void system_pal()
 		jwin_pal[jcTEXTFG] =dvc(get_config_int("Theme","jctextfg",1));
 		jwin_pal[jcSELBG]  =dvc(get_config_int("Theme","jcselbg",8));
 		jwin_pal[jcSELFG]  =dvc(get_config_int("Theme","jcselfg",6));
+		jwin_pal[jcCURSORMISC] = dvc(get_config_int("Theme","jccursormisc",1));
+		jwin_pal[jcCURSOROUTLINE] = dvc(get_config_int("Theme","jccursoroutline",2));
+		jwin_pal[jcCURSORLIGHT] = dvc(get_config_int("Theme","jccursorlight",3));
+		jwin_pal[jcCURSORDARK] = dvc(get_config_int("Theme","jccursordark",5));
 
 		set_config_file("zc.cfg"); //shift back when done
 	}
@@ -8902,6 +8974,10 @@ void system_pal()
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(8);
         jwin_pal[jcSELFG]  =dvc(6);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
    
@@ -8941,6 +9017,10 @@ void system_pal()
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(8);
         jwin_pal[jcSELFG]  =dvc(6);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     }

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -241,6 +241,7 @@ RGB_MAP rgb_table;
 COLOR_MAP trans_table, trans_table2;
 
 BITMAP     *framebuf, *scrollbuf, *tmp_bmp, *tmp_scr, *screen2, *fps_undo, *msgdisplaybuf, *pricesdisplaybuf, *tb_page[3], *real_screen, *temp_buf, *prim_bmp, *script_menu_buf;
+BITMAP     *zcmouse[4];
 DATAFILE   *data, *sfxdata, *fontsdata, *mididata;
 FONT       *nfont, *zfont, *z3font, *z3smallfont, *deffont, *lfont, *lfont_l, *pfont, *mfont, *ztfont, *sfont, *sfont2, *sfont3, *spfont, *ssfont1, *ssfont2, *ssfont3, *ssfont4, *gblafont,
            *goronfont, *zoranfont, *hylian1font, *hylian2font, *hylian3font, *hylian4font, *gboraclefont, *gboraclepfont,
@@ -4181,6 +4182,10 @@ int main(int argc, char* argv[])
     msgdisplaybuf = create_bitmap_ex(8,256, 176);
     msgbmpbuf = create_bitmap_ex(8, 512+16, 512+16);
     pricesdisplaybuf = create_bitmap_ex(8,256, 176);
+	zcmouse[0] = create_bitmap_ex(8, 16, 16);
+	zcmouse[1] = create_bitmap_ex(8, 16, 16);
+	zcmouse[2] = create_bitmap_ex(8, 16, 16);
+	zcmouse[3] = create_bitmap_ex(8, 16, 16);
 	script_menu_buf = create_bitmap_ex(8,256,224);
     
     if(!framebuf || !scrollbuf || !tmp_bmp || !fps_undo || !tmp_scr
@@ -4196,6 +4201,10 @@ int main(int argc, char* argv[])
     set_clip_state(msgdisplaybuf, 1);
     clear_bitmap(pricesdisplaybuf);
     set_clip_state(pricesdisplaybuf, 1);
+	clear_bitmap(zcmouse[0]);
+	clear_bitmap(zcmouse[1]);
+	clear_bitmap(zcmouse[2]);
+	clear_bitmap(zcmouse[3]);
     Z_message("OK\n");
     
     
@@ -5036,6 +5045,10 @@ void quit_game()
     destroy_bitmap(msgdisplaybuf);
     set_clip_state(pricesdisplaybuf, 1);
     destroy_bitmap(pricesdisplaybuf);
+	destroy_bitmap(zcmouse[0]);
+	destroy_bitmap(zcmouse[1]);
+	destroy_bitmap(zcmouse[2]);
+	destroy_bitmap(zcmouse[3]);
 	destroy_bitmap(script_menu_buf);
     
     al_trace("Subscreens... \n");

--- a/src/zelda.h
+++ b/src/zelda.h
@@ -268,6 +268,7 @@ extern int strike_hint;
 extern RGB_MAP rgb_table;
 extern COLOR_MAP trans_table, trans_table2;
 extern BITMAP     *framebuf, *scrollbuf, *tmp_bmp, *tmp_scr, *screen2, *fps_undo, *msgbmpbuf, *msgdisplaybuf, *pricesdisplaybuf, *tb_page[3], *real_screen, *temp_buf, *temp_buf2, *prim_bmp, *script_menu_buf;
+extern BITMAP *zcmouse[4];
 extern DATAFILE *data, *sfxdata, *fontsdata, *mididata;
 extern SAMPLE   wav_refill;
 extern FONT  *nfont, *zfont, *z3font, *z3smallfont, *deffont, *lfont, *lfont_l, *pfont, *mfont, *ztfont, *sfont, *sfont2, *sfont3, *spfont, *ssfont1, *ssfont2, *ssfont3, *ssfont4, *gblafont,

--- a/src/zq_class.cpp
+++ b/src/zq_class.cpp
@@ -1933,7 +1933,7 @@ void zmap::check_alignments(BITMAP* dest,int x,int y,int scr)
             {
                 if(misaligned(currmap, scr, checkcombo, up))
                 {
-                    masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,0*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                    masked_blit(arrow_bmp[0],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 }
             }
             
@@ -1941,7 +1941,7 @@ void zmap::check_alignments(BITMAP* dest,int x,int y,int scr)
             {
                 if(misaligned(currmap, scr, checkcombo, down))
                 {
-                    masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,1*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                    masked_blit(arrow_bmp[1],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 }
             }
             
@@ -1949,7 +1949,7 @@ void zmap::check_alignments(BITMAP* dest,int x,int y,int scr)
             {
                 if(misaligned(currmap, scr, checkcombo, left))
                 {
-                    masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,2*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                    masked_blit(arrow_bmp[2],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 }
             }
             
@@ -1957,7 +1957,7 @@ void zmap::check_alignments(BITMAP* dest,int x,int y,int scr)
             {
                 if(misaligned(currmap, scr, checkcombo, right))
                 {
-                    masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,3*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                    masked_blit(arrow_bmp[3],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 }
             }
             
@@ -1975,15 +1975,15 @@ void zmap::check_alignments(BITMAP* dest,int x,int y,int scr)
                 break;
                 
             case 1:                                             //up
-                masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,0*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                masked_blit(arrow_bmp[0],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 break;
                 
             case 2:                                             //left
-                masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,2*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                masked_blit(arrow_bmp[2],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 break;
                 
             case 3:                                             //up-left
-                masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,4*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                masked_blit(arrow_bmp[4],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 break;
             }
             
@@ -1999,15 +1999,15 @@ void zmap::check_alignments(BITMAP* dest,int x,int y,int scr)
                 break;
                 
             case 1:                                             //up
-                masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,0*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                masked_blit(arrow_bmp[0],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 break;
                 
             case 2:                                             //right
-                masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,3*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                masked_blit(arrow_bmp[3],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 break;
                 
             case 3:                                             //up-right
-                masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,5*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                masked_blit(arrow_bmp[5],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 break;
             }
             
@@ -2023,15 +2023,15 @@ void zmap::check_alignments(BITMAP* dest,int x,int y,int scr)
                 break;
                 
             case 1:                                             //down
-                masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,1*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                masked_blit(arrow_bmp[1],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 break;
                 
             case 2:                                             //left
-                masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,2*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                masked_blit(arrow_bmp[2],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 break;
                 
             case 3:                                             //down-left
-                masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,6*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                masked_blit(arrow_bmp[6],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 break;
             }
             
@@ -2048,15 +2048,15 @@ void zmap::check_alignments(BITMAP* dest,int x,int y,int scr)
                 break;
                 
             case 1:                                             //down
-                masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,1*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                masked_blit(arrow_bmp[1],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 break;
                 
             case 2:                                             //right
-                masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,3*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                masked_blit(arrow_bmp[3],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 break;
                 
             case 3:                                             //down-right
-                masked_blit((BITMAP*)zcdata[BMP_ARROWS].dat,dest,7*17+1,1,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
+                masked_blit(arrow_bmp[7],dest,0,0,((checkcombo&15)<<4)+x,(checkcombo&0xF0)+y,16,16);
                 break;
             }
         }

--- a/src/zq_misc.cpp
+++ b/src/zq_misc.cpp
@@ -76,6 +76,22 @@ int filetype(const char *path)
     return ftBIN;
 }
 
+int cursorColor(int col)
+{
+	switch(col)
+	{
+		case dvc(1):
+			return jwin_pal[jcCURSORMISC];
+		case dvc(2):
+			return jwin_pal[jcCURSOROUTLINE];
+		case dvc(3):
+			return jwin_pal[jcCURSORLIGHT];
+		case dvc(5):
+			return jwin_pal[jcCURSORDARK];
+	}
+	return col;
+}
+
 void load_mice()
 {
 	for(int i=0; i<MOUSE_BMP_MAX; i++)
@@ -90,27 +106,10 @@ void load_mice()
 			{
 				for(int y = 0; y < 16; ++y)
 				{
-					int color = getpixel(tmpbmp, x, y);
-					switch(color)
-					{
-						case dvc(1):
-							color = jwin_pal[jcCURSORMISC];
-							break;
-						case dvc(2):
-							color = jwin_pal[jcCURSOROUTLINE];
-							break;
-						case dvc(3):
-							color = jwin_pal[jcCURSORLIGHT];
-							break;
-						case dvc(5):
-							color = jwin_pal[jcCURSORDARK];
-							break;
-					}
-					putpixel(mouse_bmp[i][j], x, y, color);
+					putpixel(mouse_bmp[i][j], x, y, cursorColor(getpixel(tmpbmp, x, y)));
 				}
 			}
 			destroy_bitmap(tmpbmp);
-			//blit((BITMAP*)zcdata[BMP_MOUSE].dat,mouse_bmp[i][j],i*17+1,j*17+1,0,0,16,16);
 		}
 	}
 }
@@ -142,7 +141,16 @@ void load_arrows()
     for(int i=0; i<MAXARROWS; i++)
     {
         arrow_bmp[i] = create_bitmap_ex(8,16,16);
-        blit((BITMAP*)zcdata[BMP_ARROWS].dat,arrow_bmp[i],i*17+1,1,0,0,16,16);
+		BITMAP* tmpbmp = create_bitmap_ex(8,16,16);
+        blit((BITMAP*)zcdata[BMP_ARROWS].dat,tmpbmp,i*17+1,1,0,0,16,16);
+		for(int x = 0; x < 16; ++x)
+		{
+			for(int y = 0; y < 16; ++y)
+			{
+				putpixel(arrow_bmp[i], x, y, cursorColor(getpixel(tmpbmp, x, y)));
+			}
+		}
+		destroy_bitmap(tmpbmp);
     }
 }
 

--- a/src/zq_misc.cpp
+++ b/src/zq_misc.cpp
@@ -30,6 +30,7 @@
 
 extern int prv_mode;
 extern void dopreview();
+extern int jwin_pal[jcMAX];
 
 
 const char *imgstr[ftMAX] =
@@ -77,14 +78,41 @@ int filetype(const char *path)
 
 void load_mice()
 {
-    for(int i=0; i<MOUSE_BMP_MAX; i++)
-    {
-        for(int j=0; j<4; j++)
-        {
-            mouse_bmp[i][j] = create_bitmap_ex(8,16,16);
-            blit((BITMAP*)zcdata[BMP_MOUSEZQ].dat,mouse_bmp[i][j],i*17+1,j*17+1,0,0,16,16);
-        }
-    }
+	for(int i=0; i<MOUSE_BMP_MAX; i++)
+	{
+		for(int j=0; j<4; j++)
+		{
+			mouse_bmp[i][j] = create_bitmap_ex(8,16,16);
+			BITMAP* tmpbmp = create_bitmap_ex(8,16,16);
+			clear_bitmap(tmpbmp);
+			blit((BITMAP*)zcdata[BMP_MOUSEZQ].dat,tmpbmp,i*17+1,j*17+1,0,0,16,16);
+			for(int x = 0; x < 16; ++x)
+			{
+				for(int y = 0; y < 16; ++y)
+				{
+					int color = getpixel(tmpbmp, x, y);
+					switch(color)
+					{
+						case dvc(1):
+							color = jwin_pal[jcCURSORMISC];
+							break;
+						case dvc(2):
+							color = jwin_pal[jcCURSOROUTLINE];
+							break;
+						case dvc(3):
+							color = jwin_pal[jcCURSORLIGHT];
+							break;
+						case dvc(5):
+							color = jwin_pal[jcCURSORDARK];
+							break;
+					}
+					putpixel(mouse_bmp[i][j], x, y, color);
+				}
+			}
+			destroy_bitmap(tmpbmp);
+			//blit((BITMAP*)zcdata[BMP_MOUSE].dat,mouse_bmp[i][j],i*17+1,j*17+1,0,0,16,16);
+		}
+	}
 }
 
 void load_icons()

--- a/src/zq_tiles.cpp
+++ b/src/zq_tiles.cpp
@@ -919,7 +919,7 @@ void do_layerradio(BITMAP *dest,int x,int y,int bg,int fg,int &value)
     }
 }
 
-void draw_checkbox(BITMAP *dest,int x,int y,int bg,int fg, bool value)
+void draw_checkbox(BITMAP *dest,int x,int y,int sz,int bg,int fg, bool value)
 {
     //these are here to bypass compiler warnings about unused arguments
     bg=bg;
@@ -929,20 +929,20 @@ void draw_checkbox(BITMAP *dest,int x,int y,int bg,int fg, bool value)
     //  line(dest,x+1,y+1,x+7,y+7,value?fg:bg);
     //  line(dest,x+1,y+7,x+7,y+1,value?fg:bg);
     
-    jwin_draw_frame(dest, x, y, 9, 9, FR_DEEP);
-    rectfill(dest, x+2, y+2, x+9-3, y+9-3, jwin_pal[jcTEXTBG]);
+    jwin_draw_frame(dest, x, y, sz, sz, FR_DEEP);
+    rectfill(dest, x+2, y+2, x+sz-3, y+sz-3, jwin_pal[jcTEXTBG]);
     
     if(value)
     {
-        line(dest, x+2, y+2, x+9-3, y+9-3, jwin_pal[jcTEXTFG]);
-        line(dest, x+2, y+9-3, x+9-3, y+2, jwin_pal[jcTEXTFG]);
+        line(dest, x+2, y+2, x+sz-3, y+sz-3, jwin_pal[jcTEXTFG]);
+        line(dest, x+2, y+sz-3, x+sz-3, y+2, jwin_pal[jcTEXTFG]);
     }
     
 }
 
 
 
-bool do_checkbox(BITMAP *dest,int x,int y,int bg,int fg,int &value)
+bool do_checkbox(BITMAP *dest,int x,int y,int sz,int bg,int fg,int &value)
 {
     bool over=false;
     
@@ -950,13 +950,13 @@ bool do_checkbox(BITMAP *dest,int x,int y,int bg,int fg,int &value)
     {
         custom_vsync();
         
-        if(isinRect(gui_mouse_x(),gui_mouse_y(),x,y,x+8,y+8))               //if on checkbox
+        if(isinRect(gui_mouse_x(),gui_mouse_y(),x,y,x+sz-1,y+sz-1))               //if on checkbox
         {
             if(!over)                                             //if wasn't here before
             {
                 scare_mouse();
                 value=!value;
-                draw_checkbox(dest,x,y,bg,fg,value!=0);
+                draw_checkbox(dest,x,y,sz,bg,fg,value!=0);
                 refresh(rMENU);
                 unscare_mouse();
                 over=true;
@@ -968,7 +968,7 @@ bool do_checkbox(BITMAP *dest,int x,int y,int bg,int fg,int &value)
             {
                 scare_mouse();
                 value=!value;
-                draw_checkbox(dest,x,y,bg,fg,value!=0);
+                draw_checkbox(dest,x,y,sz,bg,fg,value!=0);
                 refresh(rMENU);
                 unscare_mouse();
                 over=false;

--- a/src/zq_tiles.h
+++ b/src/zq_tiles.h
@@ -41,8 +41,8 @@ bool do_graphics_button(int x,int y,int w,int h,BITMAP *bmp,BITMAP *bmp2,int bg,
 bool do_graphics_button_reset(int x,int y,int w,int h,BITMAP *bmp,BITMAP *bmp2,int bg,int fg,bool jwin,bool overlay);
 void draw_layerradio(BITMAP *dest,int x,int y,int bg,int fg, int value);
 void do_layerradio(BITMAP *dest,int x,int y,int bg,int fg,int &value);
-void draw_checkbox(BITMAP *dest,int x,int y,int bg,int fg, bool value);
-bool do_checkbox(BITMAP *dest,int x,int y,int bg,int fg,int &value);
+void draw_checkbox(BITMAP *dest,int x,int y,int sz,int bg,int fg, bool value);
+bool do_checkbox(BITMAP *dest,int x,int y,int sz,int bg,int fg,int &value);
 
 //*************** tile flood fill stuff **************
 

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -256,6 +256,8 @@ int command_buttonheight = 19;
 int layerpanel_buttonwidth = 58;
 int layerpanel_buttonheight = 16;
 
+int layerpanel_checkbox_sz = 13;
+
 int favorite_combos[MAXFAVORITECOMBOS];
 int favorite_comboaliases[MAXFAVORITECOMBOALIASES];
 int favorite_commands[MAXFAVORITECOMMANDS];
@@ -4074,19 +4076,19 @@ void drawpanel(int pnl)
                 
                 textprintf_centre_disabled(menu1,font,panel[6].x+88,panel[6].y+2,jwin_pal[jcLIGHT],jwin_pal[jcMEDDARK],"Layers");
                 textprintf_centre_disabled(menu1,font,panel[6].x+13,panel[6].y+11,jwin_pal[jcLIGHT],jwin_pal[jcMEDDARK],"0");
-                draw_checkbox(menu1,panel[6].x+9,panel[6].y+20,vc(1),vc(14), LayerMaskInt[0]!=0);
+                draw_checkbox(menu1,panel[6].x+9-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[0]!=0);
                 textprintf_centre_disabled(menu1,font,panel[6].x+38,panel[6].y+11,jwin_pal[jcLIGHT],jwin_pal[jcMEDDARK],"1");
-                draw_checkbox(menu1,panel[6].x+34,panel[6].y+20,vc(1),vc(14), LayerMaskInt[1]!=0);
+                draw_checkbox(menu1,panel[6].x+34-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[1]!=0);
                 textprintf_centre_disabled(menu1,font,panel[6].x+63,panel[6].y+11,jwin_pal[jcLIGHT],jwin_pal[jcMEDDARK],"2");
-                draw_checkbox(menu1,panel[6].x+59,panel[6].y+20,vc(1),vc(14), LayerMaskInt[2]!=0);
+                draw_checkbox(menu1,panel[6].x+59-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[2]!=0);
                 textprintf_centre_disabled(menu1,font,panel[6].x+88,panel[6].y+11,jwin_pal[jcLIGHT],jwin_pal[jcMEDDARK],"3");
-                draw_checkbox(menu1,panel[6].x+84,panel[6].y+20,vc(1),vc(14), LayerMaskInt[3]!=0);
+                draw_checkbox(menu1,panel[6].x+84-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[3]!=0);
                 textprintf_centre_disabled(menu1,font,panel[6].x+113,panel[6].y+11,jwin_pal[jcLIGHT],jwin_pal[jcMEDDARK],"4");
-                draw_checkbox(menu1,panel[6].x+109,panel[6].y+20,vc(1),vc(14), LayerMaskInt[4]!=0);
+                draw_checkbox(menu1,panel[6].x+109-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[4]!=0);
                 textprintf_centre_disabled(menu1,font,panel[6].x+138,panel[6].y+11,jwin_pal[jcLIGHT],jwin_pal[jcMEDDARK],"5");
-                draw_checkbox(menu1,panel[6].x+134,panel[6].y+20,vc(1),vc(14), LayerMaskInt[5]!=0);
+                draw_checkbox(menu1,panel[6].x+134-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[5]!=0);
                 textprintf_centre_disabled(menu1,font,panel[6].x+163,panel[6].y+11,jwin_pal[jcLIGHT],jwin_pal[jcMEDDARK],"6");
-                draw_checkbox(menu1,panel[6].x+159,panel[6].y+20,vc(1),vc(14), LayerMaskInt[6]!=0);
+                draw_checkbox(menu1,panel[6].x+159-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[6]!=0);
                 draw_layerradio(menu1,panel[6].x+9,panel[6].y+30,vc(1),vc(14), CurrentLayer);
                 
                 textprintf_disabled(menu1,spfont,panel[6].x+panel[6].w-28,panel[6].y+36,jwin_pal[jcLIGHT],jwin_pal[jcMEDDARK],"CSet");
@@ -5097,7 +5099,7 @@ void refresh(int flags)
             int rx = (i * (layerpanel_buttonwidth+23)) + layer_panel.x+6;
             int ry = layer_panel.y+16;
             draw_text_button(menu1, rx,ry, layerpanel_buttonwidth, layerpanel_buttonheight, tbuf,vc(1),vc(14), CurrentLayer==i? D_SELECTED : (!Map.CurrScr()->layermap[i-1] && i>0) ? D_DISABLED : 0,true);
-            draw_checkbox(menu1,rx+layerpanel_buttonwidth+4,ry+2,vc(1),vc(14), LayerMaskInt[i]!=0);
+            draw_checkbox(menu1,rx+layerpanel_buttonwidth+1,ry+2,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[i]!=0);
             
             // Draw the group divider
             if(i==3 || i==5)
@@ -8060,39 +8062,39 @@ void domouse()
             }
             else if(menutype==m_layers)
             {
-                if(isinRect(x, y, panel[6].x+9,panel[6].y+20,panel[6].x+9+8,panel[6].y+20+8))
+                if(isinRect(x, y, panel[6].x+9,panel[6].y+20,panel[6].x+9+layerpanel_checkbox_sz-1,panel[6].y+20+layerpanel_checkbox_sz-1))
                 {
-                    do_checkbox(menu1,panel[6].x+9,panel[6].y+20,vc(1),vc(14), LayerMaskInt[0]);
+                    do_checkbox(menu1,panel[6].x+9-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[0]);
                 }
                 
-                if(isinRect(x, y, panel[6].x+34,panel[6].y+20,panel[6].x+34+8,panel[6].y+20+8))
+                if(isinRect(x, y, panel[6].x+34,panel[6].y+20,panel[6].x+34+layerpanel_checkbox_sz-1,panel[6].y+20+layerpanel_checkbox_sz-1))
                 {
-                    do_checkbox(menu1,panel[6].x+34,panel[6].y+20,vc(1),vc(14), LayerMaskInt[1]);
+                    do_checkbox(menu1,panel[6].x+34-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[1]);
                 }
                 
-                if(isinRect(x, y, panel[6].x+59,panel[6].y+20,panel[6].x+59+8,panel[6].y+20+8))
+                if(isinRect(x, y, panel[6].x+59,panel[6].y+20,panel[6].x+59+layerpanel_checkbox_sz-1,panel[6].y+20+layerpanel_checkbox_sz-1))
                 {
-                    do_checkbox(menu1,panel[6].x+59,panel[6].y+20,vc(1),vc(14), LayerMaskInt[2]);
+                    do_checkbox(menu1,panel[6].x+59-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[2]);
                 }
                 
-                if(isinRect(x, y, panel[6].x+84,panel[6].y+20,panel[6].x+84+8,panel[6].y+20+8))
+                if(isinRect(x, y, panel[6].x+84,panel[6].y+20,panel[6].x+84+layerpanel_checkbox_sz-1,panel[6].y+20+layerpanel_checkbox_sz-1))
                 {
-                    do_checkbox(menu1,panel[6].x+84,panel[6].y+20,vc(1),vc(14), LayerMaskInt[3]);
+                    do_checkbox(menu1,panel[6].x+84-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[3]);
                 }
                 
-                if(isinRect(x, y, panel[6].x+109,panel[6].y+20,panel[6].x+109+8,panel[6].y+20+8))
+                if(isinRect(x, y, panel[6].x+109,panel[6].y+20,panel[6].x+109+layerpanel_checkbox_sz-1,panel[6].y+20+layerpanel_checkbox_sz-1))
                 {
-                    do_checkbox(menu1,panel[6].x+109,panel[6].y+20,vc(1),vc(14), LayerMaskInt[4]);
+                    do_checkbox(menu1,panel[6].x+109-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[4]);
                 }
                 
-                if(isinRect(x, y, panel[6].x+134,panel[6].y+20,panel[6].x+134+8,panel[6].y+20+8))
+                if(isinRect(x, y, panel[6].x+134,panel[6].y+20,panel[6].x+134+layerpanel_checkbox_sz-1,panel[6].y+20+layerpanel_checkbox_sz-1))
                 {
-                    do_checkbox(menu1,panel[6].x+134,panel[6].y+20,vc(1),vc(14), LayerMaskInt[5]);
+                    do_checkbox(menu1,panel[6].x+134-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[5]);
                 }
                 
-                if(isinRect(x, y, panel[6].x+159,panel[6].y+20,panel[6].x+159+8,panel[6].y+20+8))
+                if(isinRect(x, y, panel[6].x+159,panel[6].y+20,panel[6].x+159+layerpanel_checkbox_sz-1,panel[6].y+20+layerpanel_checkbox_sz-1))
                 {
-                    do_checkbox(menu1,panel[6].x+159,panel[6].y+20,vc(1),vc(14), LayerMaskInt[6]);
+                    do_checkbox(menu1,panel[6].x+159-3,panel[6].y+20,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[6]);
                 }
                 
                 if(isinRect(x, y, panel[6].x+9,panel[6].y+30, panel[6].x+9+(6*25)+8,panel[6].y+30+8))
@@ -8378,8 +8380,8 @@ void domouse()
                     }
                 }
                 
-                if(isinRect(x,y,rx+layerpanel_buttonwidth+4,ry+2,rx+layerpanel_buttonwidth+12,ry+10))
-                    do_checkbox(menu1,rx+layerpanel_buttonwidth+4,ry+2,vc(1),vc(14), LayerMaskInt[i]);
+                if(isinRect(x,y,rx+layerpanel_buttonwidth+1,ry+2,rx+layerpanel_buttonwidth+1+layerpanel_checkbox_sz-1,ry+2+layerpanel_checkbox_sz-1))
+                    do_checkbox(menu1,rx+layerpanel_buttonwidth+1,ry+2,layerpanel_checkbox_sz,vc(1),vc(14), LayerMaskInt[i]);
             }
         }
         
@@ -25662,6 +25664,10 @@ int main(int argc,char **argv)
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(8);
         jwin_pal[jcSELFG]  =dvc(6);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     
@@ -25702,6 +25708,10 @@ int main(int argc,char **argv)
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(9);
         jwin_pal[jcSELFG]  =dvc(7);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     
@@ -25741,6 +25751,10 @@ int main(int argc,char **argv)
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(8);
         jwin_pal[jcSELFG]  =dvc(6);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     
@@ -25781,6 +25795,10 @@ int main(int argc,char **argv)
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(9);
         jwin_pal[jcSELFG]  =dvc(7);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     
@@ -25820,6 +25838,10 @@ int main(int argc,char **argv)
         jwin_pal[jcTEXTFG] =dvc(7);
         jwin_pal[jcSELBG]  =dvc(8);
         jwin_pal[jcSELFG]  =dvc(6);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     
@@ -25854,6 +25876,10 @@ int main(int argc,char **argv)
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(8);
         jwin_pal[jcSELFG]  =dvc(6);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     
@@ -25891,6 +25917,10 @@ int main(int argc,char **argv)
 		jwin_pal[jcTEXTFG] =dvc(get_config_int("Theme","jctextfg",1));
 		jwin_pal[jcSELBG]  =dvc(get_config_int("Theme","jcselbg",8));
 		jwin_pal[jcSELFG]  =dvc(get_config_int("Theme","jcselfg",6));
+		jwin_pal[jcCURSORMISC] = dvc(get_config_int("Theme","jccursormisc",1));
+		jwin_pal[jcCURSOROUTLINE] = dvc(get_config_int("Theme","jccursoroutline",2));
+		jwin_pal[jcCURSORLIGHT] = dvc(get_config_int("Theme","jccursorlight",3));
+		jwin_pal[jcCURSORDARK] = dvc(get_config_int("Theme","jccursordark",5));
 		
 	}
 	else
@@ -25923,6 +25953,10 @@ int main(int argc,char **argv)
 		jwin_pal[jcTEXTFG] =dvc(get_config_int("Theme","jctextfg",1));
 		jwin_pal[jcSELBG]  =dvc(get_config_int("Theme","jcselbg",8));
 		jwin_pal[jcSELFG]  =dvc(get_config_int("Theme","jcselfg",6));
+		jwin_pal[jcCURSORMISC] = dvc(get_config_int("Theme","jccursormisc",1));
+		jwin_pal[jcCURSOROUTLINE] = dvc(get_config_int("Theme","jccursoroutline",2));
+		jwin_pal[jcCURSORLIGHT] = dvc(get_config_int("Theme","jccursorlight",3));
+		jwin_pal[jcCURSORDARK] = dvc(get_config_int("Theme","jccursordark",5));
 		set_config_file("zquest.cfg"); //shift back when done
 	}
     }
@@ -25972,6 +26006,10 @@ int main(int argc,char **argv)
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(8);
         jwin_pal[jcSELFG]  =dvc(6);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     
@@ -26011,6 +26049,10 @@ int main(int argc,char **argv)
         jwin_pal[jcTEXTFG] =dvc(1);
         jwin_pal[jcSELBG]  =dvc(8);
         jwin_pal[jcSELFG]  =dvc(6);
+		jwin_pal[jcCURSORMISC] = dvc(1);
+		jwin_pal[jcCURSOROUTLINE] = dvc(2);
+		jwin_pal[jcCURSORLIGHT] = dvc(3);
+		jwin_pal[jcCURSORDARK] = dvc(5);
     }
     break;
     }


### PR DESCRIPTION
Ported from 2.53:
4 new "jc*" constants have been added. These color options are used exclusively
	for the cursor, and can be modified in user themes.
When the cursor is loaded from the .dat file, the colors it loads are replaced
	pixel-by-pixel to match the settings. dvc colors 1, 2, 3, and 5 are
	replaced with the new jc constants, in that order.
This pixel-by-pixel replacement occurs ONCE, on load.

GUI: Increase size of layer checkboxes
Why the hell were they so small? No good reason.