### PR TITLE
Rewrite bitmap allocation.

### DIFF
--- a/output/common/ZScript_Additions.txt
+++ b/output/common/ZScript_Additions.txt
@@ -18,7 +18,7 @@ The following documents the changes, and expansions to the ZScript language in Z
 	versions 2.54, and 2.55. 
 	
 Document for: 2.55, Alpha 56
-Document Revision: 28th March, 2020
+Document Revision: 29th March, 2020
 
 
  __           _   _                 
@@ -5763,6 +5763,15 @@ int Height;
  * Returns the height of the bitmap, in pixels. 
  * READ-ONLY. Bitmaps cannot be resized by writing to this. 
 
+void Free();
+ * If the bitmap is allocated, frees the bitmap.
+ *     This means that this bitmap ID is able to be returned by subsequent
+ *     calls to 'Game->AllocateBitmap()' and such.
+ * Note: The bitmap will remain allocated until script draws are next cleared.
+ *       This generally occurs at the end of each frame, unless 'Game->Suspend[]'
+ *       is used to prevent it.
+ * Once the bitmap is freed, any image data on it is deleted.
+
 bool isValid();
  * Returns true if the bitmap points to a valid bitmap
  * A bitmap is valid when it has been created, and can be written to
@@ -5777,10 +5786,12 @@ float GetPixel(int x, int y);
  * Returns the palette index value of a pixel on the current bitmap pointer.
 
 void Create(int layer, int width, int height);
- * Creates a bitmap on an already-initialised bitmap pointer, with a size of height, width.
- * Destroys any existing bitmap ont hat pointer before creating a new one. 
- * You can use this in conjunction with Game->AllocateBitmap(), or to destroy an existing bitmap and 
- * create a new one.
+ * Creates a bitmap on a bitmap pointer, with a size of height, width.
+ * Destroys any existing bitmap on that pointer before creating a new one.
+ * You can use this on an initialized bitmap pointer; either one allocated with 'Game->AllocateBitmap()', or
+ *     a bitmap pointer that has a valid bitmap on it.
+ * You can ALSO use this on an uninitialised pointer, and it will attempt to initialize it.
+ *     The layer arg will be ignored when this is used on an uninitialised pointer.
  * Note: The 'layer' arg in this function is exclusively for ordering. 
  *       This WILL NOT clear a specific 'layer' of a bitmap. 
  *       Layers in ZC are only an expression of drawing order/sequence!
@@ -5799,7 +5810,8 @@ void ClearToColor(int layer, int color);
  
 void Read(int layer, "filename");
  * Reads a valid graphic file into a bitmap pointer.
- * Use Game->AllocateBitmap() to prime the pointer first, if it is uninitialised.
+ * If used on an uninitialised pointer, it will first attempt to allocate it.
+ *     If it fails to allocate the pointer, it will not attempt the read operation.
  * If the filename provided is invalid (e.g., the file is missing), the pointer
  * will be initialised with a blank bitmap at a size of 256x176.
  

--- a/src/ffasm.cpp
+++ b/src/ffasm.cpp
@@ -957,6 +957,8 @@ script_command command_list[NUMCOMMANDS+1]=
 	{ "FILESEEK",           2,   0,   0,   0},
 	{ "FILEOPENMODE",           2,   0,   0,   0},
 	{ "FILEGETERROR",           1,   0,   0,   0},
+	
+	{ "BITMAPFREE",           0,   0,   0,   0},
 //	{ "GETCONFIGINT",                2,   0,   0,   0},
 //	{ "SETCONFIGINT",                2,   0,   0,   0},
 	{ "",                    0,   0,   0,   0}

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -2676,8 +2676,53 @@ user_file *checkFile(long ref, const char *what, bool req_file = false, bool ski
 		}
 	}
 	if(skipError) return NULL;
-	Z_eventlog("Script attempted to reference a nonexistent File!\n");
-	Z_eventlog("You were trying to reference the '%s' of an File with UID = %ld\n", what, ref);
+	Z_scripterrlog("Script attempted to reference a nonexistent File!\n");
+	Z_scripterrlog("You were trying to reference the '%s' of a File with UID = %ld\n", what, ref);
+	return NULL;
+}
+
+user_bitmap *checkBitmap(long ref, const char *what, bool req_valid = false, bool skipError = false)
+{
+	int ind = ref - 10;
+	if(ind >= firstUserGeneratedBitmap && ind < MAX_USER_BITMAPS)
+	{
+		user_bitmap* b = &(scb.script_created_bitmaps[ind]);
+		if(b->reserved())
+		{
+			if(req_valid && !b->u_bmp)
+			{
+				if(skipError) return NULL;
+				Z_scripterrlog("Script attempted to reference an invalid bitmap!\n");
+				Z_scripterrlog("Bitmap with UID = %ld does not have a valid memory bitmap!\n",ref);
+				Z_scripterrlog("Use '->Create()' to create a memory bitmap.\n");
+				return NULL;
+			}
+			return b;
+		}
+	}
+	else
+	{
+		switch(ind)
+		{
+			case rtSCREEN:
+			case rtBMP0:
+			case rtBMP1:
+			case rtBMP2:
+			case rtBMP3:
+			case rtBMP4:
+			case rtBMP5:
+			case rtBMP6:
+				zprint2("Internal error: 'checkBitmap()' recieved ref pointing to system bitmap!\n");
+				zprint2("Please report this as a bug!\n");
+				break;
+		}
+	}
+	if(skipError) return NULL;
+	Z_scripterrlog("Script attempted to reference a nonexistent bitmap!\n");
+	if(what)
+		Z_scripterrlog("You were trying to reference the '%s' of a bitmap with UID = %ld\n", what, ref);
+	else
+		Z_scripterrlog("You were trying to reference with UID = %ld\n", ref);
 	return NULL;
 }
 
