### PR TITLE
Refactor: Replaced .dmp with .zdmapset (Beta is now: 5)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,14 @@ ChangeLog for 2.53.0
 //2.53.1
 
 //Beta 5
+
+Refactor: Replaced .dmp with .zdmapset
+	Deprecated the old Export DMaps format (.dmp).
+	The user can still IMPORT that format via Import->2.50.x->DMaps in
+	THIS VERSION only.
+	Added the new .zdmapset format, to replace this feature, which is future-safe
+	for 2.55 and above.
+	( ZoriaRPG, 23rd October, 2019 )
 Pressing F12 now captures screenshots in the Enemy, Item, 
 	and the Weapon Sprite Editors.
 	( ZoriaRPG, 22nd October, 2019 )

--- a/src/metadata/versionsig.h
+++ b/src/metadata/versionsig.h
@@ -13,7 +13,7 @@
 #define V_ZC_FOURTH 0
 //build
 #define V_ZC_ALPHA 0
-#define V_ZC_BETA 4
+#define V_ZC_BETA 5
 #define V_ZC_GAMMA 0
 #define V_ZC_RELEASE 0
 #define V_ZC_YEAR 2019

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -101,7 +101,7 @@
 #define ABOUT_VERSION 0x0253
 #define VERSION_BUILD       33                           //build number of this version
 #define ZELDA_VERSION_STR   "Omnius, 2.53.1"               //version of the program as presented in text
-#define IS_BETA             4                        //is this a beta? (1: beta, -1: alpha)
+#define IS_BETA             5                        //is this a beta? (1: beta, -1: alpha)
 #define DATE_STR            "19th October, 2019, 22:00GMT"
 #define ZELDA_ABOUT_STR 	    "Zelda Classic 'Omnius' v2.53.1"
 #define COPYRIGHT_YEAR      "2019"     

--- a/src/zq_files.cpp
+++ b/src/zq_files.cpp
@@ -989,7 +989,7 @@ int onExport_Map()
     return D_O_K;
 }
 
-int onImport_DMaps()
+int onImport_DMaps_old()
 {
     if(!getname("Import DMaps (.dmp)","dmp",NULL,datapath,false))
         return D_O_K;
@@ -1048,6 +1048,101 @@ int onImport_Tilepack_To()
 	return D_O_K;
 	
 }
+
+int onExport_DMaps()
+{
+
+    
+    
+    if(!getname("Export DMaps(.zdmapset)","zdmapset",NULL,datapath,false))
+        return D_O_K;
+        
+    saved=false;
+    
+    PACKFILE *f=pack_fopen_password(temppath,F_WRITE, "");
+	if(f)
+	{
+		if(!writesomedmaps(f,0,511,MAXDMAPS))
+		{
+			char buf[80],name[13];
+			extract_name(temppath,name,FILENAME8_3);
+			sprintf(buf,"Unable to load %s",name);
+			jwin_alert("Error",buf,NULL,NULL,"O&K",NULL,'k',0,lfont);
+		}
+		else
+		{
+			char tmpbuf[80]={0};
+			sprintf(tmpbuf,"Saved %s",temppath);
+			jwin_alert("Success!",tmpbuf,NULL,NULL,"O&K",NULL,'k',0,lfont);
+		}
+	}
+	pack_fclose(f);
+    
+    return D_O_K;
+}
+
+
+int onImport_DMaps()
+{
+    if(!getname("Import DMaps (.zdmapset)","zdmapset",NULL,datapath,false))
+        return D_O_K;
+    
+    PACKFILE *f=pack_fopen_password(temppath,F_READ, "");
+	if(f)
+	{
+		if(!readsomedmaps(f))
+		{
+			char buf[80],name[13];
+			extract_name(temppath,name,FILENAME8_3);
+			sprintf(buf,"Unable to load %s",name);
+			jwin_alert("Error",buf,NULL,NULL,"O&K",NULL,'k',0,lfont);
+		}
+		else
+		{
+			char tmpbuf[80]={0};
+			sprintf(tmpbuf,"Loaded %s",temppath);
+			
+			
+			
+			
+			int maxMap=0;
+			for(int i=0; i<MAXDMAPS; i++)
+			{
+			    if(DMaps[i].map>maxMap)
+				maxMap=DMaps[i].map;
+			}
+			
+			if(maxMap>map_count)
+			{
+			    int ret=jwin_alert("Not enough maps",
+					       "The imported DMaps use more maps than are",
+					       " currently available. Do you want to add",
+					       "more maps or change the DMaps' settings?",
+					       "&Add maps","&Modify DMaps",'a','m',lfont);
+			    if(ret==1)
+				setMapCount2(maxMap+1);
+			    else
+			    {
+				for(int i=0; i<MAXDMAPS; i++)
+				{
+				    if(DMaps[i].map>=map_count)
+					DMaps[i].map=0;
+				}
+			    }
+			}
+			
+			jwin_alert("Success!",tmpbuf,NULL,NULL,"O&K",NULL,'k',0,lfont);
+		}
+	}
+	pack_fclose(f);
+   
+    saved=false;
+
+    
+    return D_O_K;
+}
+
+
 
 int onImport_Tiles()
 {
@@ -1233,7 +1328,7 @@ int onImport_Comboaliaspack()
 }
 
 
