### PR TITLE
Added .ZTILE Format Files

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,11 @@ ChangeLog for 2.53.0
 
 //Release 3
 
+Added Export and Import .ZTILE files.
+	You can save a series of tiles, in mixed format to a .ZTILE file,
+	and load them into any quest, either in the exact position in 
+	which they were located in the source quest, or starting at a 
+	position that you specify.
 Fixed some error messages on modular object file loading.
 Fixed the sanity checks for section_version and section_cversion on modular
 	object file loading.

--- a/src/tiles.cpp
+++ b/src/tiles.cpp
@@ -381,7 +381,6 @@ void clear_tile(tiledata *buf, word tile)
   memset(buf[tile].data,0,tilesize(buf[tile].format));
 }
 */
-
 void reset_tile(tiledata *buf, int t, int format=1)
 {
     buf[t].format=format;

--- a/src/tiles.h
+++ b/src/tiles.h
@@ -37,6 +37,7 @@ extern const char *tileformat_string[tfMax];
 extern comboclass   *combo_class_buf;
 
 void register_blank_tiles();
+
 word count_tiles(tiledata *buf);
 word count_combos();
 void setup_combo_animations();

--- a/src/zq_files.cpp
+++ b/src/zq_files.cpp
@@ -1035,6 +1035,13 @@ int onImport_DMaps()
     return D_O_K;
 }
 
+int onExport_Tilepack()
+{
+	savesometiles("Save Tile Package", 0);
+	return D_O_K;
+	
+}
+
 int onExport_DMaps()
 {
     if(!getname("Export DMaps (.dmp)","dmp",NULL,datapath,false))

--- a/src/zq_files.cpp
+++ b/src/zq_files.cpp
@@ -1042,6 +1042,36 @@ int onExport_Tilepack()
 	
 }
 
+int onImport_Tilepack_To()
+{
+	writesometiles_to("Load Tile Package to:", 0);
+	return D_O_K;
+	
+}
+
+int onImport_Tilepack()
+{
+		if(getname("Load ZTILE(.ztile)", "ztile", NULL,datapath,false))
+		{  
+			PACKFILE *f=pack_fopen_password(temppath,F_READ, "");
+			if(f)
+			{
+				if (!readtilefile(f))
+				{
+					al_trace("Could not read from .ztile packfile %s\n", temppath);
+					jwin_alert("ZTILE File: Error","Could not load the specified Tile.",NULL,NULL,"O&K",NULL,'k',0,lfont);
+				}
+				else
+				{
+					jwin_alert("ZTILE File: Success!","Loaded the source tiles to your tile sheets!",NULL,NULL,"O&K",NULL,'k',0,lfont);
+				}
+			}
+	
+			pack_fclose(f);
+		}
+		return D_O_K;
+}
+
 int onExport_DMaps()
 {
     if(!getname("Export DMaps (.dmp)","dmp",NULL,datapath,false))

--- a/src/zq_files.h
+++ b/src/zq_files.h
@@ -51,6 +51,8 @@ int onImport_ZQT();
 int onExport_ZQT();
 int onImport_UnencodedQuest();
 int onExport_Tilepack();
+int onImport_Tilepack();
+int onImport_Tilepack_To();
 int onExport_UnencodedQuest();
 void center_zq_files_dialogs();
 #endif

--- a/src/zq_files.h
+++ b/src/zq_files.h
@@ -50,6 +50,7 @@ int onExport_ZGP();
 int onImport_ZQT();
 int onExport_ZQT();
 int onImport_UnencodedQuest();
+int onExport_Tilepack();
 int onExport_UnencodedQuest();
 void center_zq_files_dialogs();
 #endif

--- a/src/zq_misc.h
+++ b/src/zq_misc.h
@@ -261,6 +261,8 @@ int onExport_ZGP();
 int onExport_ZQT();
 int onExport_UnencodedQuest();
 int onExport_Tilepack();
+int onImport_Tilepack();
+int onImport_Tilepack_To();
 
 int onGotoMap();
 int onMapCount();

--- a/src/zq_misc.h
+++ b/src/zq_misc.h
@@ -260,6 +260,7 @@ int onExport_Pals();
 int onExport_ZGP();
 int onExport_ZQT();
 int onExport_UnencodedQuest();
+int onExport_Tilepack();
 
 int onGotoMap();
 int onMapCount();

--- a/src/zq_tiles.cpp
+++ b/src/zq_tiles.cpp
@@ -8402,7 +8402,7 @@ int readtilefile(PACKFILE *f)
 	byte format=tf4Bit;
 	memset(temp_tile, 0, tilesize(tf32Bit));
 
-	for ( int tilect = 0; tilect < count; tilect++ )
+	for ( int tilect = 0; tilect <= count; tilect++ )
 	{
 		memset(temp_tile, 0, tilesize(tf32Bit));
 		if(!p_getc(&format,f,true))
@@ -8418,8 +8418,8 @@ int readtilefile(PACKFILE *f)
 			return 0;
 		}
 			    
-		reset_tile(newtilebuf, index+(count-1), format);
-		memcpy(newtilebuf[index+(count-1)].data,temp_tile,tilesize(newtilebuf[index+(count-1)].format));
+		reset_tile(newtilebuf, index+(tilect-1), format);
+		memcpy(newtilebuf[index+(tilect-1)].data,temp_tile,tilesize(newtilebuf[index+(tilect-1)].format));
 	}
 	delete[] temp_tile;
 	