@@ -18830,7 +18875,7 @@ void do_drawing_command(const int script_command)
 	{
 		//Z_scripterrlog("Calling %s\n","CLEARBITMAP");
 		set_user_bitmap_command_args(j, 3);
-		script_drawing_commands[j][17] = SH::read_stack(ri->sp+3); 
+		script_drawing_commands[j][17] = SH::read_stack(ri->sp+3);
 		break;
 	}
 	case BMPPOLYGONR:
@@ -18859,14 +18904,14 @@ void do_drawing_command(const int script_command)
 	{
 		//Z_scripterrlog("Calling %s\n","READBITMAP");
 		set_user_bitmap_command_args(j, 2);
-		script_drawing_commands[j][17] = SH::read_stack(ri->sp+2); 
+		script_drawing_commands[j][17] = SH::read_stack(ri->sp+2);
 		string *str = script_drawing_commands.GetString();
 		ArrayH::getString(script_drawing_commands[j][2] / 10000, *str);
 		
-		char *cptr = new char[str->size()+1]; // +1 to account for \0 byte
-		strncpy(cptr, str->c_str(), str->size());
+		//char cptr = new char[str->size()+1]; // +1 to account for \0 byte
+		//strncpy(cptr, str->c_str(), str->size());
 		
-		Z_scripterrlog("READBITMAP string is %s\n", cptr);
+		//Z_scripterrlog("READBITMAP string is %s\n", cptr);
 		
 		script_drawing_commands[j].SetString(str);
 		break;
@@ -18887,6 +18932,7 @@ void do_drawing_command(const int script_command)
 		script_drawing_commands[j].SetString(str);
 		break;
 	}
+	
 	case BMPCIRCLER:	set_user_bitmap_command_args(j, 11); script_drawing_commands[j][17] = SH::read_stack(ri->sp+11);  break;
 	case BMPARCR:	set_user_bitmap_command_args(j, 14); script_drawing_commands[j][17] = SH::read_stack(ri->sp+14);  break;
 	case BMPELLIPSER:	set_user_bitmap_command_args(j, 12); script_drawing_commands[j][17] = SH::read_stack(ri->sp+12);  break;
@@ -22321,13 +22367,53 @@ int run_script(const byte type, const word script, const long i)
 			case BMPBLIT:
 			case BMPBLITTO:
 			case BMPMODE7:
-			case READBITMAP:
 			case WRITEBITMAP:
 			case CLEARBITMAP:
 			case BITMAPCLEARTOCOLOR:
-			case REGENERATEBITMAP:
 				do_drawing_command(scommand);
 				break;
+			case READBITMAP:
+			{
+				int bitref = SH::read_stack(ri->sp+2);
+				if(user_bitmap* b = checkBitmap(bitref,"Read()",false,true))
+					do_drawing_command(scommand);
+				else //If the pointer isn't allocated, attempt to allocate it first
+				{
+					bitref = FFCore.get_free_bitmap();
+					ri->d[3] = bitref; //Return to ptr
+					if(bitref) SH::write_stack(ri->sp+2,bitref); //Write the ref, for the drawing command to read
+					else break; //No ref allocated; don't enqueue the drawing command.
+					do_drawing_command(scommand);
+				}
+				break;
+			}
+			case REGENERATEBITMAP:
+			{
+				int bitref = SH::read_stack(ri->sp+3);
+				if(user_bitmap* b = checkBitmap(bitref,"Create()",false,true))
+					do_drawing_command(scommand);
+				else //If the pointer isn't allocated
+				{
+					long w = SH::read_stack(ri->sp+1) / 10000;
+					long h = SH::read_stack(ri->sp) / 10000;
+					if ( get_bit(quest_rules, qr_OLDCREATEBITMAP_ARGS) )
+					{
+						//flip height and width
+						h = h ^ w;
+						w = h ^ w; 
+						h = h ^ w;
+					}
+					
+					ri->d[3] = FFCore.create_user_bitmap_ex(h,w,8); //Return to ptr
+				}
+				break;
+			}
+			
+			case BITMAPFREE:
+			{
+				FFCore.do_deallocate_bitmap();
+				break;
+			}
 				
 			case COPYTILEVV:
 				do_copytile(true, true);
@@ -24182,60 +24268,11 @@ void FFScript::set_sarg1(int v)
 	set_register(sarg1, v);
 }
 
