### PR TITLE
Feat: 'npc->Remove()' instantly deletes

### DIFF
--- a/output/common/ZScript_Additions.txt
+++ b/output/common/ZScript_Additions.txt
@@ -2854,7 +2854,9 @@ bool Knockback(int time, int dir, int speed);
  *     'bool npc->NoKnockback;' was set true for this enemy
 
 void Remove(); 
- * Instantly kills an npc
+ * Instantly DELETES an npc. No items will be dropped, no sound will play; the npc is simply DELETED OUTRIGHT.
+ * This will immediately invalidate the npc pointer, as well as update 'Screen->NumNPCs()', and change the indexes for 'Screen->LoadNPC()'
+ * If called from an NPC script on the NPC running the script, immediately terminates the script.
 
 void StopBGSFX();
  * Stops the background sounds that the npc is generating.

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -18912,7 +18912,7 @@ void do_combotile(const bool v)
 int run_script(const byte type, const word script, const long i)
 {
 	if(Quit==qRESET || Quit==qEXIT) // In case an earlier script hung
-		return 1;
+		return RUNSCRIPT_ERROR;
 	
 	curScriptType=type;
 	curScriptNum=script;
@@ -19177,7 +19177,7 @@ int run_script(const byte type, const word script, const long i)
 		default:
 		{
 			al_trace("No other scripts are currently supported\n");
-			return 1;
+			return RUNSCRIPT_ERROR;
 		}
 	}
 	
@@ -20474,7 +20474,7 @@ int run_script(const byte type, const word script, const long i)
 				if(BC::checkMapID(map, "Game->SetScreenEnemy(...map...)") != SH::_NoError ||
 					BC::checkBounds(scrn, 0, 0x87, "Game->SetScreenEnemy(...screen...)") != SH::_NoError ||
 					BC::checkBounds(index, 0, 9, "Game->SetScreenEnemy(...index...)") != SH::_NoError)
-					return -10000;
+					return RUNSCRIPT_ERROR;
 				
 			//	if ( BC::checkBounds(nn, 0, 2, "Game->SetScreenEnemy(...enemy...)") != SH::_NoError) x = 1;
 			//	if ( BC::checkBounds(map, 20, 21, "Game->SetScreenEnemy(...map...)") != SH::_NoError) x = 2;
@@ -20496,7 +20496,7 @@ int run_script(const byte type, const word script, const long i)
 					BC::checkBounds(scrn, 0, 0x87, "Game->SetScreenDoor(...screen...)") != SH::_NoError ||
 					BC::checkBounds(index, 0, 3, "Game->SetScreenDoor(...doorindex...)") != SH::_NoError)
 				{
-					return -10000; break;
+					return RUNSCRIPT_ERROR; break;
 				}
 				else
 				{
@@ -21332,8 +21332,13 @@ int run_script(const byte type, const word script, const long i)
 		    break;
 		
 		case NPCKICKBUCKET:
-		    FFCore.do_npckickbucket();
-		    break;
+			if(type == SCRIPT_NPC && ri->guyref == i)
+			{
+				FFCore.do_npckickbucket();
+				return RUNSCRIPT_SELFDELETE;
+			}
+			FFCore.do_npckickbucket();
+			break;
 		
 		case NPCSTOPBGSFX:
 		    FFCore.do_npc_stopbgsfx();
@@ -21699,7 +21704,7 @@ int run_script(const byte type, const word script, const long i)
         pc++;
         
     ri->pc = pc; //Put it back where we got it from
-    
+	
 #ifdef _SCRIPT_COUNTER
     
     for(int j = 0; j < NUMCOMMANDS; j++)
@@ -21713,7 +21718,7 @@ int run_script(const byte type, const word script, const long i)
 #endif
     
     
-    return 0;
+    return RUNSCRIPT_OK;
 }
 
 //This keeps ffc scripts running beyond the first frame. 
