### PR TITLE
New Error System

### DIFF
--- a/src/parser/ASTVisitors.cpp
+++ b/src/parser/ASTVisitors.cpp
@@ -223,7 +223,7 @@ void RecursiveVisitor::caseStmtReturnVal(ASTStmtReturnVal& host, void* param)
 
 void RecursiveVisitor::caseScript(ASTScript& host, void* param)
 {
-	block_visit(host.type.get(), param);
+	visit(host.type.get(), param);
 	if (breakRecursion(host, param)) return;
 	block_visit(host, host.options, param);
 	if (breakRecursion(host, param)) return;

--- a/src/parser/ASTVisitors.cpp
+++ b/src/parser/ASTVisitors.cpp
@@ -139,7 +139,7 @@ void RecursiveVisitor::caseBlock(ASTBlock& host, void* param)
 {
 	visit(host, host.options, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.statements, param);
+	block_visit(host, host.statements, param);
 }
 
 void RecursiveVisitor::caseStmtIf(ASTStmtIf& host, void* param)

--- a/src/parser/ASTVisitors.cpp
+++ b/src/parser/ASTVisitors.cpp
@@ -31,23 +31,6 @@ bool RecursiveVisitor::breakRecursion(void* param) const
 	return failure_temp || failure_halt || breakNode;
 }
 
-/*void RecursiveVisitor::syncDisable(AST& parent, AST const& child)
-{
-	if(child.errorDisabled) parent.errorDisabled = true;
-	if(child.isDisabled()) parent.disable();
-}
-
-void RecursiveVisitor::syncDisable(AST& parent, AST const* child)
-{
-	if(!child)
-	{
-		parent.errorDisabled = true; //Assume error on null param!
-		return;
-	}
-	if(child->errorDisabled) parent.errorDisabled = true;
-	if(child->isDisabled()) parent.disable();
-}*/
-
 void RecursiveVisitor::handleError(CompileError const& error)
 {
 	bool hard_error = (scope && *ZScript::lookupOption(*scope, CompileOption::OPT_NO_ERROR_HALT) == 0);
@@ -109,23 +92,23 @@ void RecursiveVisitor::visit(AST* node, void* param)
 
 void RecursiveVisitor::caseFile(ASTFile& host, void* param)
 {
-	visit(host, host.options, param);
+	block_visit(host, host.options, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.use, param);
+	block_visit(host, host.use, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.dataTypes, param);
+	block_visit(host, host.dataTypes, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.scriptTypes, param);
+	block_visit(host, host.scriptTypes, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.imports, param);
+	block_visit(host, host.imports, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.variables, param);
+	block_visit(host, host.variables, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.functions, param);
+	block_visit(host, host.functions, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.namespaces, param);
+	block_visit(host, host.namespaces, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.scripts, param);
+	block_visit(host, host.scripts, param);
 }
 
 void RecursiveVisitor::caseSetOption(ASTSetOption& host, void* param)
@@ -137,7 +120,7 @@ void RecursiveVisitor::caseSetOption(ASTSetOption& host, void* param)
 
 void RecursiveVisitor::caseBlock(ASTBlock& host, void* param)
 {
-	visit(host, host.options, param);
+	block_visit(host, host.options, param);
 	if (breakRecursion(host, param)) return;
 	block_visit(host, host.statements, param);
 }
@@ -145,7 +128,6 @@ void RecursiveVisitor::caseBlock(ASTBlock& host, void* param)
 void RecursiveVisitor::caseStmtIf(ASTStmtIf& host, void* param)
 {
 	visit(host.condition.get(), param);
-	//syncDisable(host, *host.condition);
 	if (breakRecursion(host, param)) return;
 	visit(host.thenStatement.get(), param);
 }
@@ -160,16 +142,15 @@ void RecursiveVisitor::caseStmtIfElse(ASTStmtIfElse& host, void* param)
 void RecursiveVisitor::caseStmtSwitch(ASTStmtSwitch& host, void* param)
 {
 	visit(host.key.get(), param);
-	//syncDisable(host, *host.key);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.cases, param);
+	block_visit(host, host.cases, param);
 }
 
 void RecursiveVisitor::caseSwitchCases(ASTSwitchCases& host, void* param)
 {
-	visit(host, host.ranges, param);
+	block_visit(host, host.ranges, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.cases, param);
+	block_visit(host, host.cases, param);
 	if (breakRecursion(host, param)) return;
 	visit(host.block.get(), param);
 }
@@ -177,10 +158,8 @@ void RecursiveVisitor::caseSwitchCases(ASTSwitchCases& host, void* param)
 void RecursiveVisitor::caseRange(ASTRange& host, void* param)
 {
 	visit(host.start.get(), param);
-	//syncDisable(host, *host.start);
 	if (breakRecursion(host, param)) return;
 	visit(host.end.get(), param);
-	//syncDisable(host, *host.end);
 }
 
 void RecursiveVisitor::caseStmtFor(ASTStmtFor& host, void* param)
@@ -188,10 +167,8 @@ void RecursiveVisitor::caseStmtFor(ASTStmtFor& host, void* param)
 	visit(host.setup.get(), param);
 	if (breakRecursion(host, param)) return;
 	visit(host.test.get(), param);
-	//syncDisable(host, *host.test);
 	if (breakRecursion(host, param)) return;
 	visit(host.increment.get(), param);
-	//syncDisable(host, *host.increment);
 	if (breakRecursion(host, param)) return;
 	visit(host.body.get(), param);
 }