-void FFScript::do_readbitmap(const bool v)
-{	
-	long arrayptr = SH::get_arg(sarg1, v) / 10000;
-
-	string filename_str;
-
-	ArrayH::getString(arrayptr, filename_str, 512);
-	Z_scripterrlog("ReadBitmap() filename is %s\n",filename_str.c_str());
-	int bit_id = 0;
-		do
-		{
-			bit_id = FFCore.get_free_bitmap();
-		} while (bit_id < firstUserGeneratedBitmap); //be sure not to overlay with system bitmaps!
-		if ( bit_id > 0 )
-		{
-		int bit_id = FFCore.get_free_bitmap();
-		scb.script_created_bitmaps[bit_id].u_bmp = load_bitmap(filename_str.c_str(), RAMpal);
-		if ( scb.script_created_bitmaps[bit_id].u_bmp ) 
-		{
-			ri->bitmapref = bit_id+10;  //set_register(sarg1, bit_id);
-			Z_scripterrlog("Read a bitmap to pointer: %d\n",bit_id+10);
-			Z_scripterrlog("Height is: %d\n",scb.script_created_bitmaps[bit_id].u_bmp->h);
-			Z_scripterrlog("Width is: %d\n",scb.script_created_bitmaps[bit_id].u_bmp->w);
-		}
-		else 
-		{ 
-			ri->bitmapref = 0; 
-			//set_register(sarg1, 0);
-			--scb.num_active; //Free the struct element, because we didn't use it. 
-			Z_scripterrlog("ReadBitmap failed to properly load bitmap filename %s\n", filename_str.c_str());
-		}
-	}
-	else 
-	{ 
-		ri->bitmapref = 0; 
-		//set_register(sarg1, 0);
-		Z_scripterrlog("ReadBitmap failed to acquire a free bitmap.\n");
-	}
-	
-	//Z_eventlog("Script loaded mapdata with ID = %ld\n", ri->idata);
-}
-
-
 //script_bitmaps scb;
 
 long FFScript::do_allocate_bitmap()
 {	
-	int bit_id = 0;
-		do
-	{
-		bit_id = FFCore.get_free_bitmap();
-	} while (bit_id < firstUserGeneratedBitmap); //be sure not to overlay with system bitmaps!
-	if ( bit_id < MAX_USER_BITMAPS ) return bit_id+10;
-	else return 0;
+	return FFCore.get_free_bitmap();
 }
 void FFScript::do_isvalidbitmap()
 {
@@ -24253,45 +24290,25 @@ void FFScript::do_isallocatedbitmap()
 	if ( UID <= 0 ) set_register(sarg1, 0); 
 	else
 	{
+		set_register(sarg1, (scb.script_created_bitmaps[UID-10].reserved()) ? 10000L : 0L);
+		/*
 		UID-=10;
 		if ( UID <= highest_valid_user_bitmap() || UID < firstUserGeneratedBitmap)
 			set_register(sarg1, 10000);
 		else set_register(sarg1, 0);
+		*/
+		
 	}
 }
 
 void FFScript::user_bitmaps_init()
 {
-	scb.num_active = 0;
-	for ( int q = 0; q < MAX_USER_BITMAPS; q++ )
-	{
-		if ( scb.script_created_bitmaps[q].u_bmp != NULL )
-		{
-			destroy_bitmap(scb.script_created_bitmaps[q].u_bmp);
-		}
-		scb.script_created_bitmaps[q].width = 0;
-		scb.script_created_bitmaps[q].height = 0;
-		scb.script_created_bitmaps[q].depth = 0;
-		scb.script_created_bitmaps[q].u_bmp = NULL;
-		
-	}
-}
-
-void FFScript::user_bitmaps_destroy()
-{
-	scb.num_active = 0;
-	for ( int q = 0; q < MAX_USER_BITMAPS; q++ )
-	{
-		if ( scb.script_created_bitmaps[q].u_bmp != NULL )
-		{
-			destroy_bitmap(scb.script_created_bitmaps[q].u_bmp);
-		}
-	}
+	scb.clear();
 }
 
 long FFScript::do_create_bitmap()
 {
-	Z_scripterrlog("Begin running FFCore.do_create_bitmap()\n");
+	//Z_scripterrlog("Begin running FFCore.do_create_bitmap()\n");
 	//CreateBitmap(h,w)
 	long w = (ri->d[1] / 10000);
 	long h = (ri->d[0]/10000);
@@ -24303,84 +24320,26 @@ long FFScript::do_create_bitmap()
 		h = h ^ w;
 	}
 	