@@ -8468,15 +8468,15 @@ int writetilefile(PACKFILE *f, int index, int count)
 		return 0;
 	}
 	
-	for ( int tilect = 0; tilect < count; tilect++ )
+	for ( int tilect = 0; tilect <= count; tilect++ )
 	{
 	
-		if(!p_putc(newtilebuf[index+(count-1)].format,f))
+		if(!p_putc(newtilebuf[index+(tilect-1)].format,f))
 		{
 			return 0;
 		}
 		    
-		if(!pfwrite(newtilebuf[index+(count-1)].data,tilesize(newtilebuf[index+(count-1)].format),f))
+		if(!pfwrite(newtilebuf[index+(tilect-1)].data,tilesize(newtilebuf[index+(tilect-1)].format),f))
 		{
 			return 0;
 		}

--- a/src/zq_tiles.cpp
+++ b/src/zq_tiles.cpp
@@ -8186,6 +8186,7 @@ void do_convert_tile(int tile, int tile2, int cs, bool rect_sel, bool fourbit, b
         tile=tile2=zc_min(tile,tile2);
     }
 }
+/*
 int readtilefile(PACKFILE *f)
 {
 	dword section_version=0;
@@ -8229,11 +8230,6 @@ int readtilefile(PACKFILE *f)
 		al_trace("Reading a .ztile packfile made in ZC Version: %x, Build: %d\n", zversion, zbuild);
 	}
 	
-	//format
-	//newtilebuf[tile+t].format
-	//data
-	//tiledata temptile;
-	//memset(&temptile, 0, sizeof(tiledata));
 	int index = 0;
 	int count = 0;
 	
@@ -8251,31 +8247,30 @@ int readtilefile(PACKFILE *f)
 	}
 	al_trace("Reading tile: count(%d)\n", count);
 	
-	//if(!pfread(&temptile,sizeof(tiledata),f,true))
-	//{
-        //        return 0;
-	//}
 	
 	byte *temp_tile = new byte[tilesize(tf32Bit)];
 	byte format=tf4Bit;
 	memset(temp_tile, 0, tilesize(tf32Bit));
 
-	if(!p_getc(&format,f,true))
+	for ( int tilect = 0; tilect < count; tilect++ )
 	{
-		delete[] temp_tile;
-		return 0;
-	}
+		memset(temp_tile, 0, tilesize(tf32Bit));
+		if(!p_getc(&format,f,true))
+		{
+			delete[] temp_tile;
+			return 0;
+		}
 
-		    
-	if(!pfread(temp_tile,tilesize(format),f,true))
-	{
-		delete[] temp_tile;
-		return 0;
+			    
+		if(!pfread(temp_tile,tilesize(format),f,true))
+		{
+			delete[] temp_tile;
+			return 0;
+		}
+			    
+		reset_tile(newtilebuf, index+(count-1), format);
+		memcpy(newtilebuf[index+(count-1)].data,temp_tile,tilesize(newtilebuf[index+(count-1)].format));
 	}
-		    
-	reset_tile(newtilebuf, index+(count-1), format);
-	memcpy(newtilebuf[index+(count-1)].data,temp_tile,tilesize(newtilebuf[index+(count-1)].format));
-		    
 	delete[] temp_tile;
 	
 	//::memcpy(&(newtilebuf[tile_index]),&temptile,sizeof(tiledata));
@@ -8322,38 +8317,177 @@ int writetilefile(PACKFILE *f, int index, int count)
 		return 0;
 	}
 	
-	//format
-	//newtilebuf[tile+t].format
-	//data
-	
-	/*
-	tiledata temptile;
-	memset(&temptile, 0, sizeof(tiledata));
-	al_trace("Writing tile index(%d)\n", index);
-	//newtilebuf[j].data
-	::memcpy(&temptile,&(newtilebuf[index]),sizeof(tiledata));
-	
-	if(!pfwrite(&temptile,sizeof(tiledata),f))
+	for ( int tilect = 0; tilect < count; tilect++ )
 	{
-                return 0;
-	}
-	*/
 	
