### PR TITLE
Added .ZALIAS for Combo Aliases

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,8 +2,13 @@ ChangeLog for 2.53.0
 
 //2.53.1
 
-//Beta 1
+//Beta 2
 
+Added the ability to save and load Combo Alias files in the format
+	of .zalias, with the same GUI options and mechanics as .ZCOMBO and .ZTILE.
+	( ZoriaRPG, 21st October, 2019 )
+
+//Beta 1
 Fix .ZCOMBO Off By One Error and Wrong Version ID
 Fix .ZCOMBO off by 1 error.
 Added .ZCOMBO, identical to .ZTILE

--- a/src/zq_files.cpp
+++ b/src/zq_files.cpp
@@ -1110,6 +1110,46 @@ int onImport_Combopack()
 		return D_O_K;
 }
 
+
+int onExport_Comboaliaspack()
+{
+	savesomecomboaliases("Save Combo Alias Package", 0);
+	return D_O_K;
+	
+}
+
+int onImport_Comboaliaspack_To()
+{
+	writesomecomboaliases_to("Load Combo Alias Package to:", 0);
+	return D_O_K;
+	
+}
+
+int onImport_Comboaliaspack()
+{
+		if(getname("Load ZALIAS(.zalias)", "zalias", NULL,datapath,false))
+		{  
+			PACKFILE *f=pack_fopen_password(temppath,F_READ, "");
+			if(f)
+			{
+				if (!readcomboaliasfile(f))
+				{
+					al_trace("Could not read from .zalias packfile %s\n", temppath);
+					jwin_alert("ZALIAS File: Error","Could not load the specified combo aliases.",NULL,NULL,"O&K",NULL,'k',0,lfont);
+				}
+				else
+				{
+					jwin_alert("ZALIAS File: Success!","Loaded the source combo aliases to your combo alias tables!",NULL,NULL,"O&K",NULL,'k',0,lfont);
+					saved=false;
+				}
+			}
+	
+			pack_fclose(f);
+		}
+		return D_O_K;
+}
+
+
 int onExport_DMaps()
 {
     if(!getname("Export DMaps (.dmp)","dmp",NULL,datapath,false))

--- a/src/zq_files.h
+++ b/src/zq_files.h
@@ -58,6 +58,10 @@ int onExport_Combopack();
 int onImport_Combopack_To();
 int onImport_Combopack();
 
+int onImport_Comboaliaspack();
+int onImport_Comboaliaspack_To();
+int onExport_Comboaliaspack();
+
 int onExport_UnencodedQuest();
 void center_zq_files_dialogs();
 #endif

--- a/src/zq_misc.h
+++ b/src/zq_misc.h
@@ -268,6 +268,10 @@ int onExport_Combopack();
 int onImport_Combopack_To();
 int onImport_Combopack();
 
+int onImport_Comboaliaspack();
+int onImport_Comboaliaspack_To();
+int onExport_Comboaliaspack();
+
 int onGotoMap();
 int onMapCount();
 

--- a/src/zq_tiles.h
+++ b/src/zq_tiles.h
@@ -24,6 +24,11 @@ extern byte cset_reduce_table[PAL_SIZE];
 void calc_cset_reduce_table(PALETTE pal, int cs);
 
 void register_used_tiles();
+
+int readcomboaliasfile(PACKFILE *f);
+int readcomboaliasfile_to_location(PACKFILE *f, int start);
+int writecomboaliasfile(PACKFILE *f, int index, int count);
+
 int readtilefile(PACKFILE *f);
 int writetilefile(PACKFILE *f, int index, int count);
 int readtilefile_to_location(PACKFILE *f, int start);

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -528,9 +528,11 @@ static MENU import_menu[] =
     { (char *)"&Unencoded Quest",           onImport_UnencodedQuest,   NULL,                     0,            NULL   },
     { (char *)"Tile Pack",           	    onImport_Tilepack,   NULL,                     0,            NULL   },
     { (char *)"Combo Pack",           	    onImport_Combopack,   NULL,                     0,            NULL   },
+    { (char *)"Combo Alias Pack",           	    onImport_Comboaliaspack,   NULL,                     0,            NULL   },
     { (char *)"",                           NULL,                      NULL,                     0,            NULL   },
     { (char *)"Tile Pack to...",           	    onImport_Tilepack_To,   NULL,                     0,            NULL   },
     { (char *)"Combo Pack to...",           	    onImport_Combopack_To,   NULL,                     0,            NULL   },
+    { (char *)"Combo Alias Pack to...",           	    onImport_Comboaliaspack_To,   NULL,                     0,            NULL   },
       
     // { (char *)"ZASM to Allegro.log",           onExport_ZASM,   NULL,                     0,            NULL   },
    
@@ -554,6 +556,7 @@ static MENU export_menu[] =
     { (char *)"&Unencoded Quest",           onExport_UnencodedQuest,   NULL,                     0,            NULL   },
     { (char *)"Tile Pack",           	    onExport_Tilepack,   NULL,                     0,            NULL   },
     { (char *)"Combo Pack",           	    onExport_Combopack,   NULL,                     0,            NULL   },
+    { (char *)"Combo Alias Pack",           	    onExport_Comboaliaspack,   NULL,                     0,            NULL   },
     {  NULL,                                NULL,                      NULL,                     0,            NULL   }
 };
 
