### PR TITLE
Fewat: Add type `zstruct` as a variation of untyped script.

### DIFF
--- a/src/parser/ffscript.lpp
+++ b/src/parser/ffscript.lpp
@@ -249,6 +249,8 @@ appx_equal		TOKEN( APPXEQUAL );
  /* these would need to see if they are LH values. */
  /* https://stackoverflow.com/questions/23529298/how-to-make-bison-to-use-a-rule-if-two-rules-matches */
  /* "**" pointer/poiters */
+ 
+ zstruct		TOKEN( SCRIPTSTRUCT );
 
  /* Line Comments */
 "//".*		/* hit end of file */

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -216,6 +216,7 @@ extern YYLTYPE noloc;
 %token IMPORTSTRING
 %token SINGLECHAR
 %token NUMBER
+%token SCRIPTSTRUCT
 
 %%
 
@@ -645,7 +646,20 @@ Script : Script_Type SCRIPT IDENTIFIER Script_Block {
 	script->location = @$;
 	$$ = script;
 	delete name;}
+	
+	|
+	
+	SCRIPTSTRUCT IDENTIFIER Script_Block {
+	ASTScriptType* type = new ASTScriptType(ScriptType::untyped, @$);
+	ASTString* name = (ASTString*)$2;
+	ASTScript* script = (ASTScript*)$3;
+	script->type = type;
+	script->name = name->getValue();
+	script->location = @$;
+	$$ = script;
+	delete name;}
 	;
+
 
 Script_Type :
 	GLOBAL {$$ = new ASTScriptType(ScriptType::global, @$);}


### PR DESCRIPTION
Changelog: Added a new token `zstruct` as an alternative to
	`untyped script` + script typedef. This allows using the script
	'struct-like' syntax, without a misleading 'script' token such
	as STRUCT script.