-	
-	if(!p_putc(newtilebuf[index+(count-1)].format,f))
-	{
-                return 0;
+		if(!p_putc(newtilebuf[index+(count-1)].format,f))
+		{
+			return 0;
+		}
+		    
+		if(!pfwrite(newtilebuf[index+(count-1)].data,tilesize(newtilebuf[index+(count-1)].format),f))
+		{
+			return 0;
+		}
 	}
-            
-	if(!pfwrite(newtilebuf[index+(count-1)].data,tilesize(newtilebuf[index+(count-1)].format),f))
-	{
-                return 0;
-	}
-	
 	
 	return 1;
 	
 }
+*/
+
+
+int readtilefile(PACKFILE *f)
+{
+	dword section_version=0;
+	dword section_cversion=0;
+	int zversion = 0;
+	int zbuild = 0;
+	
+	if(!p_igetl(&zversion,f,true))
+	{
+		return 0;
+	}
+	if(!p_igetl(&zbuild,f,true))
+	{
+		return 0;
+	}
+	if(!p_igetw(&section_version,f,true))
+	{
+		return 0;
+	}
+	if(!p_igetw(&section_cversion,f,true))
+	{
+		return 0;
+	}
+	al_trace("readoneweapon section_version: %d\n", section_version);
+	al_trace("readoneweapon section_cversion: %d\n", section_cversion);
+
+	if ( zversion > ZELDA_VERSION )
+	{
+		al_trace("Cannot read .ztile packfile made in ZC version (%x) in this version of ZC (%x)\n", zversion, ZELDA_VERSION);
+		return 0;
+	}
+	
+	else if ( ( section_version > V_TILES ) || ( section_version == V_TILES && section_cversion < CV_TILES ) )
+	{
+		al_trace("Cannot read .ztile packfile made using V_TILES (%d) subversion (%d)\n", section_version, section_cversion);
+		return 0;
+		
+	}
+	else
+	{
+		al_trace("Reading a .ztile packfile made in ZC Version: %x, Build: %d\n", zversion, zbuild);
+	}
+	
+	int index = 0;
+	int count = 0;
+	
+	//tile id
+	if(!p_igetl(&index,f,true))
+	{
+		return 0;
+	}
+	al_trace("Reading tile: index(%d)\n", index);
+	
+	//tile count
+	if(!p_igetl(&count,f,true))
+	{
+		return 0;
+	}
+	al_trace("Reading tile: count(%d)\n", count);
+	
+	
+	byte *temp_tile = new byte[tilesize(tf32Bit)];
+	byte format=tf4Bit;
+	memset(temp_tile, 0, tilesize(tf32Bit));
+
+	for ( int tilect = 0; tilect < count; tilect++ )
+	{
+		memset(temp_tile, 0, tilesize(tf32Bit));
+		if(!p_getc(&format,f,true))
+		{
+			delete[] temp_tile;
+			return 0;
+		}
+
+			    
+		if(!pfread(temp_tile,tilesize(format),f,true))
+		{
+			delete[] temp_tile;
+			return 0;
+		}
+			    
+		reset_tile(newtilebuf, index+(count-1), format);
+		memcpy(newtilebuf[index+(count-1)].data,temp_tile,tilesize(newtilebuf[index+(count-1)].format));
+	}
+	delete[] temp_tile;
+	
+	//::memcpy(&(newtilebuf[tile_index]),&temptile,sizeof(tiledata));
+	
+	register_blank_tiles();
+	register_used_tiles();
+            
+	return 1;
+	
+}
+int writetilefile(PACKFILE *f, int index, int count)
+{
+	dword section_version=V_TILES;
+	dword section_cversion=CV_TILES;
+	int zversion = ZELDA_VERSION;
+	int zbuild = VERSION_BUILD;
+	
+	if(!p_iputl(zversion,f))
+	{
+		return 0;
+	}
+	if(!p_iputl(zbuild,f))
+	{
+		return 0;
+	}
+	if(!p_iputw(section_version,f))
+	{
+		return 0;
+	}
+    
+	if(!p_iputw(section_cversion,f))
+	{
+		return 0;
+	}
+	
+	//start tile id
+	if(!p_iputl(index,f))
+	{
+		return 0;
+	}
+	
+	//count
+	if(!p_iputl(count,f))
+	{
+		return 0;
+	}
+	
+	for ( int tilect = 0; tilect < count; tilect++ )
+	{
+	
+		if(!p_putc(newtilebuf[index+(count-1)].format,f))
+		{
+			return 0;
+		}
+		    
+		if(!pfwrite(newtilebuf[index+(count-1)].data,tilesize(newtilebuf[index+(count-1)].format),f))
+		{
+			return 0;
+		}
+	}
+	
+	return 1;
+	
+}
+
+
+
 
 int select_tile(int &tile,int &flip,int type,int &cs,bool edit_cs,int exnow, bool always_use_flip)
 {
@@ -8540,6 +8674,9 @@ int select_tile(int &tile,int &flip,int type,int &cs,bool edit_cs,int exnow, boo
 		}
 	
 		pack_fclose(f);
+		//register_blank_tiles();
+		//register_used_tiles();
+		redraw=true;
 		break;
 	    }
             case KEY_MINUS:

