### PR TITLE
Feat: Load Sprite Objects by Script UID

### DIFF
--- a/src/ffasm.cpp
+++ b/src/ffasm.cpp
@@ -908,7 +908,9 @@ script_command command_list[NUMCOMMANDS+1]=
     { "CLOSEWIPESHAPE",                1,   0,   0,   0},
     { "FILEEXISTS",                1,   0,   0,   0},
     { "BITMAPCLEARTOCOLOR",                0,   0,   0,   0},
-	
+	{ "LOADNPCBYSUID",        1,   0,   0,   0},
+	{ "LOADLWEAPONBYSUID",        1,   0,   0,   0},
+	{ "LOADWEAPONCBYSUID",        1,   0,   0,   0},
 //	{ "GETCONFIGINT",                2,   0,   0,   0},
 //	{ "SETCONFIGINT",                2,   0,   0,   0},
     { "",                    0,   0,   0,   0}

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -4973,6 +4973,12 @@ case NPCBEHAVIOUR: {
             
         break;
 	
+	case EWPNPARENTUID:
+        if(0!=(s=checkEWpn(ri->ewpn, "ScriptUID")))
+            ret=(((weapon*)(s))->parent_script_UID); //literal, not *10000
+            
+        break;
+	
 	case EWPNSCRIPT:
         if(0!=(s=checkEWpn(ri->ewpn,"Script")))
             ret=(((weapon*)(s))->weaponscript)*10000;
@@ -20091,6 +20097,18 @@ int run_script(const byte type, const word script, const long i)
 		    do_loaditemdata(true);
 		    break;
 		    
+		case LOADNPCBYSUID:
+		    FFCore.do_loadnpc_by_script_uid(false);
+		    break;
+		
+		case LOADLWEAPONBYSUID:
+		    FFCore.do_loadlweapon_by_script_uid(false);
+		    break;
+		
+		case LOADWEAPONCBYSUID:
+		    FFCore.do_loadeweapon_by_script_uid(false);
+		    break;
+		
 		case LOADNPCR:
 		    do_loadnpc(false);
 		    break;
@@ -33301,3 +33319,73 @@ defWpnSprite FFScript::getDefWeaponSprite(int wpnid)
 	}
 };
 
+
+int FFScript::getEnemyByScriptUID(int sUID)
+{
+	
+	for(word i = 0; i < guys.Count(); i++)
+        {
+            enemy *w = (enemy*)guys.spr(i);
+            if ( w ->script_UID == sUID ) return i;
+        }
+	return -1;
+}
+
+int FFScript::getLWeaponByScriptUID(int sUID)
+{
+	
+	for(word i = 0; i < guys.Count(); i++)
+        {
+            weapon *w = (weapon*)Lwpns.spr(i);
+            if ( w ->script_UID == sUID ) return i;
+        }
+	return -1;
+}
+
+int FFScript::getEWeaponByScriptUID(int sUID)
+{
+	
+	for(word i = 0; i < guys.Count(); i++)
+        {
+            weapon *w = (weapon*)Ewpns.spr(i);
+            if ( w ->script_UID == sUID ) return i;
+        }
+	return -1;
+}
+
+
+void FFScript::do_loadlweapon_by_script_uid(const bool v)
+{
+	long sUID = SH::get_arg(sarg1, v) / 10000;
+
+	int indx = FFCore.getLWeaponByScriptUID(sUID);
+	if ( indx > -1 ) 
+		ri->lwpn = Lwpns.spr(indx)->getUID();
+	else
+		Z_scripterrlog("There is no valid LWeapon associated with UID (%) at this time.\nThe UID is stale, or invalid.\n", sUID);
+}
+
+void FFScript::do_loadeweapon_by_script_uid(const bool v)
+{
+	
+	long sUID = SH::get_arg(sarg1, v) / 10000;
+
+	int indx = FFCore.getEWeaponByScriptUID(sUID);
+	if ( indx > -1 ) 
+		ri->ewpn = Lwpns.spr(indx)->getUID();
+	else
+		Z_scripterrlog("There is no valid EWeapon associated with UID (%) at this time.\nThe UID is stale, or invalid.\n", sUID);
+}
+
+
+void FFScript::do_loadnpc_by_script_uid(const bool v)
+{
+	
+	long sUID = SH::get_arg(sarg1, v) / 10000;
+
+	int indx = FFCore.getEnemyByScriptUID(sUID);
+	if ( indx > -1 ) 
+		ri->guyref = guys.spr(indx)->getUID();
+	else
+		Z_scripterrlog("There is no valid NPC associated with UID (%) at this time.\nThe UID is stale, or invalid.\n", sUID);
+}