-	//sanity checks
-	int id = 0;
-	
-	if ( highest_valid_user_bitmap() >= (MAX_USER_BITMAPS-1) )
-	{
-		//ri->bitmapref = 0;
-		Z_scripterrlog("Script attempted to create a bitmap, but no bitmaps are available. Setting ri->bitmapref to: %d\n", ri->bitmapref);
-		return id;
-	}
-	else
-	{
-		Z_scripterrlog("do_create_bitmap() is %s\n","getting a bitmap ID with create_user_bitmap_ex()");
-		id = create_user_bitmap_ex(h,w,8);
-		Z_scripterrlog("do_create_bitmap() found a free bitmap ID of: %d\n",id);
-		//if ( id < rtSCREEN || id > (MAX_USER_BITMAPS-1) )
-		//{
-		//	ri->bitmapref = 0;
-		//	Z_scripterrlog("Script attempted to create a bitmap with ID %d, but no bitmaps are available.\n Setting ri->bitmapref to: %d\n", id, ri->bitmapref);
-		//}
-		//else
-		//{	
-			if ( id == 0 )
-			{
-				Z_scripterrlog("FFCore.do_create_bitmap() id is %d\n", id);
-				return -2; //ri->bitmapref = -2;
-			}
-			else
-			{
-				return id+10; //ri->bitmapref = id+10; 
-				
-				Z_eventlog("Script created bitmap ID %d, pointer (%d) with height of %d and width of %d\n", id, ri->bitmapref, h,w);
-	
-			}
-			return id+10;
-		//}
-	}
-}
-
-int FFScript::highest_valid_user_bitmap()
-{
-	return (scb.num_active);
+	return create_user_bitmap_ex(h,w,8);
 }
 
 long FFScript::create_user_bitmap_ex(int w, int h, int d = 8)
 {
-	int id = 0;
-	do
-	{
-		id = get_free_bitmap();
-	} while (id < firstUserGeneratedBitmap); //be sure not to overlay with system bitmaps!
+	int id = get_free_bitmap();
 	if ( id > 0 )
 	{
-		scb.script_created_bitmaps[id].width = w;
-		scb.script_created_bitmaps[id].height = h;
-		scb.script_created_bitmaps[id].depth = d;
-		scb.script_created_bitmaps[id].u_bmp = create_bitmap_ex(d,w,h);
-		clear_bitmap(scb.script_created_bitmaps[id].u_bmp);
-	}
-	if ( id == 0 ) 
-	{
-		Z_scripterrlog("FFCore.create_user_bitmap_ex() returned: (%d).\n", id);
+		user_bitmap* bmp = &(scb.script_created_bitmaps[id-10]);
+		bmp->width = w;
+		bmp->height = h;
+		bmp->depth = d;
+		bmp->u_bmp = create_bitmap_ex(d,w,h);
+		clear_bitmap(bmp->u_bmp);
 	}
 	return id;
 }
 
-//Returns the pointer to a user-created bitmap in the struct.
-BITMAP* FFScript::get_user_bitmap(int id)
-{
-	return scb.script_created_bitmaps[id].u_bmp;
-}
-
 BITMAP* FFScript::GetScriptBitmap(int id)
 {
-	//if ( id < MIN_OLD_RENDERTARGETS || id > highest_valid_user_bitmap() ) 
-	//{
-	//	Z_scripterrlog("Attempted to get a bitmap with an invalid bitmap ID: (%d).\n", id);
-	//	return NULL;
-	//}
 	switch(id)
 	{
 		case rtSCREEN:
@@ -24396,48 +24355,56 @@ BITMAP* FFScript::GetScriptBitmap(int id)
 		}
 		default: 
 		{
-			if ( id > highest_valid_user_bitmap() )
+			if(user_bitmap* b = checkBitmap(id+10, NULL, true))
 			{
-				Z_scripterrlog("Attempted to get a bitmap with an invalid bitmap ID: (%d).\n", id);
-				return NULL;
+				return b->u_bmp;
 			}
-			else return  get_user_bitmap(id);
+			else return NULL;
 		}
 	}
 }
 
-int FFScript::get_free_bitmap()
+int FFScript::get_free_bitmap(bool skipError)
 {
-	int num_free = scb.num_active;
-	if ( num_free < ( MAX_USER_BITMAPS-1 ) )
+	user_bitmap* bmps = scb.script_created_bitmaps;
+	for(int q = MIN_USER_BITMAPS; q < MAX_USER_BITMAPS; ++q)
 	{
-		++scb.num_active;
-		//Z_scripterrlog("get_free_bitmap() found a valid free bitmap with an ID of: %d\n",num_free);
-		return scb.num_active;
+		if(!bmps[q].reserved())
+		{
+			bmps[q].reserve();
+			return q+10;
+		}
 	}
-	Z_scripterrlog("get_free_bitmap() could not find a valid free bitmap!%s\n"," ");
+	if(!skipError) Z_scripterrlog("get_free_bitmap() could not find a valid free bitmap pointer!\n");
 	return 0;
 }
 
-bool FFScript::cleanup_user_bitmaps()
+void FFScript::do_deallocate_bitmap()
 {
-	for ( int q = 0; q < scb.num_active; q++ )
+	if(isSystemBitref(ri->bitmapref))
 	{
-		if ( scb.script_created_bitmaps[q].u_bmp != NULL )
-		{
-			destroy_bitmap(scb.script_created_bitmaps[q].u_bmp);
-		}
+		return; //Don't attempt to deallocate system bitmaps!
 	}
-	return true; //so that we know when we're done
+	user_bitmap* b = checkBitmap(ri->bitmapref, "Free()", false, true);
+	if(b)
+	{
+		b->free();
+	}
 }
 