@@ -199,7 +176,6 @@ void RecursiveVisitor::caseStmtFor(ASTStmtFor& host, void* param)
 void RecursiveVisitor::caseStmtWhile(ASTStmtWhile& host, void* param)
 {
 	visit(host.test.get(), param);
-	//syncDisable(host, *host.test);
 	if (breakRecursion(host, param)) return;
 	visit(host.body.get(), param);
 }
@@ -209,13 +185,11 @@ void RecursiveVisitor::caseStmtDo(ASTStmtDo& host, void* param)
 	visit(host.body.get(), param);
 	if (breakRecursion(host, param)) return;
 	visit(host.test.get(), param);
-	//syncDisable(host, *host.test);
 }
 
 void RecursiveVisitor::caseStmtRepeat(ASTStmtRepeat& host, void* param)
 {
 	visit(*host.iter, param);
-	//syncDisable(host, *host.iter);
 	if(breakRecursion(host, param)) return;
 	optional<long> repeats = (*host.iter).getCompileTimeValue(this, scope);
 	if(repeats)
@@ -243,43 +217,42 @@ void RecursiveVisitor::caseStmtRepeat(ASTStmtRepeat& host, void* param)
 void RecursiveVisitor::caseStmtReturnVal(ASTStmtReturnVal& host, void* param)
 {
 	visit(host.value.get(), param);
-	//syncDisable(host, *host.value);
 }
 
 // Declarations
 
 void RecursiveVisitor::caseScript(ASTScript& host, void* param)
 {
-	visit(host.type.get(), param);
+	block_visit(host.type.get(), param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.options, param);
+	block_visit(host, host.options, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.use, param);
+	block_visit(host, host.use, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.types, param);
+	block_visit(host, host.types, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.variables, param);
+	block_visit(host, host.variables, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.functions, param);
+	block_visit(host, host.functions, param);
 }
 
 void RecursiveVisitor::caseNamespace(ASTNamespace& host, void* param)
 {
-	visit(host, host.options, param);
+	block_visit(host, host.options, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.dataTypes, param);
+	block_visit(host, host.dataTypes, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.scriptTypes, param);
+	block_visit(host, host.scriptTypes, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.use, param);
+	block_visit(host, host.use, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.variables, param);
+	block_visit(host, host.variables, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.functions, param);
+	block_visit(host, host.functions, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.namespaces, param);
+	block_visit(host, host.namespaces, param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.scripts, param);
+	block_visit(host, host.scripts, param);
 }
 
 void RecursiveVisitor::caseImportDecl(ASTImportDecl& host, void* param)
@@ -305,31 +278,23 @@ void RecursiveVisitor::caseDataDeclList(ASTDataDeclList& host, void* param)
 {
 	visit(host.baseType.get(), param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.getDeclarations(), param);
+	block_visit(host, host.getDeclarations(), param);
 }
 
 void RecursiveVisitor::caseDataEnum(ASTDataEnum& host, void* param)
 {
 	visit(host.baseType.get(), param);
 	if (breakRecursion(host, param)) return;
-	visit(host, host.getDeclarations(), param);
+	block_visit(host, host.getDeclarations(), param);
 }
 
 void RecursiveVisitor::caseDataDecl(ASTDataDecl& host, void* param)
 {
 	visit(host.baseType.get(), param);
-	//if(host.baseType) syncDisable(host, *host.baseType);
 	if (breakRecursion(host, param)) return;
 	visit(host, host.extraArrays, param);
-	for(vector<ASTDataDeclExtraArray*>::iterator it = host.extraArrays.begin();
-		it != host.extraArrays.end(); ++it)
-	{
-		//syncDisable(host, *it);
-	}
 	if (breakRecursion(host, param)) return;
 	visit(host.getInitializer(), param);
-	if(host.getInitializer())
-		//syncDisable(host, *host.getInitializer());
 }
 
 void RecursiveVisitor::caseDataDeclExtraArray(
@@ -355,7 +320,6 @@ void RecursiveVisitor::caseCustomDataTypeDef(ASTCustomDataTypeDef& host, void* p
 void RecursiveVisitor::caseExprConst(ASTExprConst& host, void* param)
 {
 	visit(host.content.get(), param);
-	//syncDisable(host, *host.content);
 }
 
 void RecursiveVisitor::caseVarInitializer(ASTExprVarInitializer& host, void* param)
@@ -366,28 +330,22 @@ void RecursiveVisitor::caseVarInitializer(ASTExprVarInitializer& host, void* par
 void RecursiveVisitor::caseExprAssign(ASTExprAssign& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprArrow(ASTExprArrow& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.index.get(), param);
-	//syncDisable(host, *host.index);
 }
 
 void RecursiveVisitor::caseExprIndex(ASTExprIndex& host, void* param)
 {
 	visit(host.array.get(), param);
-	//syncDisable(host, *host.array);
 	if (breakRecursion(host, param)) return;
 	visit(host.index.get(), param);
-	//syncDisable(host, *host.index);
 }
 
 void RecursiveVisitor::caseExprCall(ASTExprCall& host, void* param)
@@ -395,253 +353,197 @@ void RecursiveVisitor::caseExprCall(ASTExprCall& host, void* param)
 	//visit(host.left, param);
 	//if (breakRecursion(host, param)) return;
 	visit(host, host.parameters, param);
-	for(vector<ASTExpr*>::iterator it = host.parameters.begin();
-		it != host.parameters.end(); ++it)
-	{
-		//syncDisable(host, *it);
-	}
 }
 
 void RecursiveVisitor::caseExprNegate(ASTExprNegate& host, void* param)
 {
 	visit(host.operand.get(), param);
-	//syncDisable(host, *host.operand);
 }
 
 void RecursiveVisitor::caseExprNot(ASTExprNot& host, void* param)
 {
 	visit(host.operand.get(), param);
-	//syncDisable(host, *host.operand);
 }
 
 void RecursiveVisitor::caseExprBitNot(ASTExprBitNot& host, void* param)
 {
 	visit(host.operand.get(), param);
-	//syncDisable(host, *host.operand);
 }
 
 void RecursiveVisitor::caseExprIncrement(ASTExprIncrement& host, void* param)
 {
 	visit(host.operand.get(), param);
-	//syncDisable(host, *host.operand);
 }
 
 void RecursiveVisitor::caseExprPreIncrement(
 		ASTExprPreIncrement& host, void* param)
 {
 	visit(host.operand.get(), param);
-	//syncDisable(host, *host.operand);
 }
 
 void RecursiveVisitor::caseExprDecrement(ASTExprDecrement& host, void* param)
 {
 	visit(host.operand.get(), param);
-	//syncDisable(host, *host.operand);
 }
 
 void RecursiveVisitor::caseExprPreDecrement(
 		ASTExprPreDecrement& host, void* param)
 {
 	visit(host.operand.get(), param);
-	//syncDisable(host, *host.operand);
 }
 
 void RecursiveVisitor::caseExprCast(ASTExprCast& host, void* param)
 {
 	visit(host.operand.get(), param);
-	//syncDisable(host, *host.operand);
 }
 
 void RecursiveVisitor::caseExprAnd(ASTExprAnd& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprOr(ASTExprOr& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprGT(ASTExprGT& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprGE(ASTExprGE& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprLT(ASTExprLT& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprLE(ASTExprLE& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprEQ(ASTExprEQ& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprNE(ASTExprNE& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprAppxEQ(ASTExprAppxEQ& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprXOR(ASTExprXOR& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprPlus(ASTExprPlus& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprMinus(ASTExprMinus& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprTimes(ASTExprTimes& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprDivide(ASTExprDivide& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprModulo(ASTExprModulo& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprBitAnd(ASTExprBitAnd& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprBitOr(ASTExprBitOr& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprBitXor(ASTExprBitXor& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprLShift(ASTExprLShift& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprRShift(ASTExprRShift& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 void RecursiveVisitor::caseExprTernary(ASTTernaryExpr& host, void* param)
 {
 	visit(host.left.get(), param);
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host, param)) return;
 	visit(host.middle.get(), param);
-	//syncDisable(host, *host.middle);
 	if (breakRecursion(host, param)) return;
 	visit(host.right.get(), param);
-	//syncDisable(host, *host.right);
 }
 
 // Literals

--- a/src/parser/ASTVisitors.h
+++ b/src/parser/ASTVisitors.h
@@ -333,10 +333,6 @@ namespace ZScript
 		// each action that can fail.
 		virtual bool breakRecursion(AST& host, void* param = NULL) const;
 		virtual bool breakRecursion(void* param = NULL) const;
-		
-		// Call this when a node relies on a child node. If the child is disabled, the parent must also be disabled, or else it can crash.
-		/*static void syncDisable(AST& parent, AST const& child);
-		static void syncDisable(AST& parent, AST const* child);*/
 
 		// Current stack of visited nodes.
 		std::vector<AST*> recursionStack;

--- a/src/parser/RegistrationVisitor.cpp
+++ b/src/parser/RegistrationVisitor.cpp
@@ -44,6 +44,17 @@ void RegistrationVisitor::regvisit(AST& host, Container const& nodes, void* para
 		visit(**it, param);
 	}
 }
+template <class Container>
+void RegistrationVisitor::block_regvisit(AST& host, Container const& nodes, void* param)
+{
+	for (typename Container::const_iterator it = nodes.begin();
+		 it != nodes.end(); ++it)
+	{
+		failure_temp = false;
+		visit(**it, param);
+		if(failure_halt) return;
+	}
+}
 
 void RegistrationVisitor::caseDefault(AST& host, void* param)
 {
@@ -71,23 +82,23 @@ void RegistrationVisitor::caseFile(ASTFile& host, void* param)
 		scope = host.scope;
 	else
 		scope = host.scope = scope->makeFileChild(host.asString());
-	regvisit(host, host.options, param);
+	block_regvisit(host, host.options, param);
 	if (breakRecursion(host, param)) {scope = scope->getParent(); return;}
-	regvisit(host, host.use, param);
+	block_regvisit(host, host.use, param);
 	if (breakRecursion(host, param)) {scope = scope->getParent(); return;}
-	regvisit(host, host.dataTypes, param);
+	block_regvisit(host, host.dataTypes, param);
 	if (breakRecursion(host, param)) {scope = scope->getParent(); return;}
-	regvisit(host, host.scriptTypes, param);
+	block_regvisit(host, host.scriptTypes, param);
 	if (breakRecursion(host, param)) {scope = scope->getParent(); return;}
-	regvisit(host, host.imports, param);
+	block_regvisit(host, host.imports, param);
 	if (breakRecursion(host, param)) {scope = scope->getParent(); return;}
-	regvisit(host, host.variables, param);
+	block_regvisit(host, host.variables, param);
 	if (breakRecursion(host, param)) {scope = scope->getParent(); return;}
-	regvisit(host, host.functions, param);
+	block_regvisit(host, host.functions, param);
 	if (breakRecursion(host, param)) {scope = scope->getParent(); return;}
-	regvisit(host, host.namespaces, param);
+	block_regvisit(host, host.namespaces, param);
 	if (breakRecursion(host, param)) {scope = scope->getParent(); return;}
-	regvisit(host, host.scripts, param);
+	block_regvisit(host, host.scripts, param);
 	if(registered(host, host.options) && registered(host, host.use) && registered(host, host.dataTypes)
 		&& registered(host, host.scriptTypes) && registered(host, host.imports) && registered(host, host.variables)
 		&& registered(host, host.functions) && registered(host, host.namespaces) && registered(host, host.scripts))
@@ -138,15 +149,15 @@ void RegistrationVisitor::caseScript(ASTScript& host, void* param)
 
 	// Recurse on script elements with its scope.
 	scope = &script.getScope();
-	regvisit(host, host.options, param);
+	block_regvisit(host, host.options, param);
 	if (breakRecursion(host, param)) {scope = scope->getParent(); return;}
-	regvisit(host, host.use, param);
+	block_regvisit(host, host.use, param);
 	if (breakRecursion(host, param)) {scope = scope->getParent(); return;}
-	regvisit(host, host.types, param);
+	block_regvisit(host, host.types, param);
 	if (breakRecursion(host, param)) {scope = scope->getParent(); return;}
-	regvisit(host, host.variables, param);
+	block_regvisit(host, host.variables, param);
 	if (breakRecursion(host, param)) {scope = scope->getParent(); return;}
-	regvisit(host, host.functions, param);
+	block_regvisit(host, host.functions, param);
 	scope = scope->getParent();
 	if (breakRecursion(host)) return;
 	//
@@ -188,21 +199,21 @@ void RegistrationVisitor::caseNamespace(ASTNamespace& host, void* param)
 	// Namespaces' parent scope is RootScope*, not FileScope*. Store the FileScope* temporarily.
 	Scope* temp = scope;
 	scope = &namesp.getScope();
-	regvisit(host, host.options, param);
+	block_regvisit(host, host.options, param);
 	if (breakRecursion(host, param)) {scope = temp; return;}
-	regvisit(host, host.dataTypes, param);
+	block_regvisit(host, host.dataTypes, param);
 	if (breakRecursion(host, param)) {scope = temp; return;}
-	regvisit(host, host.scriptTypes, param);
+	block_regvisit(host, host.scriptTypes, param);
 	if (breakRecursion(host, param)) {scope = temp; return;}
-	regvisit(host, host.use, param);
+	block_regvisit(host, host.use, param);
 	if (breakRecursion(host, param)) {scope = temp; return;}
-	regvisit(host, host.variables, param);
+	block_regvisit(host, host.variables, param);
 	if (breakRecursion(host, param)) {scope = temp; return;}
-	regvisit(host, host.functions, param);
+	block_regvisit(host, host.functions, param);
 	if (breakRecursion(host, param)) {scope = temp; return;}
-	regvisit(host, host.namespaces, param);
+	block_regvisit(host, host.namespaces, param);
 	if (breakRecursion(host, param)) {scope = temp; return;}
-	regvisit(host, host.scripts, param);
+	block_regvisit(host, host.scripts, param);
 	scope = temp;
 	if(registered(host, host.options) && registered(host, host.use) && registered(host, host.dataTypes)
 		&& registered(host, host.scriptTypes) && registered(host, host.variables) && registered(host, host.functions)

--- a/src/parser/RegistrationVisitor.cpp
+++ b/src/parser/RegistrationVisitor.cpp
@@ -637,7 +637,6 @@ void RegistrationVisitor::caseExprArrow(ASTExprArrow& host, void* param)
 {
 	// Recurse on left.
 	visit(host.left.get());
-	//syncDisable(host, *host.left);
     if (breakRecursion(host)) return;
 	if(!registered(host.left.get())) return;
 
@@ -713,10 +712,8 @@ void RegistrationVisitor::caseExprArrow(ASTExprArrow& host, void* param)
 void RegistrationVisitor::caseExprIndex(ASTExprIndex& host, void* param)
 {
 	visit(host.array.get());
-	//syncDisable(host, *host.array);
 	if (breakRecursion(host)) return;
 	visit(host.index.get());
-	//syncDisable(host, *host.index);
 	if (breakRecursion(host)) return;
 	if(registered(host.array.get()) && registered(host.index.get())) doRegister(host);
 }
@@ -875,13 +872,10 @@ void RegistrationVisitor::caseExprRShift(ASTExprRShift& host, void* param)
 void RegistrationVisitor::caseExprTernary(ASTTernaryExpr& host, void* param)
 {
 	visit(host.left.get());
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host)) return;
 	visit(host.middle.get());
-	//syncDisable(host, *host.middle);
 	if (breakRecursion(host)) return;
 	visit(host.right.get());
-	//syncDisable(host, *host.right);
 	if (breakRecursion(host)) return;
 	if(registered(host.left.get()) && registered(host.middle.get()) && registered(host.right.get())) doRegister(host);
 }
@@ -918,7 +912,6 @@ void RegistrationVisitor::caseStringLiteral(ASTStringLiteral& host, void* param)
 void RegistrationVisitor::analyzeUnaryExpr(ASTUnaryExpr& host)
 {
 	visit(host.operand.get());
-	//syncDisable(host, *host.operand);
 	if (breakRecursion(host)) return;
 	if(registered(host.operand.get()))doRegister(host);
 }
@@ -926,10 +919,8 @@ void RegistrationVisitor::analyzeUnaryExpr(ASTUnaryExpr& host)
 void RegistrationVisitor::analyzeBinaryExpr(ASTBinaryExpr& host)
 {
 	visit(host.left.get());
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host)) return;
 	visit(host.right.get());
-	//syncDisable(host, *host.right);
 	if (breakRecursion(host)) return;
 	if((registered(host.left.get()) && registered(host.right.get()))) doRegister(host);
 }

--- a/src/parser/RegistrationVisitor.cpp
+++ b/src/parser/RegistrationVisitor.cpp
@@ -637,7 +637,7 @@ void RegistrationVisitor::caseExprArrow(ASTExprArrow& host, void* param)
 {
 	// Recurse on left.
 	visit(host.left.get());
-	syncDisable(host, *host.left);
+	//syncDisable(host, *host.left);
     if (breakRecursion(host)) return;
 	if(!registered(host.left.get())) return;
 
@@ -713,10 +713,10 @@ void RegistrationVisitor::caseExprArrow(ASTExprArrow& host, void* param)
 void RegistrationVisitor::caseExprIndex(ASTExprIndex& host, void* param)
 {
 	visit(host.array.get());
-	syncDisable(host, *host.array);
+	//syncDisable(host, *host.array);
 	if (breakRecursion(host)) return;
 	visit(host.index.get());
-	syncDisable(host, *host.index);
+	//syncDisable(host, *host.index);
 	if (breakRecursion(host)) return;
 	if(registered(host.array.get()) && registered(host.index.get())) doRegister(host);
 }
@@ -875,13 +875,13 @@ void RegistrationVisitor::caseExprRShift(ASTExprRShift& host, void* param)
 void RegistrationVisitor::caseExprTernary(ASTTernaryExpr& host, void* param)
 {
 	visit(host.left.get());
-	syncDisable(host, *host.left);
+	//syncDisable(host, *host.left);
 	if (breakRecursion(host)) return;
 	visit(host.middle.get());
-	syncDisable(host, *host.middle);
+	//syncDisable(host, *host.middle);
 	if (breakRecursion(host)) return;
 	visit(host.right.get());
-	syncDisable(host, *host.right);
+	//syncDisable(host, *host.right);
 	if (breakRecursion(host)) return;
 	if(registered(host.left.get()) && registered(host.middle.get()) && registered(host.right.get())) doRegister(host);
 }
@@ -918,7 +918,7 @@ void RegistrationVisitor::caseStringLiteral(ASTStringLiteral& host, void* param)
 void RegistrationVisitor::analyzeUnaryExpr(ASTUnaryExpr& host)
 {
 	visit(host.operand.get());
-	syncDisable(host, *host.operand);
+	//syncDisable(host, *host.operand);
 	if (breakRecursion(host)) return;
 	if(registered(host.operand.get()))doRegister(host);
 }
@@ -926,10 +926,10 @@ void RegistrationVisitor::analyzeUnaryExpr(ASTUnaryExpr& host)
 void RegistrationVisitor::analyzeBinaryExpr(ASTBinaryExpr& host)
 {
 	visit(host.left.get());
-	syncDisable(host, *host.left);
+	//syncDisable(host, *host.left);
 	if (breakRecursion(host)) return;
 	visit(host.right.get());
-	syncDisable(host, *host.right);
+	//syncDisable(host, *host.right);
 	if (breakRecursion(host)) return;
 	if((registered(host.left.get()) && registered(host.right.get()))) doRegister(host);
 }

--- a/src/parser/RegistrationVisitor.h
+++ b/src/parser/RegistrationVisitor.h
@@ -103,6 +103,9 @@ namespace ZScript
 		// Visit a group of nodes. Handle moving the nodes as needed, to accomodate order.
 		template <class Container>
 		void regvisit(AST& host, Container const& nodes, void* param = NULL);
+		
+		template <class Container>
+		void block_regvisit(AST& host, Container const& nodes, void* param = NULL);
 	private:
 		ZScript::Program& program;
 		

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -81,8 +81,7 @@ ScriptsData* ZScript::compile(string const& filename)
 	box_eol();
 	
 	SemanticAnalyzer semanticAnalyzer(program);
-	if (semanticAnalyzer.hasFailed() || semanticAnalyzer.hasSkipFailed()
-		|| regVisitor.hasSkipFailed())
+	if (semanticAnalyzer.hasFailed() || regVisitor.hasFailed())
 		return NULL;
     
 	FunctionData fd(program);

--- a/src/parser/SemanticAnalyzer.cpp
+++ b/src/parser/SemanticAnalyzer.cpp
@@ -732,7 +732,7 @@ void SemanticAnalyzer::caseExprAssign(ASTExprAssign& host, void*)
 		handleError(
 			CompileError::NoWriteType(
 				host.left.get(), host.left->asString()));
-		syncDisable(host, *host.left);
+		//syncDisable(host, *host.left);
 		return;
 	}
 	
@@ -771,7 +771,7 @@ void SemanticAnalyzer::caseExprArrow(ASTExprArrow& host, void* param)
 {
     // Recurse on left.
 	visit(host.left.get());
-	syncDisable(host, *host.left);
+	//syncDisable(host, *host.left);
     if (breakRecursion(host)) return;
 
 	// Grab the left side's class.
@@ -834,7 +834,7 @@ void SemanticAnalyzer::caseExprArrow(ASTExprArrow& host, void* param)
 	if (host.index)
 	{
 		visit(host.index.get());
-		syncDisable(host, *host.index);
+		//syncDisable(host, *host.index);
         if (breakRecursion(host)) return;
 
         checkCast(*host.index->getReadType(scope, this), DataType::FLOAT,
@@ -880,7 +880,7 @@ void SemanticAnalyzer::caseExprCall(ASTExprCall& host, void* param)
 	if (!identifier)
 	{
 		visit(host.left.get(), paramNone);
-		syncDisable(host, *host.left);
+		//syncDisable(host, *host.left);
 		if (breakRecursion(host)) return;
 	}
 
@@ -888,7 +888,7 @@ void SemanticAnalyzer::caseExprCall(ASTExprCall& host, void* param)
 	for(vector<ASTExpr*>::iterator it = host.parameters.begin();
 		it != host.parameters.end(); ++it)
 	{
-		syncDisable(host, *it);
+		//syncDisable(host, *it);
 	}
 	if (breakRecursion(host)) return;
 
@@ -1174,16 +1174,16 @@ void SemanticAnalyzer::caseExprRShift(ASTExprRShift& host, void*)
 void SemanticAnalyzer::caseExprTernary(ASTTernaryExpr& host, void*)
 {
 	visit(host.left.get());
-	syncDisable(host, *host.left);
+	//syncDisable(host, *host.left);
 	if (breakRecursion(host)) return;
 	checkCast(*host.left->getReadType(scope, this), DataType::UNTYPED, &host);
 	if (breakRecursion(host)) return;
 	
 	visit(host.middle.get());
-	syncDisable(host, *host.middle);
+	//syncDisable(host, *host.middle);
 	if (breakRecursion(host)) return;
 	visit(host.right.get());
-	syncDisable(host, *host.right);
+	//syncDisable(host, *host.right);
 	if (breakRecursion(host)) return;
 	checkCast(*host.middle->getReadType(scope, this), *host.right->getReadType(scope, this), &host);
 	if (breakRecursion(host)) return;
@@ -1298,7 +1298,7 @@ void SemanticAnalyzer::analyzeUnaryExpr(
 		ASTUnaryExpr& host, DataType const& type)
 {
 	visit(host.operand.get());
-	syncDisable(host, *host.operand);
+	//syncDisable(host, *host.operand);
 	if (breakRecursion(host)) return;
 	
 	checkCast(*host.operand->getReadType(scope, this), type, &host);
@@ -1308,7 +1308,7 @@ void SemanticAnalyzer::analyzeUnaryExpr(
 void SemanticAnalyzer::analyzeIncrement(ASTUnaryExpr& host)
 {
 	visit(host.operand.get(), paramReadWrite);
-	syncDisable(host, *host.operand);
+	//syncDisable(host, *host.operand);
     if (breakRecursion(host)) return;
 
 	ASTExpr& operand = *host.operand;
@@ -1321,13 +1321,13 @@ void SemanticAnalyzer::analyzeBinaryExpr(
 		DataType const& rightType)
 {
 	visit(host.left.get());
-	syncDisable(host, *host.left);
+	//syncDisable(host, *host.left);
 	if (breakRecursion(host)) return;
 	checkCast(*host.left->getReadType(scope, this), leftType, &host);
 	if (breakRecursion(host)) return;
 
 	visit(host.right.get());
-	syncDisable(host, *host.right);
+	//syncDisable(host, *host.right);
 	if (breakRecursion(host)) return;
 	checkCast(*host.right->getReadType(scope, this), rightType, &host);
 	if (breakRecursion(host)) return;

--- a/src/parser/SemanticAnalyzer.cpp
+++ b/src/parser/SemanticAnalyzer.cpp
@@ -732,7 +732,6 @@ void SemanticAnalyzer::caseExprAssign(ASTExprAssign& host, void*)
 		handleError(
 			CompileError::NoWriteType(
 				host.left.get(), host.left->asString()));
-		//syncDisable(host, *host.left);
 		return;
 	}
 	
@@ -771,7 +770,6 @@ void SemanticAnalyzer::caseExprArrow(ASTExprArrow& host, void* param)
 {
     // Recurse on left.
 	visit(host.left.get());
-	//syncDisable(host, *host.left);
     if (breakRecursion(host)) return;
 
 	// Grab the left side's class.
@@ -834,7 +832,6 @@ void SemanticAnalyzer::caseExprArrow(ASTExprArrow& host, void* param)
 	if (host.index)
 	{
 		visit(host.index.get());
-		//syncDisable(host, *host.index);
         if (breakRecursion(host)) return;
 
         checkCast(*host.index->getReadType(scope, this), DataType::FLOAT,
@@ -880,16 +877,10 @@ void SemanticAnalyzer::caseExprCall(ASTExprCall& host, void* param)
 	if (!identifier)
 	{
 		visit(host.left.get(), paramNone);
-		//syncDisable(host, *host.left);
 		if (breakRecursion(host)) return;
 	}
 
 	visit(host, host.parameters);
-	for(vector<ASTExpr*>::iterator it = host.parameters.begin();
-		it != host.parameters.end(); ++it)
-	{
-		//syncDisable(host, *it);
-	}
 	if (breakRecursion(host)) return;
 
 	// Gather parameter types.
@@ -1174,16 +1165,13 @@ void SemanticAnalyzer::caseExprRShift(ASTExprRShift& host, void*)
 void SemanticAnalyzer::caseExprTernary(ASTTernaryExpr& host, void*)
 {
 	visit(host.left.get());
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host)) return;
 	checkCast(*host.left->getReadType(scope, this), DataType::UNTYPED, &host);
 	if (breakRecursion(host)) return;
 	
 	visit(host.middle.get());
-	//syncDisable(host, *host.middle);
 	if (breakRecursion(host)) return;
 	visit(host.right.get());
-	//syncDisable(host, *host.right);
 	if (breakRecursion(host)) return;
 	checkCast(*host.middle->getReadType(scope, this), *host.right->getReadType(scope, this), &host);
 	if (breakRecursion(host)) return;
@@ -1298,7 +1286,6 @@ void SemanticAnalyzer::analyzeUnaryExpr(
 		ASTUnaryExpr& host, DataType const& type)
 {
 	visit(host.operand.get());
-	//syncDisable(host, *host.operand);
 	if (breakRecursion(host)) return;
 	
 	checkCast(*host.operand->getReadType(scope, this), type, &host);
@@ -1308,7 +1295,6 @@ void SemanticAnalyzer::analyzeUnaryExpr(
 void SemanticAnalyzer::analyzeIncrement(ASTUnaryExpr& host)
 {
 	visit(host.operand.get(), paramReadWrite);
-	//syncDisable(host, *host.operand);
     if (breakRecursion(host)) return;
 
 	ASTExpr& operand = *host.operand;
@@ -1321,13 +1307,11 @@ void SemanticAnalyzer::analyzeBinaryExpr(
 		DataType const& rightType)
 {
 	visit(host.left.get());
-	//syncDisable(host, *host.left);
 	if (breakRecursion(host)) return;
 	checkCast(*host.left->getReadType(scope, this), leftType, &host);
 	if (breakRecursion(host)) return;
 
 	visit(host.right.get());
-	//syncDisable(host, *host.right);
 	if (breakRecursion(host)) return;
 	checkCast(*host.right->getReadType(scope, this), rightType, &host);
 	if (breakRecursion(host)) return;

--- a/src/parser/SemanticAnalyzer.cpp
+++ b/src/parser/SemanticAnalyzer.cpp
@@ -55,6 +55,7 @@ SemanticAnalyzer::SemanticAnalyzer(Program& program)
 
 void SemanticAnalyzer::analyzeFunctionInternals(Function& function)
 {
+	failure_temp = false;
 	ASTFuncDecl* functionDecl = function.node;
 	Scope& functionScope = *function.internalScope;
 


### PR DESCRIPTION
Created new error system, removing the `syncDisable` slow as hell bullshit.
Now, NO_ERROR_HALT is ingrained in the standard `failure` system, which has been expanded.
With NO_ERROR_HALT set to Do Not Halt, once an error is reached, it will temporarily
halt until it reaches the next block-level recursion, where it will resume. This should prevent
any of the crashes that the old system was causing from ever occurring.
