### PR TITLE
Feat: Add sfx option on tallgrass and on shallow water.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,6 @@
 
 //Alpha 79
 
-```
 Added Combo Type (Step->Effects). At present, this
 	would allow for playing a SFX when stepping on the combo, with
 	no side effects. It plays the sound if it is both not already

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -16780,6 +16780,20 @@ void LinkClass::checkspecial2(int *ls)
 	if ( thesfx > 0 && !sfx_allocated(thesfx) && action==walking )
 		sfx(thesfx,pan((int)x));
     }
+    else if(type==cTALLGRASS||type==cTALLGRASSTOUCHY||type==cTALLGRASSNEXT)
+    { 
+	//We probably only want to do this when the player is moving.
+	int thesfx = combobuf[MAPCOMBO(tx+8,ty+8)].attribytes[2];
+	if ( thesfx > 0 && !sfx_allocated(thesfx) && action==walking )
+		sfx(thesfx,pan((int)x));
+    }
+    else if(type==cSHALLOWWATER)
+    { 
+	//We probably only want to do this when the player is moving.
+	int thesfx = combobuf[MAPCOMBO(tx+8,ty+8)].attribytes[0];
+	if ( thesfx > 0 && !sfx_allocated(thesfx) && action==walking )
+		sfx(thesfx,pan((int)x));
+    }
     else stepnext = -1;
     
     detail_int[0]=tx;

--- a/src/zq_tiles.cpp
+++ b/src/zq_tiles.cpp
@@ -16884,12 +16884,12 @@ static ComboAttributesInfo comboattrinfo[]=
 	{
 		cTALLGRASS,
 		{ (char *)"Visuals", (char *)"Itemdrop", NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
-		{ NULL,NULL,NULL,NULL},{ (char *)"Sprite", (char *)"Dropset", NULL, NULL }
+		{ NULL,NULL,NULL,NULL},{ (char *)"Sprite", (char *)"Dropset", (char*)"Sound", NULL }
 	},
 	{
 		cSHALLOWWATER,
 		{ NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
-		{ NULL,NULL,NULL,NULL},{ NULL,NULL,NULL,NULL}
+		{ NULL,NULL,NULL,NULL},{ (char*)"Sound",NULL,NULL,NULL}
 	},
 	{
 		cLOCKBLOCK,
@@ -17281,7 +17281,7 @@ static ComboAttributesInfo comboattrinfo[]=
 	{
 		cTALLGRASSTOUCHY,
 		{ (char *)"Visuals", (char *)"Itemdrop", NULL,NULL,NULL,NULL,NULL,NULL,NULL,(char*)"Clippings",(char*)"Specific Item",NULL,NULL,NULL,NULL,NULL},
-		{ NULL,NULL,NULL,NULL},{ (char *)"Sprite", (char *)"Dropset", NULL, NULL }
+		{ NULL,NULL,NULL,NULL},{ (char *)"Sprite", (char *)"Dropset", (char*)"Sound", NULL }
 	},
 	{
 		cSLASHNEXTTOUCHY,
@@ -17307,7 +17307,7 @@ static ComboAttributesInfo comboattrinfo[]=
 	{
 		cTALLGRASSNEXT,
 		{ (char *)"Visuals", (char *)"Itemdrop", NULL,NULL,NULL,NULL,NULL,NULL,NULL,(char*)"Clippings",(char*)"Specific Item",NULL,NULL,NULL,NULL,NULL},
-		{ NULL,NULL,NULL,NULL},{ (char *)"Sprite", (char *)"Dropset", NULL, NULL }
+		{ NULL,NULL,NULL,NULL},{ (char *)"Sprite", (char *)"Dropset", (char*)"Sound", NULL }
 	},
 	{
 		cSCRIPT1,


### PR DESCRIPTION
Changelog: The following combo types now have a sfx option, that will play
	an ambient sound when Link walks over them , while action==walking
	and that sound is not playing:
	Shallow Water
	Tall Grass
	Tall Grass->Next
	Tall Grass (Touchy)