--- a/src/ffscript.h
+++ b/src/ffscript.h
@@ -506,6 +506,10 @@ void do_loaditem_by_script_uid(const bool v);
 void do_loadlweapon_by_script_uid(const bool v);
 void do_loadeweapon_by_script_uid(const bool v);
 
+int getEnemyByScriptUID(int sUID);
+int getLWeaponByScriptUID(int sUID);
+int getEWeaponByScriptUID(int sUID);
+
 //new npc functions for npc scripts
 void do_isdeadnpc();
 void do_canslidenpc();
@@ -2400,6 +2404,9 @@ enum ASM_DEFINE
 	CLOSEWIPESHAPE,
 	FILEEXISTS,
 	BITMAPCLEARTOCOLOR,
+	LOADNPCBYSUID,
+	LOADLWEAPONBYSUID,
+	LOADWEAPONCBYSUID,
 
 
 	NUMCOMMANDS           //0x0168
@@ -3642,11 +3649,12 @@ enum ASM_DEFINE
 #define MAPDATASWARPRETSQR		0x1378
 #define DMAPDATAID		0x1379
 #define NPCSUBMERGED		0x137A
+#define EWPNPARENTUID		0x137B
 //#define DMAPDATAGRAVITY 	//unimplemented
 //#define DMAPDATAJUMPLAYER 	//unimplemented
 //end vars
 
-#define NUMVARIABLES         	0x137B
+#define NUMVARIABLES         	0x137C
 
 // Script types
 

--- a/src/parser/ByteCode.cpp
+++ b/src/parser/ByteCode.cpp
@@ -1776,6 +1776,7 @@ string ZScript::VarToString(long ID)
 	case MAPDATATWARPRETSQR: return "MAPDATATWARPRETSQR";
 	case MAPDATASWARPRETSQR: return "MAPDATASWARPRETSQR";
 	case NPCSUBMERGED: return "NPCSUBMERGED";
+	case EWPNPARENTUID: return "EWPNPARENTUID";
 	
 	
 	default:
@@ -2486,6 +2487,7 @@ string OLoadNPCRegister::toString()
 {
     return "LOADNPCR " + getArgument()->toString();
 }
+
 
 string OLoadLWpnRegister::toString()
 {
@@ -4932,7 +4934,18 @@ string OGETDMAPBYNAME::toString()
     return "GETDMAPBYNAME " + getArgument()->toString();
 }
 
-
+string OLoadNPCBySUIDRegister::toString()
+{
+    return "LOADNPCBYSUID " + getArgument()->toString();
+}
+string OLoadLWeaponBySUIDRegister::toString()
+{
+    return "LOADLWEAPONBYSUID " + getArgument()->toString();
+}
+string OLoadEWeaponBySUIDRegister::toString()
+{
+    return "LOADWEAPONCBYSUID " + getArgument()->toString();
+}
 
 string OReturn::toString()
 {

--- a/src/parser/ByteCode.h
+++ b/src/parser/ByteCode.h
@@ -1159,6 +1159,7 @@
 #define MAPDATASWARPRETSQR		1088
 #define DMAPDATAID		1089
 #define NPCSUBMERGED		1090
+#define EWPNPARENTUID		1091
 
 #define LAST_BYTECODE 		1091
 
@@ -8404,6 +8405,39 @@ namespace ZScript
 		Opcode *clone()
 		{
 			return new OGETDMAPBYNAME(a->clone());
+		}
+	};
+	
+	class OLoadNPCBySUIDRegister : public UnaryOpcode
+	{
+	public:
+		OLoadNPCBySUIDRegister(Argument *A) : UnaryOpcode(A) {}
+		std::string toString();
+		Opcode *clone()
+		{
+			return new OLoadNPCBySUIDRegister(a->clone());
+		}
+	};
+	
+	class OLoadLWeaponBySUIDRegister : public UnaryOpcode
+	{
+	public:
+		OLoadLWeaponBySUIDRegister(Argument *A) : UnaryOpcode(A) {}
+		std::string toString();
+		Opcode *clone()
+		{
+			return new OLoadLWeaponBySUIDRegister(a->clone());
+		}
+	};
+	
+	class OLoadEWeaponBySUIDRegister : public UnaryOpcode
+	{
+	public:
+		OLoadEWeaponBySUIDRegister(Argument *A) : UnaryOpcode(A) {}
+		std::string toString();
+		Opcode *clone()
+		{
+			return new OLoadEWeaponBySUIDRegister(a->clone());
 		}
 	};
 	

