### PR TITLE
Feat: Cursor scaling

### DIFF
--- a/output/common/zc.cfg
+++ b/output/common/zc.cfg
@@ -60,6 +60,8 @@ key_cheatmod_a1=117
 key_cheatmod_a2=118
 key_cheatmod_b1=115
 key_cheatmod_b2=116
+cursor_scale_large = 1.5
+cursor_scale_small = 1
 
 [graphics]
 disable_direct_updating=1

--- a/output/common/zquest.cfg
+++ b/output/common/zquest.cfg
@@ -79,6 +79,8 @@ frame_rest_suggest=0
 doublebuffer=1
 triplebuffer=1
 beta_warning=q~TC~~F~
+cursor_scale_large = 1.5
+cursor_scale_small = 1
 
 [graphics]
 disable_direct_updating=1

--- a/src/zc_sys.cpp
+++ b/src/zc_sys.cpp
@@ -678,12 +678,16 @@ void show_saving(BITMAP *target)
 void load_mouse()
 {
 	system_pal();
+	int sz = int(16*(is_large ? get_config_float("zeldadx","cursor_scale_large",1.5) : get_config_float("zeldadx","cursor_scale_small",1)));
 	for(int j = 0; j < 4; ++j)
 	{
 		BITMAP* tmpbmp = create_bitmap_ex(8,16,16);
+		BITMAP* subbmp = create_bitmap_ex(8,16,16);
+		zcmouse[j] = create_bitmap_ex(8,sz,sz);
+		clear_bitmap(zcmouse[j]);
 		clear_bitmap(tmpbmp);
+		clear_bitmap(subbmp);
 		blit((BITMAP*)data[BMP_MOUSE].dat,tmpbmp,1,j*17+1,0,0,16,16);
-		//BITMAP* tmpbmp = (BITMAP*)data[BMP_MOUSE].dat;
 		for(int x = 0; x < 16; ++x)
 		{
 			for(int y = 0; y < 16; ++y)
@@ -704,11 +708,15 @@ void load_mouse()
 						color = jwin_pal[jcCURSORDARK];
 						break;
 				}
-				//if(color!=0)Z_message("Pixel %d,%d == %d\n",x,y,color);
-				putpixel(zcmouse[j], x, y, color);
+				putpixel(subbmp, x, y, color);
 			}
 		}
+		if(sz!=16)
+			stretch_blit(subbmp, zcmouse[j], 0, 0, 16, 16, 0, 0, sz, sz);
+		else
+			blit(subbmp, zcmouse[j], 0, 0, 0, 0, 16, 16);
 		destroy_bitmap(tmpbmp);
+		destroy_bitmap(subbmp);
 	}
 	game_pal();
 }

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -4188,10 +4188,6 @@ int main(int argc, char* argv[])
     msgdisplaybuf = create_bitmap_ex(8,256, 176);
     msgbmpbuf = create_bitmap_ex(8, 512+16, 512+16);
     pricesdisplaybuf = create_bitmap_ex(8,256, 176);
-	zcmouse[0] = create_bitmap_ex(8, 16, 16);
-	zcmouse[1] = create_bitmap_ex(8, 16, 16);
-	zcmouse[2] = create_bitmap_ex(8, 16, 16);
-	zcmouse[3] = create_bitmap_ex(8, 16, 16);
 	script_menu_buf = create_bitmap_ex(8,256,224);
     
     if(!framebuf || !scrollbuf || !tmp_bmp || !fps_undo || !tmp_scr
@@ -4207,10 +4203,6 @@ int main(int argc, char* argv[])
     set_clip_state(msgdisplaybuf, 1);
     clear_bitmap(pricesdisplaybuf);
     set_clip_state(pricesdisplaybuf, 1);
-	clear_bitmap(zcmouse[0]);
-	clear_bitmap(zcmouse[1]);
-	clear_bitmap(zcmouse[2]);
-	clear_bitmap(zcmouse[3]);
     Z_message("OK\n");
     
     

--- a/src/zq_misc.cpp
+++ b/src/zq_misc.cpp
@@ -94,22 +94,32 @@ int cursorColor(int col)
 
 void load_mice()
 {
+	int sz = int(16*(is_large ? get_config_float("zquest","cursor_scale_large",1.5) : get_config_float("zquest","cursor_scale_small",1)));
 	for(int i=0; i<MOUSE_BMP_MAX; i++)
 	{
 		for(int j=0; j<4; j++)
 		{
-			mouse_bmp[i][j] = create_bitmap_ex(8,16,16);
+			mouse_bmp[i][j] = create_bitmap_ex(8,sz,sz);
+			mouse_bmp_1x[i][j] = create_bitmap_ex(8,16,16);
 			BITMAP* tmpbmp = create_bitmap_ex(8,16,16);
+			BITMAP* subbmp = create_bitmap_ex(8,16,16);
 			clear_bitmap(tmpbmp);
+			clear_bitmap(subbmp);
 			blit((BITMAP*)zcdata[BMP_MOUSEZQ].dat,tmpbmp,i*17+1,j*17+1,0,0,16,16);
 			for(int x = 0; x < 16; ++x)
 			{
 				for(int y = 0; y < 16; ++y)
 				{
-					putpixel(mouse_bmp[i][j], x, y, cursorColor(getpixel(tmpbmp, x, y)));
+					putpixel(subbmp, x, y, cursorColor(getpixel(tmpbmp, x, y)));
 				}
 			}
+			if(sz!=16)
+				stretch_blit(subbmp, mouse_bmp[i][j], 0, 0, 16, 16, 0, 0, sz, sz);
+			else
+				blit(subbmp, mouse_bmp[i][j], 0, 0, 0, 0, 16, 16);
+			blit(subbmp, mouse_bmp_1x[i][j], 0, 0, 0, 0, 16, 16);
 			destroy_bitmap(tmpbmp);
+			destroy_bitmap(subbmp);
 		}
 	}
 }

--- a/src/zq_tiles.cpp
+++ b/src/zq_tiles.cpp
@@ -1314,7 +1314,7 @@ void draw_edit_scr(int tile,int flip,int cs,byte *oldtile, bool create_tbar)
         int rows=(MOUSE_BMP_BLANK-MOUSE_BMP_SWORD+2)/tool_buttons_columns;
         int row=(i-MOUSE_BMP_SWORD)-(column*rows);
         jwin_draw_button(screen2,tool_buttons_left+(column*23),tool_buttons_top+(row*23),22,22,tool==(i-MOUSE_BMP_SWORD)?2:0,0);
-        masked_blit(mouse_bmp[i][0],screen2,0,0,tool_buttons_left+(column*23)+3+(tool==(i-MOUSE_BMP_SWORD)?1:0),tool_buttons_top+3+(row*23)+(tool==(i-MOUSE_BMP_SWORD)?1:0),16,16);
+        masked_blit(mouse_bmp_1x[i][0],screen2,0,0,tool_buttons_left+(column*23)+3+(tool==(i-MOUSE_BMP_SWORD)?1:0),tool_buttons_top+3+(row*23)+(tool==(i-MOUSE_BMP_SWORD)?1:0),16,16);
     }
     
     //coordinates

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -310,7 +310,7 @@ FONT       *nfont, *zfont, *z3font, *z3smallfont, *deffont, *lfont, *lfont_l, *p
 		*sinqlfont, *spectrumfont, *speclgfont, *ti99font, *trsfont, *z2font, *zxfont, *lisafont
 	    //#endif
 	   ;