@@ -25926,7 +25931,8 @@ void FFScript::do_npckickbucket()
 	{
 		//enemy *e = (enemy*)guys.spr(GuyH::getNPCIndex(ri->guyref));
 		//e->kickbucket();
-		GuyH::getNPC()->kickbucket();
+		//GuyH::getNPC()->kickbucket();
+		guys.del(GuyH::getNPCIndex(ri->guyref));
 	}
 	//else Z_scripterrlog
 }

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -21332,6 +21332,7 @@ int run_script(const byte type, const word script, const long i)
 		    break;
 		
 		case NPCKICKBUCKET:
+			FFScript::deallocateAllArrays(SCRIPT_NPC, ri->guyref);
 			if(type == SCRIPT_NPC && ri->guyref == i)
 			{
 				FFCore.do_npckickbucket();

--- a/src/guys.cpp
+++ b/src/guys.cpp
@@ -655,11 +655,17 @@ bool enemy::animate(int index)
     
     ++c_clk;
     
-    //Run its script
-    if ( script > 0 && doscript ) 
-    {
-	if ( FFCore.getQuestHeaderInfo(vZelda) >= 0x255 && !(FFCore.system_suspend[susptNPCSCRIPTS])  ) ZScriptVersion::RunScript(SCRIPT_NPC, script, getUID());
-    }
+	//Run its script
+	if ( script > 0 && doscript ) 
+	{
+		if ( FFCore.getQuestHeaderInfo(vZelda) >= 0x255 && !(FFCore.system_suspend[susptNPCSCRIPTS])  )
+		{
+			if(ZScriptVersion::RunScript(SCRIPT_NPC, script, getUID())==RUNSCRIPT_SELFDELETE)
+			{
+				return 0; //Avoid NULLPO if this object deleted itself
+			}
+		}
+	}
     
     // returns true when enemy is defeated
     return Dead(index);

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -2176,7 +2176,7 @@ void sprite::drawshadow(BITMAP* dest,bool translucent)
 
 //class enemy;
 
-sprite_list::sprite_list() : count(0) {}
+sprite_list::sprite_list() : count(0), active_iterator(0) {}
 void sprite_list::clear()
 {
     while(count>0) del(0);

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -2320,6 +2320,7 @@ bool sprite_list::del(int j)
     }
     
     --count;
+	if(j<=active_iterator) --active_iterator;
     //checkConsistency();
     return true;
 }
@@ -2403,21 +2404,21 @@ void sprite_list::drawcloaked2(BITMAP* dest,bool lowfirst)
 
 void sprite_list::animate()
 {
-    int i=0;
+    active_iterator = 0;
     
-    while(i<count)
+    while(active_iterator<count)
     {
-        if(!(freeze_guys && sprites[i]->canfreeze))
+        if(!(freeze_guys && sprites[active_iterator]->canfreeze))
         {
-            if(sprites[i]->animate(i))
+            if(sprites[active_iterator]->animate(active_iterator))
             {
-                del(i);
-                --i;
+                del(active_iterator);
             }
         }
         
-        ++i;
+        ++active_iterator;
     }
+	active_iterator = -1;
 }
 
 void sprite_list::check_conveyor()

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -169,6 +169,7 @@ class sprite_list
 {
     sprite *sprites[SLMAX];
     int count;
+	int active_iterator;
     map<long, int> containedUIDs;
     // Cache requests from scripts
     mutable long lastUIDRequested;

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -4284,4 +4284,8 @@ extern void removeFromItemCache(int itemid);
 #define LF_PAID_WAND_COST		0x02
 #define LF_PAID_CBYRNA_COST		0x04
 
+#define RUNSCRIPT_OK			0
+#define RUNSCRIPT_ERROR			1
+#define RUNSCRIPT_SELFDELETE	2
+
 #endif                                                      //_ZDEFS_H_


### PR DESCRIPTION
Standardized runscript return values via defines
Added 'active_iterator' as a member of sprite_list
	This is automatically modified by del() if it is called while the list is
	being animated, used instead of a local 'i' variable
Added handling for a script object deleting itself, via returning
	RUNSCRIPT_SELFDELETE; this handles returning to avoid NULLPOs
Updated ZScript_Additions.txt