-bool FFScript::destroy_user_bitmap(int id)
+bool FFScript::isSystemBitref(long ref)
 {
-	if ( scb.script_created_bitmaps[id].u_bmp != NULL )
+	switch(ref-10)
 	{
-		//destroy it
-		destroy_bitmap(scb.script_created_bitmaps[id].u_bmp);
-		return true;
+		case rtSCREEN:
+		case rtBMP0:
+		case rtBMP1:
+		case rtBMP2:
+		case rtBMP3:
+		case rtBMP4:
+		case rtBMP5:
+		case rtBMP6:
+			return true;
 	}
 	return false;
 }
@@ -26030,15 +25997,6 @@ void FFScript::init()
 long FFScript::getQuestHeaderInfo(int type)
 {
 	return quest_format[type];
-}
-
-bool FFScript::checkPath(const char* path, const bool is_dir)
-{
-	struct stat info;
-
-	if(stat( path, &info ) != 0)
-		return false;
-	else return is_dir ? (info.st_mode & S_IFDIR)!=0 : (info.st_mode & S_IFDIR)==0;
 }
 
 void FFScript::do_checkdir(const bool is_dir)
@@ -30734,6 +30692,8 @@ script_command ZASMcommands[NUMCOMMANDS+1]=
 	{ "FILESEEK",           2,   0,   0,   0},
 	{ "FILEOPENMODE",           2,   0,   0,   0},
 	{ "FILEGETERROR",           1,   0,   0,   0},
+	
+	{ "BITMAPFREE",           0,   0,   0,   0},
 	
 	{ "",                    0,   0,   0,   0}
 };

--- a/src/parser/ByteCode.cpp
+++ b/src/parser/ByteCode.cpp
@@ -4713,6 +4713,10 @@ string OWriteBitmap::toString()
 {
     return "WRITEBITMAP";
 }
+string OBitmapFree::toString()
+{
+    return "BITMAPFREE";
+}
 
 string OIsValidBitmap::toString()
 {

--- a/src/parser/ByteCode.h
+++ b/src/parser/ByteCode.h
@@ -7975,6 +7975,16 @@ namespace ZScript
 		}
 	};
 	
+	class OBitmapFree : public Opcode
+	{
+	public:
+		std::string toString();
+		Opcode *clone()
+		{
+			return new OBitmapFree();
+		}
+	};
+	
 	class OBMPDrawScreenSolidRegister : public Opcode
 	{
 	public:

--- a/src/parser/GlobalSymbols.cpp
+++ b/src/parser/GlobalSymbols.cpp
@@ -2895,7 +2895,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new ORectangleRegister());
         LABELBACK(label);
-        POP_ARGS(12, EXP2);
+        POP_ARGS(12, NUL);
         //pop pointer, and ignore it
         POPREF();
         RETURN();
@@ -2909,7 +2909,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OCircleRegister());
         LABELBACK(label);
-        POP_ARGS(11, EXP2);
+        POP_ARGS(11, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -2923,7 +2923,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OArcRegister());
         LABELBACK(label);
-        POP_ARGS(14, EXP2);
+        POP_ARGS(14, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -2937,7 +2937,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OEllipseRegister());
         LABELBACK(label);
-        POP_ARGS(12, EXP2);
+        POP_ARGS(12, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -2951,7 +2951,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OLineRegister());
         LABELBACK(label);
-        POP_ARGS(11, EXP2);
+        POP_ARGS(11, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -2965,7 +2965,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OSplineRegister());
         LABELBACK(label);
-        POP_ARGS(11, EXP2);
+        POP_ARGS(11, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -2979,7 +2979,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OPutPixelRegister());
         LABELBACK(label);
-        POP_ARGS(8, EXP2);
+        POP_ARGS(8, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -2993,7 +2993,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OPutPixelArrayRegister());
         LABELBACK(label);
-        POP_ARGS(5, EXP2);
+        POP_ARGS(5, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3007,7 +3007,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OPutTileArrayRegister());
         LABELBACK(label);
-        POP_ARGS(2, EXP2);
+        POP_ARGS(2, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3021,7 +3021,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OFastComboArrayRegister());
         LABELBACK(label);
-        POP_ARGS(2, EXP2);
+        POP_ARGS(2, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3035,7 +3035,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OPutLinesArrayRegister());
         LABELBACK(label);
-        POP_ARGS(2, EXP2);
+        POP_ARGS(2, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3049,7 +3049,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new ODrawCharRegister());
         LABELBACK(label);
-        POP_ARGS(10, EXP2);
+        POP_ARGS(10, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3063,7 +3063,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new ODrawIntRegister());
         LABELBACK(label);
-        POP_ARGS(11, EXP2);
+        POP_ARGS(11, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3077,7 +3077,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new ODrawTileRegister());
         LABELBACK(label);
-        POP_ARGS(15, EXP2);
+        POP_ARGS(15, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3091,7 +3091,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new ODrawTileCloakedRegister());
         LABELBACK(label);
-        POP_ARGS(7, EXP2);
+        POP_ARGS(7, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3105,7 +3105,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new ODrawComboRegister());
         LABELBACK(label);
-        POP_ARGS(16, EXP2);
+        POP_ARGS(16, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3119,7 +3119,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new ODrawComboCloakedRegister());
         LABELBACK(label);
-        POP_ARGS(7, EXP2);
+        POP_ARGS(7, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3133,7 +3133,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OQuadRegister());
         LABELBACK(label);