--- a/src/zq_tiles.h
+++ b/src/zq_tiles.h
@@ -26,6 +26,7 @@ void calc_cset_reduce_table(PALETTE pal, int cs);
 void register_used_tiles();
 int readtilefile(PACKFILE *f);
 int writetilefile(PACKFILE *f, int index, int count);
+int readtilefile_to_location(PACKFILE *f, int start);
 int d_comboframe_proc(int msg, DIALOG *d, int c);
 int d_combo_proc(int msg,DIALOG *d,int c);
 void go_tiles();

--- a/src/zq_tiles.h
+++ b/src/zq_tiles.h
@@ -24,6 +24,8 @@ extern byte cset_reduce_table[PAL_SIZE];
 void calc_cset_reduce_table(PALETTE pal, int cs);
 
 void register_used_tiles();
+int readtilefile(PACKFILE *f);
+int writetilefile(PACKFILE *f, int index, int count);
 int d_comboframe_proc(int msg, DIALOG *d, int c);
 int d_combo_proc(int msg,DIALOG *d,int c);
 void go_tiles();

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -546,6 +546,7 @@ static MENU export_menu[] =
     { (char *)"&Graphics Pack",             onExport_ZGP,              NULL,                     0,            NULL   },
     { (char *)"&Quest Template",            onExport_ZQT,              NULL,                     0,            NULL   },
     { (char *)"&Unencoded Quest",           onExport_UnencodedQuest,   NULL,                     0,            NULL   },
