### PR TITLE
jwin d->dp3 function pointer is now int, returns D_*

### DIFF
--- a/src/jwin.cpp
+++ b/src/jwin.cpp
@@ -5519,10 +5519,10 @@ int d_jwinbutton_proc(int msg, DIALOG *d, int)
 	if(d->dp3 != NULL)
         {
             //object_message(d, MSG_DRAW, 0);
-            typedef void (*funcType)(void);
+            typedef int (*funcType)(void);
             funcType func=reinterpret_cast<funcType>(d->dp3);
-            func();
-	    return D_EXIT;
+            
+	    return func();
         }
 	
         /* should we close the dialog? */

--- a/src/zq_tiles.cpp
+++ b/src/zq_tiles.cpp
@@ -13179,7 +13179,7 @@ std::map<int, ComboAttributesInfo *> *getComboInfoMap()
     return comboinfomap;
 }
 
-void get_tick_sel(){} 
+int get_tick_sel(){ return D_CLOSE; } 
 
 static DIALOG combo_dlg[] =
 {


### PR DESCRIPTION
Changelog: The function pointer for jwin_button_proc (and for
	jwin_check_proc) now returns int. The dialogue will return what that
	function returns.
	Example function returns D_CLOSE, allowing a callback that affects
	the dialogue base don return type.