### PR TITLE
Remove ZShark Quest Memory Obfustification

### DIFF
--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -1732,7 +1732,7 @@ int init_game()
         lens_hint_weapon[x][1]=0;
     }
     
-    
+    /* Disabling to see if this is causing virus scanner redflags. -Z
 //Confuse the cheaters by moving the game data to a random location
     if(game != NULL)
         delete game;
@@ -1742,10 +1742,11 @@ int init_game()
     game->Clear();
     
     zc_free(dummy);
-    
+    */
 //Copy saved data to RAM data (but not global arrays)
     game->Copy(saves[currgame]);
     flushItemCache();
+    
     
 //Load the quest
     //setPackfilePassword(datapwd);


### PR DESCRIPTION
Changelog: Disable anti-cheating memory nobfustification to see if it
	is the cause of virus scanner red flags.