-BITMAP *menu1, *menu3, *mapscreenbmp, *tmp_scr, *screen2, *mouse_bmp[MOUSE_BMP_MAX][4], *icon_bmp[ICON_BMP_MAX][4], *select_bmp[2], *dmapbmp_small, *dmapbmp_large;
+BITMAP *menu1, *menu3, *mapscreenbmp, *tmp_scr, *screen2, *mouse_bmp[MOUSE_BMP_MAX][4], *mouse_bmp_1x[MOUSE_BMP_MAX][4], *icon_bmp[ICON_BMP_MAX][4], *select_bmp[2], *dmapbmp_small, *dmapbmp_large;
 BITMAP *arrow_bmp[MAXARROWS],*brushbmp, *brushscreen, *tooltipbmp;//*brushshadowbmp;
 byte *colordata=NULL, *trashbuf=NULL;
 itemdata *itemsbuf;
@@ -26526,7 +26526,10 @@ void destroy_bitmaps_on_exit()
     show_mouse(NULL);
     
     for(int i=0; i<MOUSE_BMP_MAX*4; i++)
+	{
         destroy_bitmap(mouse_bmp[i/4][i%4]);
+        destroy_bitmap(mouse_bmp_1x[i/4][i%4]);
+	}
         
     for(int i=0; i<ICON_BMP_MAX*4; i++)
         destroy_bitmap(icon_bmp[i/4][i%4]);

--- a/src/zquest.h
+++ b/src/zquest.h
@@ -131,7 +131,7 @@ extern FONT *nfont, *zfont, *z3font, *z3smallfont, *deffont, *lfont, *lfont_l, *
 		*sinqlfont, *spectrumfont, *speclgfont, *ti99font, *trsfont, *z2font, *zxfont, *lisafont
 	    //#endif
 	   ;
-extern BITMAP *menu1,*menu3, *mapscreenbmp, *tmp_scr, *screen2, *mouse_bmp[MOUSE_BMP_MAX][4], *icon_bmp[ICON_BMP_MAX][4], *panel_button_icon_bmp[m_menucount][4], *select_bmp[2],*dmapbmp_small, *dmapbmp_large;
+extern BITMAP *menu1,*menu3, *mapscreenbmp, *tmp_scr, *screen2, *mouse_bmp[MOUSE_BMP_MAX][4], *mouse_bmp_1x[MOUSE_BMP_MAX][4], *icon_bmp[ICON_BMP_MAX][4], *panel_button_icon_bmp[m_menucount][4], *select_bmp[2],*dmapbmp_small, *dmapbmp_large;
 extern BITMAP *arrow_bmp[MAXARROWS],*brushbmp, *brushscreen, *tooltipbmp; //, *brushshadowbmp;
 extern byte *colordata, *trashbuf;
 //extern byte *tilebuf;


### PR DESCRIPTION
Config options 'cursor_scale_large' and 'cursor_scale_small', to scale the cursor
	added to zquest.cfg and zc.cfg. Range 1 to 5, decimal allowed.