-int onExport_DMaps()
+int onExport_DMaps_old()
 {
     if(!getname("Export DMaps (.dmp)","dmp",NULL,datapath,false))
         return D_O_K;

--- a/src/zq_files.h
+++ b/src/zq_files.h
@@ -34,6 +34,10 @@ int onImport_Map();
 int onExport_Map();
 int onImport_DMaps();
 int onExport_DMaps();
+
+int onImport_DMaps_old();
+int onExport_DMaps_old();
+
 int onImport_Pals();
 int onExport_Pals();
 int onImport_Msgs();

--- a/src/zq_misc.h
+++ b/src/zq_misc.h
@@ -238,6 +238,10 @@ int onColors_Sprites();
 
 int onImport_Map();
 int onImport_DMaps();
+
+int onImport_DMaps_old();
+int onExport_DMaps_old();
+
 int onImport_Msgs();
 int onImport_Combos();
 int onImport_Tiles();

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -516,6 +516,7 @@ static MENU import_250x_files[]=
 {
 	{ (char *)"&Tiles (2.50.x)",                     onImport_Tiles_old,            NULL,                     0,            NULL   },
         { (char *)"&Graphics Pack",             onImport_ZGP,              NULL,                     0,            NULL   },
+        { (char *)"&DMaps",             onImport_DMaps_old,              NULL,                     0,            NULL   },
     
 	//TO-DO: Move old combo and combo alias here
 	// make new comboset and aliasset functions
@@ -538,7 +539,7 @@ static MENU import_250x_files[]=
 static MENU import_menu[] =
 {
     { (char *)"&Map",                       onImport_Map,              NULL,                     0,            NULL   },
-    { (char *)"&DMaps",                     onImport_DMaps,            NULL,                     0,            NULL   },
+    { (char *)"&DMaps Set",                     onImport_DMaps,            NULL,                     0,            NULL   },
     { (char *)"&Tileset",                     onImport_Tiles,            NULL,                     0,            NULL   },
     { (char *)"&Enemies",                   onImport_Guys,             NULL,                     0,            NULL   },
     { (char *)"Su&bscreen",                 onImport_Subscreen,        NULL,                     0,            NULL   },
@@ -14031,6 +14032,437 @@ static DIALOG selectdmap_dlg[] =
 
 static dmap copiedDMap;
 static byte dmapcopied = 0;
+
+int writesomedmaps(PACKFILE *f, int first, int last, int max)
+{
+    
+    dword section_version=V_DMAPS;
+    dword section_cversion=CV_DMAPS;
+	int zversion = ZELDA_VERSION;
+	int zbuild = VERSION_BUILD;
+	
+    
+  
+    //section version info
+	if(!p_iputl(zversion,f))
+	{
+		return 0;
+	}
+	if(!p_iputl(zbuild,f))
+	{
+		return 0;
+	}
+	if(!p_iputw(section_version,f))
+	{
+		new_return(2);
+	}
+    
+	if(!p_iputw(section_cversion,f))
+	{
+		new_return(3);
+	}
+	//max possible at this time
+	if(!p_iputl(max,f))
+	{
+		new_return(4);
+	}
+	//first id written
+	if(!p_iputl(first,f))
+	{
+		new_return(5);
+	}
+	//last id written
+	if(!p_iputl(last,f))
+	{
+		new_return(6);
+	}
+	int count = last-first;
+	//number written
+	if(!p_iputl(count,f))
+	{
+		new_return(7);
+	}
+	
+   
+        for ( int i = first; i <= last; ++i )
+	{
+		if ( i > max ) break;
+	
+            if(!p_putc(DMaps[i].map,f))
+            {
+                new_return(8);
+            }
+            
+            if(!p_iputw(DMaps[i].level,f))
+            {
+                new_return(9);
+            }
+            
+            if(!p_putc(DMaps[i].xoff,f))
+            {
+                new_return(10);
+            }
+            
+            if(!p_putc(DMaps[i].compass,f))
+            {
+                new_return(11);
+            }
+            
+            if(!p_iputw(DMaps[i].color,f))
+            {
+                new_return(12);
+            }
+            
+            if(!p_putc(DMaps[i].midi,f))
+            {
+                new_return(13);
+            }
+            
+            if(!p_putc(DMaps[i].cont,f))
+            {
+                new_return(14);
+            }
+            
+            if(!p_putc(DMaps[i].type,f))
+            {
+                new_return(15);
+            }
+            
+            for(int j=0; j<8; j++)
+            {
+                if(!p_putc(DMaps[i].grid[j],f))
+                {
+                    new_return(16);
+                }
+            }
+            
+            //16
+            if(!pfwrite(&DMaps[i].name,sizeof(DMaps[0].name),f))
+            {
+                new_return(17);
+            }
+            
+            if(!pfwrite(&DMaps[i].title,sizeof(DMaps[0].title),f))
+            {
+                new_return(18);
+            }
+            
+            if(!pfwrite(&DMaps[i].intro,sizeof(DMaps[0].intro),f))
+            {
+                new_return(19);
+            }
+            
+            if(!p_iputl(DMaps[i].minimap_1_tile,f))
+            {
+                new_return(20);
+            }
+            
+            if(!p_putc(DMaps[i].minimap_1_cset,f))
+            {
+                new_return(21);
+            }
+            
+            if(!p_iputl(DMaps[i].minimap_2_tile,f))
+            {
+                new_return(22);
+            }
+            
+            if(!p_putc(DMaps[i].minimap_2_cset,f))
+            {
+                new_return(23);
+            }
+            
+            if(!p_iputl(DMaps[i].largemap_1_tile,f))
+            {
+                new_return(24);
+            }
+            
+            if(!p_putc(DMaps[i].largemap_1_cset,f))
+            {
+                new_return(25);
+            }
+            
+            if(!p_iputl(DMaps[i].largemap_2_tile,f))
+            {
+                new_return(26);
+            }
+            
+            if(!p_putc(DMaps[i].largemap_2_cset,f))
+            {
+                new_return(27);
+            }
+            
+            if(!pfwrite(&DMaps[i].tmusic,sizeof(DMaps[0].tmusic),f))
+            {
+                new_return(28);
+            }
+            
+            if(!p_putc(DMaps[i].tmusictrack,f))
+            {
+                new_return(29);
+            }
+            
+            if(!p_putc(DMaps[i].active_subscreen,f))
+            {
+                new_return(30);
+            }
+            
+            if(!p_putc(DMaps[i].passive_subscreen,f))
+            {
+                new_return(31);
+            }
+            
+            byte disabled[32];
+            memset(disabled,0,32);
+            
+            for(int j=0; j<MAXITEMS; j++)
+            {
+                if(DMaps[i].disableditems[j])
+                {
+                    disabled[j/8] |= (1 << (j%8));
+                }
+            }
+            
+            if(!pfwrite(disabled,32,f))
+            {
+                new_return(32);
+            }
+            
+            if(!p_iputl(DMaps[i].flags,f))
+            {
+                new_return(33);
+            }
+	}
+
+	return 1;
+}
+
+
+int readsomedmaps(PACKFILE *f)
+{
+	dword section_version = 0;
+	dword section_cversion = 0;
+	int zversion = 0;
+	int zbuild = 0;
+	dmap tempdmap;
+	memset(&tempdmap, 0, sizeof(dmap));
+	
+	int first = 0, last = 0, max = 0, count = 0;
+   
+	//char dmapstring[64]={0};
+	//section version info
+	if(!p_igetl(&zversion,f,true))
+	{
+		return 0;
+	}
+	if(!p_igetl(&zbuild,f,true))
+	{
+		return 0;
+	}
+	
+	if(!p_igetw(&section_version,f,true))
+	{
+		return 0;
+	}
+    
+	if(!p_igetw(&section_cversion,f,true))
+	{
+		return 0;
+	}
+	
+	if(!p_igetl(&max,f,true))
+	{
+		return 0;
+	}
+	if(!p_igetl(&first,f,true))
+	{
+		return 0;
+	}
+	if(!p_igetl(&last,f,true))
+	{
+		return 0;
+	}
+	if(!p_igetl(&count,f,true))
+	{
+		return 0;
+	}
+	
+	
+	
+	
+	al_trace("readsomedmaps section_version: %d\n", section_version);
+	al_trace("readsomedmaps section_cversion: %d\n", section_cversion);
+    
+	if ( zversion > ZELDA_VERSION )
+	{
+		al_trace("Cannot read .zdmap packfile made in ZC version (%x) in this version of ZC (%x)\n", zversion, ZELDA_VERSION);
+		return 0;
+	}
+	else if (( section_version > V_DMAPS ) || ( section_version == V_DMAPS && section_cversion > CV_DMAPS ) ) 
+	{
+		al_trace("Cannot read .zdmap packfile made using V_DMAPS (%d) subversion (%d)\n", section_version, section_cversion);
+		return 0;
+	}
+	else
+	{
+		al_trace("Reading a .zdmap packfile made in ZC Version: %x, Build: %d\n", zversion, zbuild);
+	}
+	//if(!pfread(&dmapstring, 64, f,true))
+	//{
+	//	return 0;
+	//}
+    
+    
+   
+		for ( int i = first; i <= last; ++i )
+		{
+		    if(!p_getc(&tempdmap.map,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_igetw(&tempdmap.level,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_getc(&tempdmap.xoff,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_getc(&tempdmap.compass,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_igetw(&tempdmap.color,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_getc(&tempdmap.midi,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_getc(&tempdmap.cont,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_getc(&tempdmap.type,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    for(int j=0; j<8; j++)
+		    {
+			if(!p_getc(&tempdmap.grid[j],f,true))
+			{
+			    return 0;
+			}
+		    }
+		    
+		    //16
+		    if(!pfread(&tempdmap.name,sizeof(DMaps[0].name),f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!pfread(&tempdmap.title,sizeof(DMaps[0].title),f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!pfread(&tempdmap.intro,sizeof(DMaps[0].intro),f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_igetl(&tempdmap.minimap_1_tile,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_getc(&tempdmap.minimap_1_cset,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_igetl(&tempdmap.minimap_2_tile,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_getc(&tempdmap.minimap_2_cset,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_igetl(&tempdmap.largemap_1_tile,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_getc(&tempdmap.largemap_1_cset,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_igetl(&tempdmap.largemap_2_tile,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_getc(&tempdmap.largemap_2_cset,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!pfread(&tempdmap.tmusic,sizeof(DMaps[0].tmusic),f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_getc(&tempdmap.tmusictrack,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_getc(&tempdmap.active_subscreen,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    if(!p_getc(&tempdmap.passive_subscreen,f,true))
+		    {
+			return 0;
+		    }
+		    
+		    byte disabled[32];
+		    memset(disabled,0,32);
+		    
+		    if(!pfread(&disabled, 32, f, true)) return 0;
+		    
+		    for(int j=0; j<MAXITEMS; j++)
+		    {
+			if(disabled[j/8] & (1 << (j%8))) tempdmap.disableditems[j]=1;
+			else tempdmap.disableditems[j]=0;
+		    }
+		    
+		    
+		    if(!p_igetl(&tempdmap.flags,f,true))
+		    {
+			return 0;
+		    }
+		::memcpy(&DMaps[i], &tempdmap, sizeof(dmap));
+	    }
+       
+	return 1;
+}
+
+
 
 int writeonedmap(PACKFILE *f, int i)
 {

--- a/src/zquest.h
+++ b/src/zquest.h
@@ -1007,6 +1007,11 @@ int onInit();
 int onItemProps();
 int onSubscreen();
 
+int writeonedmap(PACKFILE *f, int i);
+int readonedmap(PACKFILE *f, int index);
+int writesomedmaps(PACKFILE *f, int first, int last, int max);
+int readsomedmaps(PACKFILE *f);
+
 void get_cset(int dataset,int row,RGB *pal);
 void draw_edit_dataset_specs(int index,int copy);
 void init_colormixer();


### PR DESCRIPTION
Changelog: Deprecated the old Export DMaps format (.dmp).
	The user can still IMPORT that format via Import->2.50.x->DMaps in
	THIS VERSION only.
	Added the new .zdmapset format, to replace this feature, which is future-safe
	for 2.55 and above.