### PR TITLE
Feat: Use hardcoded sprite clippings with Generic combos.

### DIFF
--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -1060,7 +1060,13 @@ int wid = (w->useweapon > 0) ? w->useweapon : w->id;
 		if ((c[cid].usrflags&0x1)) 
 		{
 			//zprint("Adding decoration, sprite: %d\n", c[cid].attributes[0]);
-			if ( ((unsigned)c[cid].attributes[0]) < 256 )
+			if ( c[cid].attributes[0] == -1 )
+				decorations.add(new dBushLeaves((fix)ComboX(scombo), (fix)ComboY(scombo),dBUSHLEAVES, 0, 0));
+			else if ( c[cid].attributes[0] == -2 )
+				decorations.add(new dFlowerClippings((fix)ComboX(scombo), (fix)ComboY(scombo),dFLOWERCLIPPINGS, 0, 0));
+			else if ( c[cid].attributes[0] == -3 )
+				decorations.add(new dGrassClippings((fix)ComboX(scombo), (fix)ComboY(scombo), dGRASSCLIPPINGS, 0, 0));
+			else if ( ((unsigned)c[cid].attributes[0]) < 256 )
 				decorations.add(new comboSprite((fix)ComboX(scombo), (fix)ComboY(scombo), 0, 0, c[cid].attributes[0]));
 		}
 		int it = -1; 


### PR DESCRIPTION
Changelog: You can now pass negative values to the 'Sprite' field for
	Generic combo type combos, where:
	-1: Bush Leaves
	-2: Flower Clippings
	-3: Grass Clippings