-        POP_ARGS(15, EXP2);
+        POP_ARGS(15, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3148,7 +3148,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OPolygonRegister());
         LABELBACK(label);
-        POP_ARGS(5, EXP2);
+        POP_ARGS(5, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3163,7 +3163,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OTriangleRegister());
         LABELBACK(label);
-        POP_ARGS(13, EXP2);
+        POP_ARGS(13, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3178,7 +3178,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OQuad3DRegister());
         LABELBACK(label);
-        POP_ARGS(8, EXP2);
+        POP_ARGS(8, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3192,7 +3192,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OTriangle3DRegister());
         LABELBACK(label);
-        POP_ARGS(8, EXP2);
+        POP_ARGS(8, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3207,7 +3207,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OFastTileRegister());
         LABELBACK(label);
-        POP_ARGS(6, EXP2);
+        POP_ARGS(6, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3221,7 +3221,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new OFastComboRegister());
         LABELBACK(label);
-        POP_ARGS(6, EXP2);
+        POP_ARGS(6, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3235,7 +3235,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new ODrawStringRegister());
         LABELBACK(label);
-        POP_ARGS(9, EXP2);
+        POP_ARGS(9, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3249,7 +3249,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new ODrawLayerRegister());
         LABELBACK(label);
-        POP_ARGS(8, EXP2);
+        POP_ARGS(8, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3263,7 +3263,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new ODrawScreenRegister());
         LABELBACK(label);
-        POP_ARGS(6, EXP2);
+        POP_ARGS(6, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3277,7 +3277,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new ODrawBitmapRegister());
         LABELBACK(label);