@@ -1406,8 +1409,8 @@ void savesomecombos(const char *prompt,int initialval)
 	
 	if(ret == 8)
 	{
-		first_tile_id = vbound(atoi(firsttile), 0, NEWMAXTILES);
-		the_tile_count = vbound(atoi(tilecount), 1, NEWMAXTILES-first_tile_id);
+		first_tile_id = vbound(atoi(firsttile), 0, (MAXCOMBOS-1));
+		the_tile_count = vbound(atoi(tilecount), 1, (MAXCOMBOS-1)-first_tile_id);
 		if(getname("Save ZCOMBO(.zcombo)", "zcombo", NULL,datapath,false))
 		{  
 			PACKFILE *f=pack_fopen_password(temppath,F_WRITE, "");
@@ -1470,7 +1473,7 @@ void writesomecombos_to(const char *prompt,int initialval)
 	
 	if(ret == 8)
 	{
-		first_tile_id = vbound(atoi(firsttile), 0, NEWMAXTILES);
+		first_tile_id = vbound(atoi(firsttile), 0, (MAXCOMBOS-1));
 		//the_tile_count = vbound(atoi(tilecount), 1, NEWMAXTILES-first_tile_id);
 		if(getname("Load ZCOMBO(.zcombo)", "zcombo", NULL,datapath,false))
 		{  
@@ -1493,6 +1496,147 @@ void writesomecombos_to(const char *prompt,int initialval)
 		}
 	}
 }
+
+
+
+static DIALOG save_comboaliasfiles_dlg[] =
+{
+    // (dialog proc)     (x)   (y)   (w)   (h)   (fg)     (bg)    (key)    (flags)     (d1)           (d2)     (dp)
+
+
+	{ jwin_win_proc,      0,   0,   120,  100,  vc(14),  vc(1),  0,       D_EXIT,          0,             0, (void *) "Save Combo Pack", NULL, NULL },
+    { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
+    //for future tabs
+    { d_dummy_proc,         120,  128,  80+1,   8+1,    vc(14),  vc(1),  0,       0,          1,             0,       NULL, NULL, NULL },
+    { d_dummy_proc,         120,  128,  80+1,   8+1,    vc(14),  vc(1),  0,       0,          1,             0,       NULL, NULL, NULL },
+    //4
+    {  jwin_text_proc,        10,    28,     20,      8,    vc(11),     vc(1),      0,    0,          0,    0, (void *) "First",               NULL,   NULL  },
+    { jwin_edit_proc,          55,     26,    40,     16,    vc(12),                 vc(1),                   0,       0,          63,    0,  NULL,                                           NULL,   NULL                  },
+    //6
+    {  jwin_text_proc,        10,    46,     20,      8,    vc(11),     vc(1),      0,    0,          0,    0, (void *) "Count",               NULL,   NULL  },
+    { jwin_edit_proc,          55,     44,    40,     16,    vc(12),                 vc(1),                   0,       0,          63,    0,  NULL,                                           NULL,   NULL                  },
+    //8
+    { jwin_button_proc,   15,   72,  36,   21,   vc(14),  vc(1),  13,      D_EXIT,     0,             0, (void *) "Save", NULL, NULL },
+    { jwin_button_proc,   69,  72,  36,   21,   vc(14),  vc(1),  27,      D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
+    { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
+};
+
+
+void savesomecomboaliases(const char *prompt,int initialval)
+{
+	
+	char firsttile[8], tilecount[8];
+	int first_tile_id = 0; int the_tile_count = 1;
+	sprintf(firsttile,"%d",0);
+	sprintf(tilecount,"%d",1);
+	//int ret;
+	
+	
+	
+	save_comboaliasfiles_dlg[0].dp2 = lfont;
+	
+	sprintf(firsttile,"%d",0);
+	sprintf(tilecount,"%d",1);
+	
+	save_comboaliasfiles_dlg[5].dp = firsttile;
+	save_comboaliasfiles_dlg[7].dp = tilecount;
+	
+	if(is_large)
+		large_dialog(save_comboaliasfiles_dlg);
+	
+	int ret = zc_popup_dialog(save_comboaliasfiles_dlg,-1);
+	jwin_center_dialog(save_comboaliasfiles_dlg);
+	
+	if(ret == 8)
+	{
+		first_tile_id = vbound(atoi(firsttile), 0, (MAXCOMBOALIASES-1));
+		the_tile_count = vbound(atoi(tilecount), 1, (MAXCOMBOALIASES-1)-first_tile_id);
+		if(getname("Save ZALIAS(.zalias)", "zalias", NULL,datapath,false))
+		{  
+			PACKFILE *f=pack_fopen_password(temppath,F_WRITE, "");
+			if(f)
+			{
+				al_trace("Saving combo aliasess %d to %d: %d\n", first_tile_id, first_tile_id+(the_tile_count-1));
+				writecomboaliasfile(f,first_tile_id,the_tile_count);
+				pack_fclose(f);
+			}
+		}
+	}
+}
+
+
+static DIALOG read_comboaliaspack_dlg[] =
+{
+    // (dialog proc)     (x)   (y)   (w)   (h)   (fg)     (bg)    (key)    (flags)     (d1)           (d2)     (dp)
+
+
+	{ jwin_win_proc,      0,   0,   120,  100,  vc(14),  vc(1),  0,       D_EXIT,          0,             0, (void *) "Load Combo Pack To:", NULL, NULL },
+    { d_timer_proc,         0,    0,     0,    0,    0,       0,       0,       0,          0,          0,         NULL, NULL, NULL },
+    //for future tabs
+    { d_dummy_proc,         120,  128,  80+1,   8+1,    vc(14),  vc(1),  0,       0,          1,             0,       NULL, NULL, NULL },
+    { d_dummy_proc,         120,  128,  80+1,   8+1,    vc(14),  vc(1),  0,       0,          1,             0,       NULL, NULL, NULL },
+    //4
+    {  jwin_text_proc,        10,    28,     20,      8,    vc(11),     vc(1),      0,    0,          0,    0, (void *) "Starting at:",               NULL,   NULL  },
+    { jwin_edit_proc,          55,     26,    40,     16,    vc(12),                 vc(1),                   0,       0,          63,    0,  NULL,                                           NULL,   NULL                  },
+    //6
+    {  d_dummy_proc,        10,    46,     20,      8,    vc(11),     vc(1),      0,    0,          0,    0, (void *) "Count",               NULL,   NULL  },
+    { d_dummy_proc,          55,     44,    40,     16,    vc(12),                 vc(1),                   0,       0,          63,    0,  NULL,                                           NULL,   NULL                  },
+    //8
+    { jwin_button_proc,   15,   72,  36,   21,   vc(14),  vc(1),  13,      D_EXIT,     0,             0, (void *) "Load", NULL, NULL },
+    { jwin_button_proc,   69,  72,  36,   21,   vc(14),  vc(1),  27,      D_EXIT,     0,             0, (void *) "Cancel", NULL, NULL },
+    { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
+};
+
+
+void writesomecomboaliases_to(const char *prompt,int initialval)
+{
+	
+	char firsttile[8];;
+	int first_tile_id = 0; int the_tile_count = 1;
+	sprintf(firsttile,"%d",0);
+		//int ret;
+	
+	
+	
+	read_comboaliaspack_dlg[0].dp2 = lfont;
+	
+	sprintf(firsttile,"%d",0);
+	//sprintf(tilecount,"%d",1);
+	
+	read_comboaliaspack_dlg[5].dp = firsttile;
+	
+	if(is_large)
+		large_dialog(read_comboaliaspack_dlg);
+	
+	int ret = zc_popup_dialog(read_comboaliaspack_dlg,-1);
+	jwin_center_dialog(read_comboaliaspack_dlg);
+	
+	if(ret == 8)
+	{
+		first_tile_id = vbound(atoi(firsttile), 0, (MAXCOMBOALIASES-1));
+		//the_tile_count = vbound(atoi(tilecount), 1, NEWMAXTILES-first_tile_id);
+		if(getname("Load ZALIAS(.zalias)", "zalias", NULL,datapath,false))
+		{  
+			PACKFILE *f=pack_fopen_password(temppath,F_READ, "");
+			if(f)
+			{
+				
+				if (!readcomboaliasfile_to_location(f,first_tile_id))
+				{
+					al_trace("Could not read from .zcombo packfile %s\n", temppath);
+					jwin_alert("ZALIAS File: Error","Could not load the specified combo aliases.",NULL,NULL,"O&K",NULL,'k',0,lfont);
+				}
+				else
+				{
+					jwin_alert("ZALIAS File: Success!","Loaded the source combos to your combo alias table!",NULL,NULL,"O&K",NULL,'k',0,lfont);
+					saved=false;
+				}
+				pack_fclose(f);
+			}
+		}
+	}
+}
+
 
 int gettilepagenumber(const char *prompt, int initialval)
 {

--- a/src/zquest.h
+++ b/src/zquest.h
@@ -256,6 +256,8 @@ void savesometiles(const char *prompt,int initialval);
 void writesometiles_to(const char *prompt,int initialval);
 void savesomecombos(const char *prompt,int initialval);
 void writesomecombos_to(const char *prompt,int initialval);
+void savesomecomboaliases(const char *prompt,int initialval);
+void writesomecomboaliases_to(const char *prompt,int initialval);
 int gethexnumber(const char *prompt,int initialval);
 
 void update_combo_cycling();


### PR DESCRIPTION
Changelog: Added the ability to save and load Combo Alias files in the format
	of .zalias, with the same GUI options and mechanics as .ZCOMBO and .ZTILE.