+    { (char *)"Tile Pack",           	    onExport_Tilepack,   NULL,                     0,            NULL   },
     {  NULL,                                NULL,                      NULL,                     0,            NULL   }
 };
 
@@ -1207,6 +1208,62 @@ int getnumber(const char *prompt,int initialval)
         return atoi(buf);
         
     return initialval;
+}
+
+static DIALOG save_tiles_dlg[] =
+{
+    // (dialog proc)     (x)   (y)   (w)   (h)   (fg)     (bg)    (key)    (flags)     (d1)           (d2)     (dp)
+    { jwin_win_proc,      60-12,   40,   200-16,  72,  vc(14),  vc(1),  0,       D_EXIT,          0,             0, (void *) "Select Track", NULL, NULL },
+    { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
+    //for future tabs
+    { d_dummy_proc,         120,  128,  80+1,   8+1,    vc(14),  vc(1),  0,       0,          1,             0,       NULL, NULL, NULL },
+    { d_dummy_proc,         120,  128,  80+1,   8+1,    vc(14),  vc(1),  0,       0,          1,             0,       NULL, NULL, NULL },
+    //4
+    {  jwin_text_proc,        32,    26,     96,      8,    vc(11),     vc(1),      0,    0,          0,    0, (void *) "First",               NULL,   NULL  },
+    { jwin_edit_proc,          55,     26,    150,     16,    vc(12),                 vc(1),                   0,       0,          63,    0,  NULL,                                           NULL,   NULL                  },
+    //6
+    {  jwin_text_proc,        32,    44,     96,      8,    vc(11),     vc(1),      0,    0,          0,    0, (void *) "Count",               NULL,   NULL  },
+    { jwin_edit_proc,          55,     44,    150,     16,    vc(12),                 vc(1),                   0,       0,          63,    0,  NULL,                                           NULL,   NULL                  },
+    //7
+    { jwin_button_proc,   70,   87,  61,   21,   vc(14),  vc(1),  13,      D_EXIT,     0,             0, (void *) "Save", NULL, NULL },
+    { jwin_button_proc,   150,  87,  61,   21,   vc(14),  vc(1),  27,      D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
+    { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
+};
+
+
+void savesometiles(const char *prompt,int initialval)
+{
+	
+	char firsttile[8], tilecount[8];
+	int first_tile_id = 0; int the_tile_count = 1;
+	sprintf(firsttile,"%d",0);
+	sprintf(tilecount,"%d",1);
+	//int ret;
+	if(is_large)
+        large_dialog(save_tiles_dlg);
+	
+	int ret = zc_popup_dialog(save_tiles_dlg,-1);
+	
+	save_tiles_dlg[3].dp = firsttile;
+	save_tiles_dlg[5].dp = tilecount;
+	
+	
+	
+	if(ret == 7)
+	{
+		first_tile_id = vbound(atoi(firsttile), 0, NEWMAXTILES);
+		the_tile_count = vbound(atoi(tilecount), 1, NEWMAXTILES-first_tile_id);
+		if(getname("Save ZTILE(.ztile)", "ztile", NULL,datapath,false))
+		{  
+			PACKFILE *f=pack_fopen_password(temppath,F_WRITE, "");
+			if(f)
+			{
+				al_trace("Saving tiles %d to %d: %d\n", first_tile_id, first_tile_id+(the_tile_count-1));
+				writetilefile(f,first_tile_id,the_tile_count);
+				pack_fclose(f);
+			}
+		}
+	}
 }
 
 int gettilepagenumber(const char *prompt, int initialval)

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -1213,20 +1213,22 @@ int getnumber(const char *prompt,int initialval)
 static DIALOG save_tiles_dlg[] =
 {
     // (dialog proc)     (x)   (y)   (w)   (h)   (fg)     (bg)    (key)    (flags)     (d1)           (d2)     (dp)
-    { jwin_win_proc,      60-12,   40,   200-16,  72,  vc(14),  vc(1),  0,       D_EXIT,          0,             0, (void *) "Select Track", NULL, NULL },
+
+
+	{ jwin_win_proc,      0,   0,   120,  100,  vc(14),  vc(1),  0,       D_EXIT,          0,             0, (void *) "Select Track", NULL, NULL },
     { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
     //for future tabs
     { d_dummy_proc,         120,  128,  80+1,   8+1,    vc(14),  vc(1),  0,       0,          1,             0,       NULL, NULL, NULL },
     { d_dummy_proc,         120,  128,  80+1,   8+1,    vc(14),  vc(1),  0,       0,          1,             0,       NULL, NULL, NULL },
     //4
-    {  jwin_text_proc,        32,    26,     96,      8,    vc(11),     vc(1),      0,    0,          0,    0, (void *) "First",               NULL,   NULL  },
-    { jwin_edit_proc,          55,     26,    150,     16,    vc(12),                 vc(1),                   0,       0,          63,    0,  NULL,                                           NULL,   NULL                  },
+    {  jwin_text_proc,        10,    28,     20,      8,    vc(11),     vc(1),      0,    0,          0,    0, (void *) "First",               NULL,   NULL  },
+    { jwin_edit_proc,          55,     26,    40,     16,    vc(12),                 vc(1),                   0,       0,          63,    0,  NULL,                                           NULL,   NULL                  },
     //6
-    {  jwin_text_proc,        32,    44,     96,      8,    vc(11),     vc(1),      0,    0,          0,    0, (void *) "Count",               NULL,   NULL  },
-    { jwin_edit_proc,          55,     44,    150,     16,    vc(12),                 vc(1),                   0,       0,          63,    0,  NULL,                                           NULL,   NULL                  },
-    //7
-    { jwin_button_proc,   70,   87,  61,   21,   vc(14),  vc(1),  13,      D_EXIT,     0,             0, (void *) "Save", NULL, NULL },
-    { jwin_button_proc,   150,  87,  61,   21,   vc(14),  vc(1),  27,      D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
+    {  jwin_text_proc,        10,    46,     20,      8,    vc(11),     vc(1),      0,    0,          0,    0, (void *) "Count",               NULL,   NULL  },
+    { jwin_edit_proc,          55,     44,    40,     16,    vc(12),                 vc(1),                   0,       0,          63,    0,  NULL,                                           NULL,   NULL                  },
+    //8
+    { jwin_button_proc,   15,   72,  36,   21,   vc(14),  vc(1),  13,      D_EXIT,     0,             0, (void *) "Save", NULL, NULL },
+    { jwin_button_proc,   69,  72,  36,   21,   vc(14),  vc(1),  27,      D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
     { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
 };
 
@@ -1239,17 +1241,24 @@ void savesometiles(const char *prompt,int initialval)
 	sprintf(firsttile,"%d",0);
 	sprintf(tilecount,"%d",1);
 	//int ret;
+	
+	
+	
+	save_tiles_dlg[0].dp2 = lfont;
+	
+	sprintf(firsttile,"%d",0);
+	sprintf(tilecount,"%d",1);
+	
+	save_tiles_dlg[5].dp = firsttile;
+	save_tiles_dlg[7].dp = tilecount;
+	
 	if(is_large)
-        large_dialog(save_tiles_dlg);
+		large_dialog(save_tiles_dlg);
 	
 	int ret = zc_popup_dialog(save_tiles_dlg,-1);
+	jwin_center_dialog(save_tiles_dlg);
 	
-	save_tiles_dlg[3].dp = firsttile;
-	save_tiles_dlg[5].dp = tilecount;
-	
-	
-	
-	if(ret == 7)
+	if(ret == 8)
 	{
 		first_tile_id = vbound(atoi(firsttile), 0, NEWMAXTILES);
 		the_tile_count = vbound(atoi(tilecount), 1, NEWMAXTILES-first_tile_id);

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -526,7 +526,11 @@ static MENU import_menu[] =
     { (char *)"&Graphics Pack",             onImport_ZGP,              NULL,                     0,            NULL   },
     { (char *)"&Quest Template",            onImport_ZQT,              NULL,                     0,            NULL   },
     { (char *)"&Unencoded Quest",           onImport_UnencodedQuest,   NULL,                     0,            NULL   },
-   // { (char *)"ZASM to Allegro.log",           onExport_ZASM,   NULL,                     0,            NULL   },
+    { (char *)"Tile Pack",           	    onImport_Tilepack,   NULL,                     0,            NULL   },
+    { (char *)"",                           NULL,                      NULL,                     0,            NULL   },
+    { (char *)"Tile Pack to...",           	    onImport_Tilepack_To,   NULL,                     0,            NULL   },
+      
+    // { (char *)"ZASM to Allegro.log",           onExport_ZASM,   NULL,                     0,            NULL   },
    
     {  NULL,                                NULL,                      NULL,                     0,            NULL   }
 };
@@ -1215,7 +1219,7 @@ static DIALOG save_tiles_dlg[] =
     // (dialog proc)     (x)   (y)   (w)   (h)   (fg)     (bg)    (key)    (flags)     (d1)           (d2)     (dp)
 
 
-	{ jwin_win_proc,      0,   0,   120,  100,  vc(14),  vc(1),  0,       D_EXIT,          0,             0, (void *) "Select Track", NULL, NULL },
+	{ jwin_win_proc,      0,   0,   120,  100,  vc(14),  vc(1),  0,       D_EXIT,          0,             0, (void *) "Save Tile Pack", NULL, NULL },
     { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
     //for future tabs
     { d_dummy_proc,         120,  128,  80+1,   8+1,    vc(14),  vc(1),  0,       0,          1,             0,       NULL, NULL, NULL },
@@ -1269,6 +1273,78 @@ void savesometiles(const char *prompt,int initialval)
 			{
 				al_trace("Saving tiles %d to %d: %d\n", first_tile_id, first_tile_id+(the_tile_count-1));
 				writetilefile(f,first_tile_id,the_tile_count);
+				pack_fclose(f);
+			}
+		}
+	}
+}
+
+
+static DIALOG read_tiles_dlg[] =
+{
+    // (dialog proc)     (x)   (y)   (w)   (h)   (fg)     (bg)    (key)    (flags)     (d1)           (d2)     (dp)
+
+
+	{ jwin_win_proc,      0,   0,   120,  100,  vc(14),  vc(1),  0,       D_EXIT,          0,             0, (void *) "Load Tilepack To:", NULL, NULL },
+    { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
+    //for future tabs
+    { d_dummy_proc,         120,  128,  80+1,   8+1,    vc(14),  vc(1),  0,       0,          1,             0,       NULL, NULL, NULL },
+    { d_dummy_proc,         120,  128,  80+1,   8+1,    vc(14),  vc(1),  0,       0,          1,             0,       NULL, NULL, NULL },
+    //4
+    {  jwin_text_proc,        10,    28,     20,      8,    vc(11),     vc(1),      0,    0,          0,    0, (void *) "Starting at:",               NULL,   NULL  },
+    { jwin_edit_proc,          55,     26,    40,     16,    vc(12),                 vc(1),                   0,       0,          63,    0,  NULL,                                           NULL,   NULL                  },
+    //6
+    {  d_dummy_proc,        10,    46,     20,      8,    vc(11),     vc(1),      0,    0,          0,    0, (void *) "Count",               NULL,   NULL  },
+    { d_dummy_proc,          55,     44,    40,     16,    vc(12),                 vc(1),                   0,       0,          63,    0,  NULL,                                           NULL,   NULL                  },
+    //8
+    { jwin_button_proc,   15,   72,  36,   21,   vc(14),  vc(1),  13,      D_EXIT,     0,             0, (void *) "Load", NULL, NULL },
+    { jwin_button_proc,   69,  72,  36,   21,   vc(14),  vc(1),  27,      D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
+    { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
+};
+
+
+void writesometiles_to(const char *prompt,int initialval)
+{
+	
+	char firsttile[8];;
+	int first_tile_id = 0; int the_tile_count = 1;
+	sprintf(firsttile,"%d",0);
+		//int ret;
+	
+	
+	
+	read_tiles_dlg[0].dp2 = lfont;
+	
+	sprintf(firsttile,"%d",0);
+	//sprintf(tilecount,"%d",1);
+	
+	read_tiles_dlg[5].dp = firsttile;
+	
+	if(is_large)
+		large_dialog(read_tiles_dlg);
+	
+	int ret = zc_popup_dialog(read_tiles_dlg,-1);
+	jwin_center_dialog(read_tiles_dlg);
+	
+	if(ret == 8)
+	{
+		first_tile_id = vbound(atoi(firsttile), 0, NEWMAXTILES);
+		//the_tile_count = vbound(atoi(tilecount), 1, NEWMAXTILES-first_tile_id);
+		if(getname("Load ZTILE(.ztile)", "ztile", NULL,datapath,false))
+		{  
+			PACKFILE *f=pack_fopen_password(temppath,F_READ, "");
+			if(f)
+			{
+				
+				if (!readtilefile_to_location(f,first_tile_id))
+				{
+					al_trace("Could not read from .ztile packfile %s\n", temppath);
+					jwin_alert("ZTILE File: Error","Could not load the specified Tile.",NULL,NULL,"O&K",NULL,'k',0,lfont);
+				}
+				else
+				{
+					jwin_alert("ZTILE File: Success!","Loaded the source tiles to your tile sheets!",NULL,NULL,"O&K",NULL,'k',0,lfont);
+				}
 				pack_fclose(f);
 			}
 		}

--- a/src/zquest.h
+++ b/src/zquest.h
@@ -252,6 +252,7 @@ int d_vsync_proc(int msg,DIALOG *d,int c);
 int d_nbmenu_proc(int msg,DIALOG *d,int c);
 int getnumber(const char *prompt,int initialval);
 int gettilepagenumber(const char *prompt, int initialval);
+void savesometiles(const char *prompt,int initialval);
 int gethexnumber(const char *prompt,int initialval);
 
 void update_combo_cycling();

--- a/src/zquest.h
+++ b/src/zquest.h
@@ -253,6 +253,7 @@ int d_nbmenu_proc(int msg,DIALOG *d,int c);
 int getnumber(const char *prompt,int initialval);
 int gettilepagenumber(const char *prompt, int initialval);
 void savesometiles(const char *prompt,int initialval);
+void writesometiles_to(const char *prompt,int initialval);
 int gethexnumber(const char *prompt,int initialval);
 
 void update_combo_cycling();


### PR DESCRIPTION
Added Export and Import .ZTILE files.
	You can save a series of tiles, in mixed format to a .ZTILE file,
	and load them into any quest, either in the exact position in 
	which they were located in the source quest, or starting at a 
	position that you specify.