-        POP_ARGS(12, EXP2);
+        POP_ARGS(12, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -3292,7 +3292,7 @@ void ScreenSymbols::generateCode()
         vector<Opcode *> code;
         code.push_back(new ODrawBitmapExRegister());
         LABELBACK(label);
-        POP_ARGS(16, EXP2);
+        POP_ARGS(16, NUL);
         //pop pointer, and ignore it
         POPREF();
         
@@ -8381,6 +8381,7 @@ static AccessorTable BitmapTable[] =
 	{ "Create",                 ZVARTYPEID_VOID,          FUNCTION,     0,                    1,             0,                                    4,           {  ZVARTYPEID_BITMAP,          ZVARTYPEID_FLOAT,                               ZVARTYPEID_FLOAT,                           ZVARTYPEID_FLOAT,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
 	{ "Polygon",                ZVARTYPEID_VOID,          FUNCTION,     0,                    1,             0,                                    6,           {  ZVARTYPEID_BITMAP,         ZVARTYPEID_FLOAT,         ZVARTYPEID_FLOAT,         ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     ZVARTYPEID_FLOAT,     -1,     -1,     -1,     -1,         -1,     -1,     -1,     -1,     -1,  -1,                         -1,                           -1,                           -1,                           -1,                           } },
 	{ "ClearToColor",           ZVARTYPEID_VOID,          FUNCTION,     0,                    1,             FUNCFLAG_INLINE,                      3,           {  ZVARTYPEID_BITMAP,          ZVARTYPEID_FLOAT,                               ZVARTYPEID_FLOAT,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
+	{ "Free",                   ZVARTYPEID_VOID,          FUNCTION,     0,                    1,             FUNCFLAG_INLINE,                      1,           {  ZVARTYPEID_BITMAP,                -1,         -1,    -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1,                           -1                           } },
 	
 
 	{ "",                       -1,                       -1,           -1,                   -1,            0,                                    0,           { -1,                   -1,                     -1,               -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 } }
@@ -8433,7 +8434,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPRectangleRegister());
 		LABELBACK(label);
-		POP_ARGS(12, EXP2);
+		POP_ARGS(12, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
 		RETURN();
@@ -8447,11 +8448,11 @@ void BitmapSymbols::generateCode()
 		int label = function->getLabel();
 		vector<Opcode *> code;
 		code.push_back(new OReadBitmap());
+		REASSIGN_PTR(EXP2);
 		LABELBACK(label);
-		POP_ARGS(2, EXP2);
+		POP_ARGS(2, NUL);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(EXP2)));
-		
+		POPREF();
 		RETURN();
 		function->giveCode(code);
 
@@ -8464,7 +8465,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OClearBitmap());
 		LABELBACK(label);
-		POP_ARGS(1, EXP2);
+		POP_ARGS(1, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
 		
@@ -8479,10 +8480,11 @@ void BitmapSymbols::generateCode()
 		int label = function->getLabel();
 		vector<Opcode *> code;
 		code.push_back(new ORegenerateBitmap());
+		REASSIGN_PTR(EXP2);
 		LABELBACK(label);
-		POP_ARGS(3, EXP2);
+		POP_ARGS(3, NUL);
 		//pop pointer, and ignore it
-		code.push_back(new OPopRegister(new VarArgument(EXP2)));
+		POPREF();
 		
 		RETURN();
 		function->giveCode(code);
@@ -8495,7 +8497,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OWriteBitmap());
 		LABELBACK(label);
-		POP_ARGS(3, EXP2);
+		POP_ARGS(3, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
 		RETURN();
@@ -8509,7 +8511,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPCircleRegister());
 		LABELBACK(label);
-		POP_ARGS(11, EXP2);
+		POP_ARGS(11, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8523,7 +8525,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPArcRegister());
 		LABELBACK(label);
-		POP_ARGS(14, EXP2);
+		POP_ARGS(14, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8537,7 +8539,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPEllipseRegister());
 		LABELBACK(label);
-		POP_ARGS(12, EXP2);
+		POP_ARGS(12, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8551,7 +8553,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPLineRegister());
 		LABELBACK(label);
-		POP_ARGS(11, EXP2);
+		POP_ARGS(11, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8565,7 +8567,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPSplineRegister());
 		LABELBACK(label);
-		POP_ARGS(11, EXP2);
+		POP_ARGS(11, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8579,7 +8581,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPPutPixelRegister());
 		LABELBACK(label);
-		POP_ARGS(8, EXP2);
+		POP_ARGS(8, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8593,7 +8595,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawCharRegister());
 		LABELBACK(label);
-		POP_ARGS(10, EXP2);
+		POP_ARGS(10, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8607,7 +8609,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawIntRegister());
 		LABELBACK(label);
-		POP_ARGS(11, EXP2);
+		POP_ARGS(11, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8621,7 +8623,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawTileRegister());
 		LABELBACK(label);
-		POP_ARGS(15, EXP2);
+		POP_ARGS(15, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8635,7 +8637,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawTileCloakedRegister());
 		LABELBACK(label);
-		POP_ARGS(7, EXP2);
+		POP_ARGS(7, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8649,7 +8651,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawComboRegister());
 		LABELBACK(label);
-		POP_ARGS(16, EXP2);
+		POP_ARGS(16, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8663,7 +8665,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawComboCloakedRegister());
 		LABELBACK(label);
-		POP_ARGS(7, EXP2);
+		POP_ARGS(7, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8677,7 +8679,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPQuadRegister());
 		LABELBACK(label);
-		POP_ARGS(16, EXP2);
+		POP_ARGS(16, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8692,7 +8694,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPPolygonRegister());
 		LABELBACK(label);
-		POP_ARGS(5, EXP2);
+		POP_ARGS(5, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8707,7 +8709,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPTriangleRegister());
 		LABELBACK(label);
-		POP_ARGS(14, EXP2);
+		POP_ARGS(14, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8722,7 +8724,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPQuad3DRegister());
 		LABELBACK(label);
-		POP_ARGS(9, EXP2);
+		POP_ARGS(9, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8736,7 +8738,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPTriangle3DRegister());
 		LABELBACK(label);
-		POP_ARGS(9, EXP2);
+		POP_ARGS(9, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8751,7 +8753,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPFastTileRegister());
 		LABELBACK(label);
-		POP_ARGS(6, EXP2);
+		POP_ARGS(6, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8765,7 +8767,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPFastComboRegister());
 		LABELBACK(label);
-		POP_ARGS(6, EXP2);
+		POP_ARGS(6, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8779,7 +8781,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawStringRegister());
 		LABELBACK(label);
-		POP_ARGS(9, EXP2);
+		POP_ARGS(9, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8793,7 +8795,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawLayerRegister());
 		LABELBACK(label);
-		POP_ARGS(8, EXP2);
+		POP_ARGS(8, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8807,7 +8809,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawScreenCIFlagRegister());
 		LABELBACK(label);
-		POP_ARGS(8, EXP2);
+		POP_ARGS(8, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8821,7 +8823,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawScreenCFlagRegister());
 		LABELBACK(label);
-		POP_ARGS(8, EXP2);
+		POP_ARGS(8, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8835,7 +8837,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawScreenSolidMaskRegister());
 		LABELBACK(label);
-		POP_ARGS(8, EXP2);
+		POP_ARGS(8, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8849,7 +8851,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawScreenCTypeRegister());
 		LABELBACK(label);
-		POP_ARGS(8, EXP2);
+		POP_ARGS(8, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8864,7 +8866,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawScreenSolidityRegister());
 		LABELBACK(label);
-		POP_ARGS(8, EXP2);
+		POP_ARGS(8, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8878,7 +8880,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawScreenRegister());
 		LABELBACK(label);
-		POP_ARGS(6, EXP2);
+		POP_ARGS(6, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8893,7 +8895,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawScreenSolidRegister());
 		LABELBACK(label);
-		POP_ARGS(6, EXP2);
+		POP_ARGS(6, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8908,7 +8910,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawScreenSolid2Register());
 		LABELBACK(label);
-		POP_ARGS(6, EXP2);
+		POP_ARGS(6, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8922,7 +8924,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawScreenComboTRegister());
 		LABELBACK(label);
-		POP_ARGS(6, EXP2);
+		POP_ARGS(6, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8936,7 +8938,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawScreenComboFRegister());
 		LABELBACK(label);
-		POP_ARGS(6, EXP2);
+		POP_ARGS(6, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8950,7 +8952,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawScreenComboIRegister());
 		LABELBACK(label);
-		POP_ARGS(6, EXP2);
+		POP_ARGS(6, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
         
@@ -8966,7 +8968,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPDrawBitmapExRegister());
 		LABELBACK(label);
-		POP_ARGS(16, EXP2);
+		POP_ARGS(16, NUL);
 		//pop pointer, and ignore it
 		POPREF();
         
@@ -8980,7 +8982,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPMode7());
 		LABELBACK(label);
-		POP_ARGS(13, EXP2);
+		POP_ARGS(13, NUL);
 		//pop pointer, and ignore it
 		POPREF();
         
@@ -8994,7 +8996,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPBlitTO());
 		LABELBACK(label);