--- a/src/parser/GlobalSymbols.cpp
+++ b/src/parser/GlobalSymbols.cpp
@@ -2569,6 +2569,12 @@ static AccessorTable ScreenTable[] =
 	{ "getInitD[]",            	  ZVARTYPEID_UNTYPED,       GETTER,       SCREENINITD,                       8,           0,                                    2,           {  ZVARTYPEID_SCREEN,          ZVARTYPEID_FLOAT,                               -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
 	{ "setInitD[]",            	  ZVARTYPEID_VOID,          SETTER,       SCREENINITD,                       8,           0,                                    3,           {  ZVARTYPEID_SCREEN,          ZVARTYPEID_FLOAT,                               ZVARTYPEID_UNTYPED,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
 	
+	{ "LoadNPCByUID",                      ZVARTYPEID_NPC,           FUNCTION,     0,                                1,            0,                                    2,           {  ZVARTYPEID_SCREEN,        ZVARTYPEID_FLOAT,        -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
+	{ "LoadLWeaponByUID",                      ZVARTYPEID_LWPN,           FUNCTION,     0,                                1,            0,                                    2,           {  ZVARTYPEID_SCREEN,        ZVARTYPEID_FLOAT,        -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
+	{ "LoadEWeaponByUID",                      ZVARTYPEID_EWPN,           FUNCTION,     0,                                1,            0,                                    2,           {  ZVARTYPEID_SCREEN,        ZVARTYPEID_FLOAT,        -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
+	
+	
+	
 	{ "",                             -1,                       -1,           -1,                               -1,           0,                                    0,           { -1,                                -1,                              -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } }
 };
 
@@ -2734,6 +2740,57 @@ void ScreenSymbols::generateCode()
         //convert from 1-index to 0-index
         code.push_back(new OSubImmediate(new VarArgument(EXP1), new LiteralArgument(10000)));
         code.push_back(new OLoadEWpnRegister(new VarArgument(EXP1)));
+        code.push_back(new OSetRegister(new VarArgument(EXP1), new VarArgument(REFEWPN)));
+        code.push_back(new OReturn());
+        function->giveCode(code);
+    }
+    //npc LoadNPCByUID(screen, int)
+    {
+	    Function* function = getFunction("LoadNPCByUID", 2);
+        int label = function->getLabel();
+        vector<Opcode *> code;
+        //pop off the param
+        Opcode *first = new OPopRegister(new VarArgument(EXP1));
+        first->setLabel(label);
+        code.push_back(first);
+        //pop pointer, and ignore it
+        code.push_back(new OPopRegister(new VarArgument(NUL)));
+        
+        code.push_back(new OLoadNPCBySUIDRegister(new VarArgument(EXP1)));
+        code.push_back(new OSetRegister(new VarArgument(EXP1), new VarArgument(REFNPC)));
+        code.push_back(new OReturn());
+        function->giveCode(code);
+    }
+    
+     //npc LoadLWeaponByUID(screen, int)
+    {
+	    Function* function = getFunction("LoadLWeaponByUID", 2);
+        int label = function->getLabel();
+        vector<Opcode *> code;
+        //pop off the param
+        Opcode *first = new OPopRegister(new VarArgument(EXP1));
+        first->setLabel(label);
+        code.push_back(first);
+        //pop pointer, and ignore it
+        code.push_back(new OPopRegister(new VarArgument(NUL)));
+        code.push_back(new OLoadLWeaponBySUIDRegister(new VarArgument(EXP1)));
+        code.push_back(new OSetRegister(new VarArgument(EXP1), new VarArgument(REFLWPN)));
+        code.push_back(new OReturn());
+        function->giveCode(code);
+    }
+    
+    //ewpn LoadEWeaponByUID(screen, int)
+    {
+	    Function* function = getFunction("LoadEWeaponByUID", 2);
+        int label = function->getLabel();
+        vector<Opcode *> code;
+        //pop off the param
+        Opcode *first = new OPopRegister(new VarArgument(EXP1));
+        first->setLabel(label);
+        code.push_back(first);
+        //pop pointer, and ignore it
+        code.push_back(new OPopRegister(new VarArgument(NUL)));
+        code.push_back(new OLoadEWeaponBySUIDRegister(new VarArgument(EXP1)));
         code.push_back(new OSetRegister(new VarArgument(EXP1), new VarArgument(REFEWPN)));
         code.push_back(new OReturn());
         function->giveCode(code);
@@ -7203,6 +7260,7 @@ static AccessorTable ewpnTable[] =
 	{ "getAnimation",           ZVARTYPEID_FLOAT,         GETTER,       EWPNENGINEANIMATE,    1,             0,                                    1,           {  ZVARTYPEID_EWPN,         -1,                               -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
 	{ "setAnimation",           ZVARTYPEID_VOID,          SETTER,       EWPNENGINEANIMATE,    1,             0,                                    2,           {  ZVARTYPEID_EWPN,          ZVARTYPEID_BOOL,         -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
 	{ "getUID",                 ZVARTYPEID_FLOAT,         GETTER,       EWEAPONSCRIPTUID,     1,             0,                                    1,           {  ZVARTYPEID_EWPN,         -1,                               -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
+	{ "getParentUID",                 ZVARTYPEID_FLOAT,         GETTER,       EWPNPARENTUID,     1,             0,                                    1,           {  ZVARTYPEID_EWPN,         -1,                               -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
 	{ "getScript",              ZVARTYPEID_FLOAT,         GETTER,       EWPNSCRIPT,           1,             0,                                    1,           {  ZVARTYPEID_EWPN,         -1,                               -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
 	{ "setScript",              ZVARTYPEID_VOID,          SETTER,       EWPNSCRIPT,           1,             0,                                    2,           {  ZVARTYPEID_EWPN,          ZVARTYPEID_FLOAT,        -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
 	{ "getInitD[]",             ZVARTYPEID_UNTYPED,       GETTER,       EWPNINITD,            8,             0,                                    2,           {  ZVARTYPEID_EWPN,          ZVARTYPEID_FLOAT,        -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -267,6 +267,7 @@ weapon::weapon(weapon const & other):
 		enemy *s = (enemy *)guys.getByUID(parentid);
 	
 		weaponscript = guysbuf[s->id & 0xFFF].weaponscript;
+		parent_script_UID = s->script_UID;
 		for ( int q = 0; q < INITIAL_D; q++ ) 
 		{
 			//Z_scripterrlog("(weapon::weapon(weapon const & other)): Loading Initd[%d] for this eweapon script with a value of (%d).\n", q, guysbuf[parentid].weap_initiald[q]); 
@@ -470,6 +471,7 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
 	//Z_scripterrlog("The enemy ID that created it was: %d\n",s->id & 0xFFF);
 	//weaponscript = guysbuf[prntid].weaponscript;
 	weaponscript = guysbuf[s->id & 0xFFF].weaponscript;
+	parent_script_UID = s->script_UID;
 	for ( int q = 0; q < 8; q++ )
 	{
 		//load InitD
@@ -501,6 +503,7 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
     isLit = false;
 	linkedItem = 0;
 	script_UID = FFCore.GetScriptObjectUID(UID_TYPE_WEAPON); 
+        parent_script_UID = 0;
 	ScriptGenerated = script_gen; //t/b/a for script generated swords and other LinkCLass items. 
 		//This will need an input in the params! -Z
 		
@@ -2154,6 +2157,11 @@ weapon::weapon(fix X,fix Y,fix Z,int Id,int Type,int pow,int Dir, int Parentitem
 
 int weapon::getScriptUID() { return script_UID; }
 void weapon::setScriptUID(int new_id) { script_UID = new_id; }
+
+int weapon::getParentScriptUID() { return parent_script_UID; }
+void weapon::setParentScriptUID(int new_id) { parent_script_UID = new_id; }
+
+
 bool weapon::isLinkWeapon()
 {
 	if ( isLWeapon > 0 ) return true;

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -82,8 +82,11 @@ public:
     //! End weapon editor. -Z
     
     int script_UID;
+    int parent_script_UID;
     int getScriptUID();
+    int getParentScriptUID();
     void setScriptUID(int new_id);
+    void setParentScriptUID(int new_id);
     bool isLinkWeapon();
     bool isLinkMelee();
     //2.6 ZScript -Z


### PR DESCRIPTION
Changelog: Added parent_script_UID to weapons (weapon class)
	Set this on creation of eweapon.
	Added accessors for getting an npc, lweapon, or an
	eweapon by script_UID.
	Added the following to ZScript:
	Screen->LoadNPCByUID(int UID);
	Screen->LoadLWeaponByUID(int UID);
	Screen->LoadEWeaponByUID(int UID);
	eweapon->ParentUID