### PR TITLE
Feat: ZASM breakpoints

### DIFF
--- a/output/common/ZScript_Additions.txt
+++ b/output/common/ZScript_Additions.txt
@@ -5164,6 +5164,18 @@ lweapon l = Screen->LoadLWeapon(16);
 l->Dir = DIR_UP;
 l = NULL(); // Clear the pointer to NULL.
 
+void Breakpoint(char[] string);
+ * If the ZASM debugger is open, this will break execution, and print the given string.
+ * Break controls:
+ *     'Insert' - break, or step forward if broken
+ *     'Shift+Insert' - Step forward until next breakpoint, or start of next script, whichever comes first
+ *     'Alt+Insert' - Step forward until next breakpoint
+ *     'Ctrl+Insert' - Exit the ZASM debugger entirely
+ * If the ZASM debugger is not open, this instruction does NOTHING.
+ * Passing NULL to this function will not produce an error, instead printing no label
+ * In ZASM scripts, passing the 'NUL' register to this instruction will not produce an error, instead printing no label
+
+
 float D[256];
  * This is the value of the ri->d[] registers. 
  * These vary depending on the function, or the instruction.

--- a/src/ffasm.cpp
+++ b/src/ffasm.cpp
@@ -916,6 +916,7 @@ script_command command_list[NUMCOMMANDS+1]=
     { "LOADSCROLLSCR",             1,   0,   0,   0},
     { "MAPDATAISSOLIDLYR",             1,   0,   0,   0},
     { "ISSOLIDLAYER",             1,   0,   0,   0},
+    { "BREAKPOINT",             1,   0,   0,   0},
 //	{ "GETCONFIGINT",                2,   0,   0,   0},
 //	{ "SETCONFIGINT",                2,   0,   0,   0},
     { "",                    0,   0,   0,   0}

--- a/src/ffscript.h
+++ b/src/ffscript.h
@@ -71,7 +71,12 @@ enum linkspritetype { LSprwalkspr, LSprstabspr, LSprslashspr, LSprfloatspr,
 LSprjumpspr, LSprchargespr, LSprcastingspr, 
 	LSprholdspr1, LSprholdspr2, LSprholdsprw1, LSprholdsprw2, LSprlast };
 
-	
+enum zasmBreak
+{
+	ZASM_BREAK_NONE,
+	ZASM_BREAK_HALT,
+	ZASM_BREAK_ADVANCE_SCRIPT
+};
 
 //suspend types
 enum { 
@@ -358,13 +363,14 @@ void do_xtoa();
 
 void do_tracebool(const bool v);
 void do_tracestring();
+void do_breakpoint();
 void do_trace(bool v);
 void do_tracenl();
 void do_cleartrace();
 bool print_ZASM;
 void do_tracetobase();
 void ZScriptConsole(bool open);
-void TraceScriptIDs();
+void TraceScriptIDs(bool zasm_console = false);
 void ZScriptConsolePrint(int colourformat, const char * const format,...);
 void ZASMPrint(bool open);
 void ZASMPrintCommand(const word scommand);
@@ -459,6 +465,8 @@ byte FF_msg_speed;
 byte FF_transition_type; // Can't edit, yet.
 byte FF_jump_link_layer_threshold; // Link is drawn above layer 3 if z > this.
 byte FF_link_swim_speed;
+
+byte zasm_break_mode;
 
 //Enemy removal bounds
 int enemy_removal_point[6];
@@ -2425,9 +2433,10 @@ enum ASM_DEFINE
     LOADSCROLLSCR,
     MAPDATAISSOLIDLYR,
     ISSOLIDLAYER,
+	BREAKPOINT,
 
 
-	NUMCOMMANDS           //0x016D
+	NUMCOMMANDS           //0x016E
 };
 
 

--- a/src/parser/ByteCode.cpp
+++ b/src/parser/ByteCode.cpp
@@ -2326,6 +2326,11 @@ string OTrace6Register::toString()
     return "TRACE6 " + getArgument()->toString();
 }
 
+string OBreakpoint::toString()
+{
+    return "BREAKPOINT " + getArgument()->toString();
+}
+
 
 string ORandRegister::toString()
 {

--- a/src/parser/ByteCode.h
+++ b/src/parser/ByteCode.h
@@ -1813,6 +1813,17 @@ namespace ZScript
 		}
 	};
 
+	class OBreakpoint : public UnaryOpcode
+	{
+	public:
+		OBreakpoint(Argument *A) : UnaryOpcode(A) {}
+		std::string toString();
+		Opcode *clone()
+		{
+			return new OBreakpoint(a->clone());
+		}
+	};
+
 	class OAndImmediate : public BinaryOpcode
 	{
 	public:

--- a/src/parser/GlobalSymbols.cpp
+++ b/src/parser/GlobalSymbols.cpp
@@ -10667,6 +10667,7 @@ static AccessorTable DebugTable[] =
 	{ "Null",                    ZVARTYPEID_UNTYPED,       GETTER,       DONULL,               1,             0,                                    1,           {  ZVARTYPEID_DEBUG,       -1,                               -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
 	{ "getNULL",                 ZVARTYPEID_UNTYPED,       GETTER,       DONULL,               1,             0,                                    1,           {  ZVARTYPEID_DEBUG,       -1,                               -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
 	{ "getNull",                 ZVARTYPEID_UNTYPED,       GETTER,       DONULL,               1,             0,                                    1,           {  ZVARTYPEID_DEBUG,       -1,                               -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
+	{ "Breakpoint",              ZVARTYPEID_VOID,          FUNCTION,     0,                    1,             0,                                    2,           {  ZVARTYPEID_DEBUG,          ZVARTYPEID_CHAR,        -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
 	
 	{ "",                        -1,                       -1,           -1,                   -1,            0,                                    0,           { -1,                               -1,                               -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } }
 };
@@ -10915,6 +10916,19 @@ void DebugSymbols::generateCode()
         code.push_back(new OReturn());
         function->giveCode(code);
     }
+	//void Breakpoint(debug, char)
+	{
+	    Function* function = getFunction("Breakpoint", 2);
+        int label = function->getLabel();
+        vector<Opcode *> code;
+        Opcode *first = new OPopRegister(new VarArgument(EXP2));
+        first->setLabel(label);
+        code.push_back(first);
+		code.push_back(new OPopRegister(new VarArgument(refVar)));
+        code.push_back(new OBreakpoint(new VarArgument(EXP2)));
+        code.push_back(new OReturn());
+        function->giveCode(code);
+	}
 }
 
 


### PR DESCRIPTION
Added ZASM breakpoints, for the ZASM debugger
In ZScript, 'Debug->Breakpoint(string)', or 'Debug->Breakpoint(NULL)'
In ZASM, 'BREAKPOINT reg', or 'BREAKPOINT NUL'
Controls:
INSERT - Break, or if broken, step once
SHIFT+INSERT - Step to next script start, or next breakpoint; whichever first
ALT+INSERT - Step to the next breakpoint
CTRL+INSERT - Kill the ZASM debugger, ending debugging