-		POP_ARGS(16, EXP2);
+		POP_ARGS(16, NUL);
 		//pop pointer, and ignore it
 		POPREF();
         
@@ -9008,7 +9010,7 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBMPBlitTO());
 		LABELBACK(label);
-		POP_ARGS(16, EXP2);
+		POP_ARGS(16, NUL);
 		//pop pointer, and ignore it
 		POPREF();
         
@@ -9048,13 +9050,26 @@ void BitmapSymbols::generateCode()
 		vector<Opcode *> code;
 		code.push_back(new OBitmapClearToColor());
 		LABELBACK(label);
-		POP_ARGS(2, EXP2);
+		POP_ARGS(2, NUL);
 		//pop pointer, and ignore it
 		code.push_back(new OPopRegister(new VarArgument(EXP2)));
 		
 		RETURN();
 		function->giveCode(code);
 
+	}
+	//void Free(bitmap)
+	{
+		Function* function = getFunction("Free", 1);
+		int label = function->getLabel();
+		vector<Opcode *> code;
+		//pop pointer
+		ASSERT_NON_NUL();
+		POPREF();
+		LABELBACK(label);
+		code.push_back(new OBitmapFree());
+		RETURN();
+		function->giveCode(code);
 	}
 }
 

--- a/src/script_drawing.h
+++ b/src/script_drawing.h
@@ -5,10 +5,8 @@
 #include <vector>
 #include <string>
 
-
 #define MAX_SCRIPT_DRAWING_COMMANDS 10000
 #define SCRIPT_DRAWING_COMMAND_VARIABLES 20
-
 
 // For Quad and Triangle. *allegro Bug-Fix* -Gleeok
 class SmallBitmapTextureCache
@@ -306,17 +304,7 @@ public:
         //small_tex_cache.Init();
     }
     
-    void Clear()
-    {
-        if(commands.empty())
-            return;
-            
-        //only clear what was used.
-        memset((void*)&commands[0], 0, count * sizeof(CScriptDrawingCommandVars));
-        count = 0;
-        
-        draw_container.Clear();
-    }
+    void Clear();
     
     int Count() const
     {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -185,5 +185,14 @@ namespace util
 		return chmod(path,mode);
 #endif
 	}
+
+	bool checkPath(const char* path, const bool is_dir)
+	{
+		struct stat info;
+
+		if(stat( path, &info ) != 0)
+			return false;
+		else return is_dir ? (info.st_mode & S_IFDIR)!=0 : (info.st_mode & S_IFDIR)==0;
+	}
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -24,6 +24,7 @@ namespace util
 	bool create_path(const char* path);
 	char* zc_itoa(int value, char* str, int base);
 	int zc_chmod(const char* path, mode_t mode);
+	bool checkPath(const char* path, const bool is_dir);
 }
 
 #endif

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -5347,6 +5347,7 @@ int main(int argc, char* argv[])
 			memset(disabledKeys, 0, sizeof(disabledKeys));
 			memset(disable_control, 0, sizeof(disable_control));
 			FFCore.user_files_init(); //Clear open FILE*!
+			FFCore.user_bitmaps_init(); //Clear open bitmaps
 		}
 		//Deallocate ALL ZScript arrays on ANY exit.
 		FFCore.deallocateAllArrays();

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -35657,18 +35657,7 @@ script_bitmaps scb;
 //script_bitmaps scb;
 void FFScript::user_bitmaps_init()
 {
-	scb.num_active = 0;
-	for ( int q = 0; q < MAX_USER_BITMAPS; q++ )
-	{
-		if ( scb.script_created_bitmaps[q].u_bmp != NULL )
-		{
-			destroy_bitmap(scb.script_created_bitmaps[q].u_bmp);
-		}
-		scb.script_created_bitmaps[q].width = 0;
-		scb.script_created_bitmaps[q].height = 0;
-		scb.script_created_bitmaps[q].depth = 0;
-		scb.script_created_bitmaps[q].u_bmp = NULL;
-	}
+	scb.clear();
 }
 
 void FFScript::user_files_init(){}


### PR DESCRIPTION
New bitmap allocation system. Now, pointers can be re-used after being
	freed by a call to '->Free()'.
Also: '->Create()' and '->Read()' work on non-initialized and invalid
	pointers, automatically allocating a new pointer. This creation
	is NOT deferred to draw-time; as it reassigns to the pointer.
Fixed crash on trying to '->Read()' from non-existant file.
Changed success messages for 'Read()'/'Write()' to debug, from error.
Changed 'POP_ARGS()' calls to pop to 'NUL', instead of 'EXP2'.
Fixed memory leak in 'bitmap->Read()'.
Commented out various traces relating to bitmaps.