### PR TITLE
Standard Conformance, level 3 warnings, and const rules

### DIFF
--- a/allegro/include/allegro/inline/fmaths.inl
+++ b/allegro/include/allegro/inline/fmaths.inl
@@ -57,7 +57,7 @@ AL_INLINE(double, fixtof, (fixed x),
 
 AL_INLINE(fixed, fixadd, (fixed x, fixed y),
 {
-   fixed result = x + y;
+   const fixed result = x + y;
 
    if (result >= 0) {
       if ((x < 0) && (y < 0)) {
@@ -80,7 +80,7 @@ AL_INLINE(fixed, fixadd, (fixed x, fixed y),
 
 AL_INLINE(fixed, fixsub, (fixed x, fixed y),
 {
-   fixed result = x - y;
+   const fixed result = x - y;
 
    if (result >= 0) {
       if ((x < 0) && (y > 0)) {

--- a/allegro/include/allegro/inline/gfx.inl
+++ b/allegro/include/allegro/inline/gfx.inl
@@ -101,7 +101,7 @@ AL_INLINE(void, clear_to_color, (BITMAP *bitmap, int color),
 })
 
 
-AL_INLINE(int, bitmap_color_depth, (BITMAP *bmp),
+AL_INLINE(int, bitmap_color_depth, (const BITMAP *bmp),
 {
    ASSERT(bmp);
 
@@ -109,7 +109,7 @@ AL_INLINE(int, bitmap_color_depth, (BITMAP *bmp),
 })
 
 
-AL_INLINE(int, bitmap_mask_color, (BITMAP *bmp),
+AL_INLINE(int, bitmap_mask_color, (const BITMAP *bmp),
 {
    ASSERT(bmp);
 
@@ -117,7 +117,7 @@ AL_INLINE(int, bitmap_mask_color, (BITMAP *bmp),
 })
 
 
-AL_INLINE(int, is_same_bitmap, (BITMAP *bmp1, BITMAP *bmp2),
+AL_INLINE(int, is_same_bitmap, (const BITMAP *bmp1, const BITMAP *bmp2),
 {
    unsigned long m1;
    unsigned long m2;
@@ -135,7 +135,7 @@ AL_INLINE(int, is_same_bitmap, (BITMAP *bmp1, BITMAP *bmp2),
 })
 
 
-AL_INLINE(int, is_linear_bitmap, (BITMAP *bmp),
+AL_INLINE(int, is_linear_bitmap, (const BITMAP* bmp),
 {
    ASSERT(bmp);
 
@@ -143,7 +143,7 @@ AL_INLINE(int, is_linear_bitmap, (BITMAP *bmp),
 })
 
 
-AL_INLINE(int, is_planar_bitmap, (BITMAP *bmp),
+AL_INLINE(int, is_planar_bitmap, (const BITMAP* bmp),
 {
    ASSERT(bmp);
 
@@ -151,7 +151,7 @@ AL_INLINE(int, is_planar_bitmap, (BITMAP *bmp),
 })
 
 
-AL_INLINE(int, is_memory_bitmap, (BITMAP *bmp),
+AL_INLINE(int, is_memory_bitmap, (const BITMAP* bmp),
 {
    ASSERT(bmp);
 
@@ -159,7 +159,7 @@ AL_INLINE(int, is_memory_bitmap, (BITMAP *bmp),
 })
 
 
-AL_INLINE(int, is_screen_bitmap, (BITMAP *bmp),
+AL_INLINE(int, is_screen_bitmap, (const BITMAP* bmp),
 {
    ASSERT(bmp);
 
@@ -167,7 +167,7 @@ AL_INLINE(int, is_screen_bitmap, (BITMAP *bmp),
 })
 
 
-AL_INLINE(int, is_video_bitmap, (BITMAP *bmp),
+AL_INLINE(int, is_video_bitmap, (const BITMAP* bmp),
 {
    ASSERT(bmp);
 
@@ -175,7 +175,7 @@ AL_INLINE(int, is_video_bitmap, (BITMAP *bmp),
 })
 
 
-AL_INLINE(int, is_system_bitmap, (BITMAP *bmp),
+AL_INLINE(int, is_system_bitmap, (const BITMAP *bmp),
 {
    ASSERT(bmp);
 
@@ -183,7 +183,7 @@ AL_INLINE(int, is_system_bitmap, (BITMAP *bmp),
 })
 
 
-AL_INLINE(int, is_sub_bitmap, (BITMAP *bmp),
+AL_INLINE(int, is_sub_bitmap, (const BITMAP *bmp),
 {
    ASSERT(bmp);
 
@@ -232,7 +232,7 @@ AL_INLINE(void, release_screen, (void),
 #endif
 
 
-AL_INLINE(int, is_inside_bitmap, (BITMAP *bmp, int x, int y, int clip),
+AL_INLINE(int, is_inside_bitmap, (const BITMAP* bmp, int x, int y, int clip),
 {
    ASSERT(bmp);
 
@@ -267,7 +267,7 @@ AL_INLINE(void, set_clip_state, (BITMAP *bitmap, int state),
    bitmap->clip = state;
 })
 
-AL_INLINE(int, get_clip_state, (BITMAP *bitmap),
+AL_INLINE(int, get_clip_state, (const BITMAP* bitmap),
 {
    ASSERT(bitmap);
 

--- a/allegro/include/allegro/internal/alconfig.h
+++ b/allegro/include/allegro/internal/alconfig.h
@@ -400,7 +400,7 @@
 
    AL_INLINE(int, bmp_read24, (uintptr_t addr),
    {
-      unsigned char *p = (unsigned char *)addr;
+      const unsigned char* p = (const unsigned char*)addr;
       int c;
 
       c = READ3BYTES(p);

--- a/src/ConsoleLogger.h
+++ b/src/ConsoleLogger.h
@@ -125,7 +125,7 @@ protected:
 		)
 	{
 		EnterCriticalSection();
-		BOOL bRet = ::WriteFile(hFile,lpBuffer,nNumberOfBytesToWrite,lpNumberOfBytesWritten,lpOverlapped);
+		const BOOL bRet = ::WriteFile(hFile,lpBuffer,nNumberOfBytesToWrite,lpNumberOfBytesWritten,lpOverlapped);
 		LeaveCriticalSection();
 		return bRet;
 	}
@@ -218,7 +218,7 @@ protected:
 	{	// Thnx to this function, the "Helper" can see that we are "extended" logger !!!
 		// (so we can use the same helper-child-application for both loggers
 		DWORD cbWritten=0;
-		char *ptr="Extended-Console: TRUE\r\n";
+		const char* ptr="Extended-Console: TRUE\r\n";
 		WriteFile(m_hPipe,ptr,strlen(ptr),&cbWritten,NULL);
 		return (cbWritten==strlen(ptr)) ? 0 : -1;
 	}

--- a/src/compat_config.h
+++ b/src/compat_config.h
@@ -1,0 +1,31 @@
+/***
+* Author: Samer Charif
+* Desciption: Mainly used for suppressing compiler warnings and to 
+*             ease in new lanaguage features when the time comes
+* Date: 8/18/2020
+**/
+
+/* keywords */
+#if (__cplusplus >= 201103L)
+/* constexpr is a keyword */
+#else
+#define constexpr const
+#endif /* (__cplusplus >= 201103L) */
+
+/***
+* Attributes - C++17 is checked first because those are where the standard defines them
+**/
+#if (__cplusplus >= 201704L)
+#define _MAYBE_UNSUED(x) x [[maybe_unused]]
+#define _FALLTHROUGH [[fallthrough]]
+#elif defined(__GNUC__) || defined(__clang__)
+#define _MAYBE_UNSUED(x) x __attribute__((unused))
+#define _FALLTHROUGH __attribute__((fallthrough))
+#elif defined(_MSC_VER)
+#define _MAYBE_UNUSED(x) static_cast<void>(x)
+#define _FALLTHROUGH __fallthrough /* annotates depending on your compiler, sometimes does nothing */
+#else
+#define _MAYBE_UNUSED(x) static_cast<void>(x)
+#define _FALLTHROUGH /* no standard way to do it */
+#endif /* (__cplusplus >= 201704L) */
+

--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -30939,9 +30939,9 @@ void FFScript::do_arraycpy(const bool a, const bool b)
 	long arrayptr_b = SH::get_arg(sarg1, a) / 10000;
 	long arrayptr_a = SH::get_arg(sarg2, b) / 10000;
 	long *P = NULL;
-	FFCore.getValues(arrayptr_a,P, FFCore.getSize(arrayptr_a));
+	FFCore.getValues(arrayptr_a,P, static_cast<word>(FFCore.getSize(arrayptr_a)));
 	//ZScriptArray& a = FFCore.getArray(arrayptr_a);
-	FFCore.setArray(arrayptr_b, FFCore.getSize(arrayptr_a), P);
+	FFCore.setArray(arrayptr_b, static_cast<word>(FFCore.getSize(arrayptr_a)), P);
 
 	//if(ArrayH::setArray(arrayptr_b, a.size(), a) == SH::_Overflow)
 	//	Z_scripterrlog("Dest string supplied to 'ArrayCopy()' not large enough\n");

--- a/src/ffscript.h
+++ b/src/ffscript.h
@@ -317,12 +317,12 @@ struct user_file
 	{
 		if(file) fclose(file);
 		file = NULL;
-		int r = remove(filepath.c_str());
+		const int r = remove(filepath.c_str());
 		filepath = "";
 		return r;
 	}
 	
-	void setPath(char* buf)
+	void setPath(const char* buf)
 	{
 		if(buf)
 			filepath = buf;
@@ -548,7 +548,7 @@ void do_savegamestructs(const bool v, const bool v2);
 void do_loadgamestructs(const bool v, const bool v2);
 
 int combo_script_engine(const bool preload);
-int FFScript::combo_script_engine_waitdraw(const bool preload);
+int combo_script_engine_waitdraw(const bool preload);
 
 void do_strstr();
 void do_strcat();
@@ -1499,7 +1499,7 @@ enum __Error
             
         if(ptr >= NUM_ZSCRIPT_ARRAYS) //Then it's a global
         {
-            long gptr = ptr - NUM_ZSCRIPT_ARRAYS;
+            const long gptr = ptr - NUM_ZSCRIPT_ARRAYS;
             
             if(gptr > (long)game->globalRAM.size())
                 return InvalidError(ptr);
@@ -1517,7 +1517,7 @@ enum __Error
     
     size_t getSize(const long ptr)
     {
-        ZScriptArray& a = getArray(ptr);
+		const ZScriptArray& a = getArray(ptr);
         
         if(a == INVALIDARRAY)
             return size_t(-1);

--- a/src/guys.cpp
+++ b/src/guys.cpp
@@ -325,7 +325,7 @@ bool flyerblocked(int dx, int dy, int special, guydata const& gd)
 
   */
 
-eFire::eFire(enemy const & other, bool new_script_uid, bool clear_parent_script_UID):
+eFire::eFire(const enemy& other, bool new_script_uid, bool clear_parent_script_UID):
 	 //Struct Element			Type		Purpose
 	//sprite(other),
 	enemy(other),

--- a/src/guys.h
+++ b/src/guys.h
@@ -321,7 +321,7 @@ public:
 	virtual void draw(BITMAP *dest);
 	virtual int takehit(weapon *w);
 	virtual void break_shield();
-	eFire::eFire(enemy const & other, bool new_script_uid, bool clear_parent_script_UID);
+	eFire(const enemy& other, bool new_script_uid, bool clear_parent_script_UID);
 };
 
 class eOther : public enemy

--- a/src/link.h
+++ b/src/link.h
@@ -33,6 +33,7 @@
 #include "zc_custom.h"
 #include "subscr.h"
 #include "zfix.h"
+#include "compat_config.h"
 
 extern movingblock mblock2;                                 //mblock[4]?
 extern sprite_list  guys, items, Ewpns, Lwpns, Sitems, chainlinks, decorations;
@@ -518,12 +519,12 @@ void paymagiccost(int itemid, bool ignoreTimer = false);
 int Bweapon(int pos);
 void stopCaneOfByrna();
 //void selectWpn(int xstep, int ystep, bool b);
-const int SEL_UP = 0;
-const int SEL_LEFT = 1;
-const int SEL_DOWN = 2;
-const int SEL_RIGHT = 3;
-const int SEL_VERIFY_LEFT = 4;
-const int SEL_VERIFY_RIGHT = 5;
+constexpr int SEL_UP = 0;
+constexpr int SEL_LEFT = 1;
+constexpr int SEL_DOWN = 2;
+constexpr int SEL_RIGHT = 3;
+constexpr int SEL_VERIFY_LEFT = 4;
+constexpr int SEL_VERIFY_RIGHT = 5;
 int selectWpn_new(int type, int startpos, int forbiddenpos = -1);
 bool isWpnPressed(int wpn);
 int getWpnPressed(int wpn);

--- a/src/maps.cpp
+++ b/src/maps.cpp
@@ -641,6 +641,7 @@ int WARPCODE(int dmap,int scr,int dw)
 void update_combo_cycling()
 {
     int x,y;
+    _MAYBE_UNUSED(y);
     static int newdata[176];
     static int newcset[176];
     static int newdata2[176];

--- a/src/parser/CompilerUtils.h
+++ b/src/parser/CompilerUtils.h
@@ -3,6 +3,8 @@
 #ifndef ZSCRIPT_COMPILER_UTILS_H
 #define ZSCRIPT_COMPILER_UTILS_H
 
+#include "../compat_config.h"
+
 #include <cassert>
 #include <vector>
 #include <set>
@@ -21,7 +23,7 @@ std::string to_string(Type val)
 	return oss.str();
 }
 
-int const formatBufferSize = 4096;
+constexpr int formatBufferSize = 4096;
 
 /*
 namespace ZScript

--- a/src/parser/GlobalSymbols.h
+++ b/src/parser/GlobalSymbols.h
@@ -2,6 +2,8 @@
 #define GLOBALSYMBOLS_H
 
 #include "DataStructs.h"
+#include "../compat_config.h"
+
 #include <string>
 #include <map>
 #include <vector>
@@ -18,9 +20,9 @@ namespace ZScript
 	class Scope;
 }
 
-static const int SETTER = 0;
-static const int GETTER = 1;
-static const int FUNCTION = 2;
+static constexpr int SETTER = 0;
+static constexpr int GETTER = 1;
+static constexpr int FUNCTION = 2;
 
 struct AccessorTable
 {

--- a/src/parser/Scope.h
+++ b/src/parser/Scope.h
@@ -201,7 +201,9 @@ namespace ZScript
 	// Lookup
 
 	// Attempt to resolve name to a type id under scope.
-	DataType const* lookupDataType(Scope const& scope, std::string const& name, ASTExprIdentifier& host, CompileErrorHandler* errorHandler, bool isTypedefCheck = false, bool forceSkipUsing = false);
+	const DataType* lookupDataType(const Scope& scope, const std::string& name,
+								   const ASTExprIdentifier& host, CompileErrorHandler* errorHandler, 
+								   bool isTypedefCheck = false, bool forceSkipUsing = false);
 	DataType const* lookupDataType(Scope const& scope, ASTExprIdentifier& host, CompileErrorHandler* errorHandler, bool isTypedefCheck = false);
 	
 	// Attempt to resolve name to a script type id under scope.
@@ -211,7 +213,7 @@ namespace ZScript
 	ZClass* lookupClass(Scope const&, std::string const& name);
 
 	// Attempt to resolve name to a variable under scope.
-	Datum* lookupDatum(Scope &, std::string const& name, ASTExprIdentifier& host, CompileErrorHandler* errorHandler, bool forceSkipUsing = false);
+	Datum* lookupDatum(const Scope&, const std::string& name, const ASTExprIdentifier& host, CompileErrorHandler* errorHandler, bool forceSkipUsing = false);
 	Datum* lookupDatum(Scope &, ASTExprIdentifier& host, CompileErrorHandler* errorHandler);
 	
 	// Attempt to resolve name to a getter under scope.
@@ -225,7 +227,7 @@ namespace ZScript
 	
 	// Attempt to resolve name to possible functions under scope.
 	std::vector<Function*> lookupFunctions(
-			Scope&, std::string const& name, std::vector<DataType const*> const& parameterTypes, bool noUsing);
+		const Scope&, const std::string& name, const std::vector<const DataType*>& parameterTypes, bool noUsing);
 	std::vector<Function*> lookupFunctions(
 			Scope&, std::vector<std::string> const& name, std::vector<std::string> const& delimiters, std::vector<DataType const*> const& parameterTypes, bool noUsing);
 			

--- a/src/parser/SemanticAnalyzer.cpp
+++ b/src/parser/SemanticAnalyzer.cpp
@@ -954,7 +954,7 @@ void SemanticAnalyzer::caseExprCall(ASTExprCall& host, void* param)
 		// Count number of casts.
 		Function& function = **it;
 		int castCount = 0;
-		for (int i = 0; i < parameterTypes.size(); ++i)
+		for (size_t i = 0; i < parameterTypes.size(); ++i)
 		{
 			DataType const& from = getNaiveType(*parameterTypes[i], scope);
 			DataType const& to = getNaiveType(*function.paramTypes[i], scope);

--- a/src/parser/Types.h
+++ b/src/parser/Types.h
@@ -222,7 +222,7 @@ namespace ZScript
 	
 	static DataTypeId getTypeId(std::string name)
 	{
-		if(int v = atoi(name.c_str()))
+		if(const int v = atoi(name.c_str()))
 			return v;
 		else if(name == "UNTYPED")
 			return ZVARTYPEID_UNTYPED;

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -284,7 +284,7 @@ Namespace :
 		ASTExprIdentifier* idens = (ASTExprIdentifier*)$2;
 		std::vector<std::string> components = idens->components;
 		std::string name = components.front();
-		int size = idens->components.size();
+		const int size = idens->components.size();
 		if(size == 1)
 		{
 			ASTNamespace* namesp = (ASTNamespace*)$4;
@@ -691,7 +691,7 @@ Annotated_Script :
 		ASTAnnotationList* list = (ASTAnnotationList*)$1;
 		owning_vector<ASTAnnotation>& set = list->set;
 		ASTScript* script = (ASTScript*)$2;
-		for(int q = 0; q < set.size(); ++q)
+		for(size_t q = 0; q < set.size(); ++q)
 		{
 			ASTAnnotation* a = set[q];
 			std::string key = a->first->getValue();
@@ -1453,7 +1453,7 @@ Literal :
 		ASTFloat* val = (ASTFloat*)$1;
 		$$ = new ASTNumberLiteral(val, @$);}
 	| SINGLECHAR {
-		ASTString* as = (ASTString*)$1;
+		const ASTString* as = (const ASTString*)$1;
 		char val[15];
 		sprintf(val, "%d", as->getValue().at(1));
 		ASTFloat* number = new ASTFloat(val, (ASTFloat::Type)0, @$);

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -2603,6 +2603,7 @@ int readheader(PACKFILE *f, zquestheader *Header, bool keepdata, byte printmetad
 				{
 					switch(tempheader.build)
 					{
+                        case 0: _FALLTHROUGH;
 						default:
 						zprint2("Last saved in ZC Editor Version: 2.55.0, Alpha Build ID: %d\n", tempheader.build); break;	
 					}
@@ -2612,6 +2613,7 @@ int readheader(PACKFILE *f, zquestheader *Header, bool keepdata, byte printmetad
 				{
 					switch(tempheader.build)
 					{
+                        case 0: _FALLTHROUGH;
 						default:
 						zprint2("Last saved in ZC Editor Version: 2.54.0, Alpha Build ID: %d\n", tempheader.build); break;	
 					}
@@ -15613,6 +15615,7 @@ int readcolordata(PACKFILE *f, miscQdata *Misc, word version, word build, word s
 int readtiles(PACKFILE *f, tiledata *buf, zquestheader *Header, word version, word build, word start_tile, int max_tiles, bool from_init, bool keepdata)
 {
     int dummy;
+    _MAYBE_UNUSED(dummy);
     int tiles_used=0;
 	word section_version = 0;
 	word section_cversion = 0;

--- a/src/qst.h
+++ b/src/qst.h
@@ -261,9 +261,9 @@ INLINE int skipcombos(PACKFILE *f, zquestheader *Header, word version, word buil
 {
     return readcombos(f, Header, version, build, start_combo, max_combos, false);
 }
-INLINE int skipcolordata(PACKFILE *f, zquestheader *Header, miscQdata *Misc, word version, word build, word start_cset, word max_csets)
+INLINE int skipcolordata(PACKFILE *f, const zquestheader *Header, miscQdata *Misc, word version, word build, word start_cset, word max_csets)
 {
-    (void)Header;
+    _MAYBE_UNUSED(Header);
     return readcolordata(f, Misc, version, build, start_cset, max_csets, false);
 }
 INLINE int skipstrings(PACKFILE *f, zquestheader *Header, word version, word build, word start_string, word max_strings)

--- a/src/script_drawing.cpp
+++ b/src/script_drawing.cpp
@@ -15,6 +15,8 @@
 #include "ffscript.h"
 #include "util.h"
 #include "subscr.h"
+#include "compat_config.h"
+
 using namespace util;
 extern FFScript FFCore;
 extern ZModule zcm;
@@ -779,7 +781,8 @@ void do_ellipser(BITMAP *bmp, int *sdci, int xoffset, int yoffset)
     {
         int x;
         int y;
-        
+		_MAYBE_UNUSED(x);
+		_MAYBE_UNUSED(y);
         // This is very slow, so check the smallest possible square
         int endx=zc_min(bmp->w-1, x1+zc_max(radx, rady));
         int endy=zc_min(bmp->h-1, y1+zc_max(radx, rady));
@@ -4395,7 +4398,9 @@ void bmp_do_ellipser(BITMAP *bmp, int *sdci, int xoffset, int yoffset)
     {
         int x;
         int y;
-        
+		_MAYBE_UNUSED(x);
+		_MAYBE_UNUSED(y);
+
         // This is very slow, so check the smallest possible square
         int endx=zc_min(bmp->w-1, x1+zc_max(radx, rady));
         int endy=zc_min(bmp->h-1, y1+zc_max(radx, rady));

--- a/src/script_drawing.h
+++ b/src/script_drawing.h
@@ -26,7 +26,7 @@ public:
         if(is_init)
             return;
             
-        int size[4] = { 16, 32, 64, 128 };
+        const int size[4] = { 16, 32, 64, 128 };
         
         for(int i(0); i < 4; ++i)
         {

--- a/src/zc_sys.cpp
+++ b/src/zc_sys.cpp
@@ -54,6 +54,8 @@
 #include "mem_debug.h"
 #include "zconsole.h"
 #include "ffscript.h"
+#include "compat_config.h"
+
 extern FFScript FFCore;
 extern bool Playing;
 int sfx_voice[WAV_COUNT];
@@ -7180,12 +7182,13 @@ int onVidMode()
 //Added an extra statement, so that if the key is cleared to 0, the cleared
 //keybinding status need not be unique. -Z ( 1st April, 2019 )
 
-static enum uKey
+/*static*/ enum uKey
 {
 	ukey_a, ukey_b, ukey_s, ukey_l, ukey_r, ukey_p, ukey_ex1, ukey_ex2, ukey_ex3, ukey_ex4,
 	ukey_du, ukey_dd, ukey_dl, ukey_dr, ukey_mod1a, ukey_mod1b, ukey_mod2a, ukey_mod2b,
 	num_ukey
 };
+
 
 static void load_ukeys(int* arr)
 {

--- a/src/zconsole.h
+++ b/src/zconsole.h
@@ -1,9 +1,9 @@
 #ifndef _zc_win_console_h_
 #define _zc_win_console_h_
 
+#include "compat_config.h"
 
 #ifdef _WIN32
-
 #define WIN32_LEAN_AND_MEAN
 #define WIN32_EXTRA_LEAN
 #include <windows.h>
@@ -50,7 +50,7 @@ public:
             
         singleton.isOpen = true;
         
-        const int MAX_CONSOLE_LINES = 512;
+        constexpr int MAX_CONSOLE_LINES = 512;
         
         CONSOLE_SCREEN_BUFFER_INFO console_info;
         int hConHandle;
@@ -124,7 +124,7 @@ public:
             
         singleton.isOpen = true;
         
-        const int MAX_ZASM_LINES = 32768;
+        constexpr int MAX_ZASM_LINES = 32768;
         
         CONSOLE_SCREEN_BUFFER_INFO console_info;
         int hConHandle;
@@ -136,7 +136,7 @@ public:
         
         // set the screen buffer to be big enough to scroll text
         GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &console_info);
-        console_info.dwSize.Y = MAX_ZASM_LINES;
+        console_info.dwSize.Y = static_cast<SHORT>(MAX_ZASM_LINES);
         SetConsoleScreenBufferSize(GetStdHandle(STD_OUTPUT_HANDLE), console_info.dwSize);
         
         

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -107,6 +107,7 @@
 #include "zc_alleg.h"
 #include "gamedata.h"
 #include "zc_array.h"
+#include "compat_config.h"
 
 #define ZELDA_VERSION       0x0255                         //version of the program
 #define ZC_VERSION 25500 //Version ID for ZScript Game->Version
@@ -3136,14 +3137,14 @@ struct MsgStr
 	}
 	
 	// Copy text data - just s and nextstring
-	void copyText(MsgStr& other)
+	void copyText(const MsgStr& other)
 	{
 		strncpy(s, other.s, MSGSIZE+1);
 		nextstring=other.nextstring;
 	}
 	
 	// Copy style data - everything except s, nextstring, and listpos
-	void copyStyle(MsgStr& other)
+	void copyStyle(const MsgStr& other)
 	{
 		tile=other.tile;
 		cset=other.cset;
@@ -4396,7 +4397,7 @@ INLINE bool p_igetl(void *p,PACKFILE *f,bool keepdata)
 INLINE bool p_igetd(void *p, PACKFILE *f, bool keepdata)
 {
     long temp;
-    bool result = p_igetl(&temp,f,keepdata);
+    const bool result = p_igetl(&temp,f,keepdata);
     *(int *)p=(int)temp;
     return result;
 }
@@ -4615,7 +4616,7 @@ INLINE bool p_mputl(long c,PACKFILE *f)
     return success;
 }
 
-INLINE bool isinRect(int x,int y,int rx1,int ry1,int rx2,int ry2)
+INLINE constexpr bool isinRect(int x,int y,int rx1,int ry1,int rx2,int ry2)
 {
     return x>=rx1 && x<=rx2 && y>=ry1 && y<=ry2;
 }

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -57,6 +57,8 @@
 #include "ffasm.h"
 #include "qst.h"
 #include "util.h"
+#include "compat_config.h"
+
 using namespace util;
 extern FFScript FFCore; //the core script engine.
 extern byte epilepsyFlashReduction;
@@ -210,7 +212,7 @@ void throttleFPS()
 			{
 				// bugfix: win xp/7/8 have incompatible timers.
 				// preserve 60 fps and CPU based on user settings. -Gleeok
-				int ms = t >= 16 ? 0 : frame_rest_suggest;
+                const int ms = t >= 16 ? 0 : frame_rest_suggest;
                 rest(ms);
 				t += frame_rest_suggest;
 			}
@@ -848,7 +850,8 @@ int donew_shop_msg(int itmstr, int shopstr)
 			dismissmsg();
 	
 	int tempmsg;
-	int tempmsgnext = MsgStrings[shopstr].nextstring; //store the next string
+    _MAYBE_UNUSED(tempmsg);
+    const int tempmsgnext = MsgStrings[shopstr].nextstring; //store the next string
 	//Disabling this for now.
 	/*
 	while ( tempmsgnext != 0 )
@@ -905,7 +908,7 @@ int donew_shop_msg(int itmstr, int shopstr)
     cursor_y=msg_margins[up];
     return tempmsgnext;
 }
-void zc_trans_blit(BITMAP* dest, BITMAP* src, int sx, int sy, int dx, int dy, int w, int h)
+void zc_trans_blit(BITMAP* dest, const BITMAP* src, int sx, int sy, int dx, int dy, int w, int h)
 {
 	for(int tx = 0; tx < w; ++tx)
 		for(int ty = 0; ty < h; ++ty)
@@ -928,7 +931,7 @@ void msg_bg(MsgStr const& msg)
 	}
 	else
 	{
-		int add = (get_bit(quest_rules,qr_STRING_FRAME_OLD_WIDTH_HEIGHT)!=0 ? 2 : 0);
+        const int add = (get_bit(quest_rules,qr_STRING_FRAME_OLD_WIDTH_HEIGHT)!=0 ? 2 : 0);
         frame2x2(msg_bg_bmp_buf,&QMisc,0,0,msg.tile,msg.cset,
                  (msg.w>>3)+add,(msg.h>>3)+add,0,true,0);
 	}
@@ -1932,7 +1935,7 @@ int init_game()
     
 //Load the quest
     //setPackfilePassword(datapwd);
-    int ret = load_quest(game);
+    const int ret = load_quest(game);
     
     if(ret != qe_OK)
     {
@@ -1951,7 +1954,7 @@ int init_game()
     replace_extension(keyfilename3, qstpath, "zcheat", 2047);
     bool gotfromkey=false;
     bool gotfrompwdfile=false;
-    bool gotfromcheatfile=false;
+    constexpr bool gotfromcheatfile=false;
     
     if(exists(keyfilename))
     {
@@ -2097,14 +2100,14 @@ int init_game()
 		size_t pos = str.find_last_of("/\\");
 		if(pos==string::npos) pos=0;
 		else ++pos;
-		size_t dotpos = str.find_last_of(".");
+        const size_t dotpos = str.find_last_of(".");
 		sprintf(qst_files_path,"%sFiles/%s/",get_config_string("zeldadx", qst_dir_name, "./"),str.substr(pos, dotpos-pos).c_str());
 		regulate_path(qst_files_path);
 		// zprint2("Calculated path: '%s'\n",qst_files_path);
 		// zprint2("Path creating... %s\n",create_path(qst_files_path)?"Success!":"Failure!");
 	}
 	
-    bool firstplay = (game->get_hasplayed() == 0);
+    const bool firstplay = (game->get_hasplayed() == 0);
     
     BSZ = get_bit(quest_rules,qr_BSZELDA)!=0;
     //setuplinktiles(zinit.linkanimationstyle);
@@ -2227,6 +2230,7 @@ int init_game()
 				{
 					switch(QHeader.build)
 					{
+                        case 0: _FALLTHROUGH;
 						default:
 						zprint2("Last saved in ZC Editor Version: 2.55.0, Alpha Build ID: %d\n", QHeader.build); break;	
 					}
@@ -2236,6 +2240,7 @@ int init_game()
 				{
 					switch(QHeader.build)
 					{
+                        case 0: _FALLTHROUGH;
 						default:
 						zprint2("Last saved in ZC Editor Version: 2.54.0, Alpha Build ID: %d\n", QHeader.build); break;	
 					}
@@ -2422,7 +2427,7 @@ int init_game()
 //load the previous weapons -DD
     zprint2("last_quest_was_BA_subscreen prior to init is: %s\n", ((last_quest_was_BA_subscreen) ? "true" : "false") );
     
-    bool usesaved = (game->get_quest() == 0xFF); //What was wrong with firstplay?
+    const bool usesaved = (game->get_quest() == 0xFF); //What was wrong with firstplay?
     int apos = 0;
     int bpos = 0;
     
@@ -2875,7 +2880,7 @@ void do_magic_casting()
     static byte linktilebuf[256];
     int ltile=0;
     int lflip=0;
-    bool shieldModify=true;
+    constexpr bool shieldModify=true;
     
     if(magicitem==-1)
     {
@@ -2930,7 +2935,7 @@ void do_magic_casting()
             if(get_bit(quest_rules,qr_MORESOUNDS))
                 sfx(itemsbuf[magicitem].usesound,pan(int(Link.getX())));
                 
-            int flamemax=itemsbuf[magicitem].misc1;
+            const int flamemax=itemsbuf[magicitem].misc1;
             
             for(int flamecounter=((-1)*(flamemax/2))+1; flamecounter<=((flamemax/2)+1); flamecounter++)
             {
@@ -3014,14 +3019,14 @@ void do_magic_casting()
                         if(itemsbuf[magicitem].misc1==1)  // Twilight
                         {
                             particles.add(new pTwilight(Link.getX()+j, Link.getY()-Link.getZ()+i, 5, 0, 0, (rand()%8)+i*4));
-                            int k=particles.Count()-1;
+                            const int k=particles.Count()-1;
                             particle *p = (particle*)(particles.spr(k));
                             p->step=3;
                         }
                         else if(itemsbuf[magicitem].misc1==2)  // Sands of Hours
                         {
                             particles.add(new pTwilight(Link.getX()+j, Link.getY()-Link.getZ()+i, 5, 1, 2, (rand()%16)+i*2));
-                            int k=particles.Count()-1;
+                            const int k=particles.Count()-1;
                             particle *p = (particle*)(particles.spr(k));
                             p->step=4;
                             
@@ -3035,7 +3040,7 @@ void do_magic_casting()
                         {
                             particles.add(new pFaroresWindDust(Link.getX()+j, Link.getY()-Link.getZ()+i, 5, 6, linktilebuf[i*16+j], rand()%96));
                             
-                            int k=particles.Count()-1;
+                            const int k=particles.Count()-1;
                             particle *p = (particle*)(particles.spr(k));
                             p->angular=true;
                             p->angle=rand();
@@ -3050,7 +3055,7 @@ void do_magic_casting()
         if((magiccastclk++)>=226)
         {
             //attackclk=0;
-            int nayrutemp=nayruitem;
+            const int nayrutemp=nayruitem;
             restart_level();
             nayruitem=nayrutemp;
             //xofs=0;
@@ -3088,13 +3093,13 @@ void do_magic_casting()
         {
             for(int i=0; i<Lwpns.Count(); i++)
             {
-                weapon* w=static_cast<weapon*>(Lwpns.spr(i));
+                const weapon* w=static_cast<const weapon*>(Lwpns.spr(i));
                 if(w->id==wPhantom &&
                   w->type>=pNAYRUSLOVEROCKET1 && w->type<=pNAYRUSLOVEROCKETTRAILRETURN2)
                     Lwpns.del(i);
             }
             
-            int d=zc_max(LinkX(),256-LinkX())+32;
+            const int d=zc_max(LinkX(),256-LinkX())+32;
             Lwpns.add(new weapon((zfix)(LinkX()-d),(zfix)LinkY(),(zfix)LinkZ(),wPhantom,pNAYRUSLOVEROCKETRETURN1,0,right, magicitem,Link.getUID()));
             weapon *w1 = (weapon*)(Lwpns.spr(Lwpns.Count()-1));
             w1->step=4;
@@ -3145,7 +3150,7 @@ void do_magic_casting()
         {
             for(int i=0; i<Lwpns.Count(); i++)
             {
-                weapon* w=static_cast<weapon*>(Lwpns.spr(i));
+                const weapon* w=static_cast<const weapon*>(Lwpns.spr(i));
                 if(w->id==wPhantom &&
                   w->type>=pNAYRUSLOVEROCKET1 && w->type<=pNAYRUSLOVEROCKETTRAILRETURN2)
                     Lwpns.del(i);
@@ -3181,7 +3186,7 @@ void update_hookshot()
     
     if(check_hs)
     {
-        int parentitem = ((weapon*)Lwpns.spr(Lwpns.idFirst(wHookshot)))->parentitem;
+        const int parentitem = ((const weapon*)Lwpns.spr(Lwpns.idFirst(wHookshot)))->parentitem;
         hs_x=Lwpns.spr(Lwpns.idFirst(wHookshot))->x;
         hs_y=Lwpns.spr(Lwpns.idFirst(wHookshot))->y;
         hs_z=Lwpns.spr(Lwpns.idFirst(wHookshot))->z;
@@ -3191,7 +3196,7 @@ void update_hookshot()
         //extending
         if(((weapon*)Lwpns.spr(Lwpns.idFirst(wHookshot)))->misc==0)
         {
-            int maxchainlinks=itemsbuf[parentitem].misc2;
+            const int maxchainlinks=itemsbuf[parentitem].misc2;
             
             if(chainlinks.Count()<maxchainlinks)           //extending chain
             {
@@ -3352,7 +3357,7 @@ void do_dcounters()
                 if(i!=1)   // Only rupee drain is sounded
                     sfxon = false;
                     
-                int drain = (i==4 ? 2*game->get_magicdrainrate() : 1);
+                const int drain = (i==4 ? 2*game->get_magicdrainrate() : 1);
                 
                 if(game->get_counter(i)>0)
                 {
@@ -3474,7 +3479,7 @@ void game_loop()
     
     // freezemsg if message is being printed && qr_MSGFREEZE is on,
     // or if a message is being prepared && qr_MSGDISAPPEAR is on.
-    bool freezemsg = ((msg_active || (intropos && intropos<72) || (linkedmsgclk && get_bit(quest_rules,qr_MSGDISAPPEAR)))
+    const bool freezemsg = ((msg_active || (intropos && intropos<72) || (linkedmsgclk && get_bit(quest_rules,qr_MSGDISAPPEAR)))
                       && get_bit(quest_rules,qr_MSGFREEZE));
                       
     // Messages also freeze FF combos.
@@ -3819,8 +3824,8 @@ void game_loop()
 	#endif
         if(!freezemsg && current_item(itype_heartring))
         {
-            int itemid = current_item_id(itype_heartring);
-            int fskip = itemsbuf[itemid].misc2;
+            const int itemid = current_item_id(itype_heartring);
+            const int fskip = itemsbuf[itemid].misc2;
             
             if(fskip == 0 || frame % fskip == 0)
                 game->set_life(zc_min(game->get_life() + itemsbuf[itemid].misc1, game->get_maxlife()));
@@ -3830,8 +3835,8 @@ void game_loop()
 	#endif
         if(!freezemsg && current_item(itype_magicring))
         {
-            int itemid = current_item_id(itype_magicring);
-            int fskip = itemsbuf[itemid].misc2;
+            const int itemid = current_item_id(itype_magicring);
+            const int fskip = itemsbuf[itemid].misc2;
             
             if(fskip == 0 || frame % fskip == 0)
             {
@@ -3843,8 +3848,8 @@ void game_loop()
 	#endif
         if(!freezemsg && current_item(itype_wallet))
         {
-            int itemid = current_item_id(itype_wallet);
-            int fskip = itemsbuf[itemid].misc2;
+            const int itemid = current_item_id(itype_wallet);
+            const int fskip = itemsbuf[itemid].misc2;
             
             if(fskip == 0 || frame % fskip == 0)
             {
@@ -3856,7 +3861,7 @@ void game_loop()
 	#endif
         if(!freezemsg && current_item(itype_bombbag))
         {
-            int itemid = current_item_id(itype_bombbag);
+            const int itemid = current_item_id(itype_bombbag);
             
             if(itemsbuf[itemid].misc1)
             {
@@ -3869,7 +3874,7 @@ void game_loop()
                 
                 if(itemsbuf[itemid].flags & ITEM_FLAG1)
                 {
-                    int ratio = zinit.bomb_ratio;
+                    const int ratio = zinit.bomb_ratio;
                     
                     fskip = itemsbuf[itemid].misc2 * ratio;
                     
@@ -3885,8 +3890,8 @@ void game_loop()
 	#endif
         if(!freezemsg && current_item(itype_quiver) && game->get_arrows() != game->get_maxarrows())
         {
-            int itemid = current_item_id(itype_quiver);
-            int fskip = itemsbuf[itemid].misc2;
+            const int itemid = current_item_id(itype_quiver);
+            const int fskip = itemsbuf[itemid].misc2;
             
             if(fskip == 0 || frame % fskip == 0)
             {
@@ -4033,10 +4038,10 @@ void shiftColour(int rshift, int gshift, int bshift, int base)
 	for(int i=0; i <= 0xEF; i++)
 	{
 		if(base==baseUNIFORM){//Recolor the palette to uniform greyscale before tinting
-			int grey = (RAMpal[i].r+RAMpal[i].g+RAMpal[i].b)/3;
+            const int grey = (RAMpal[i].r+RAMpal[i].g+RAMpal[i].b)/3;
 			RAMpal[i] = _RGB(grey,grey,grey);
 		} else if(base==baseDISTRIBUTED){//Recolor the palette to distributed greyscale before tinting
-			int grey = 0.299*RAMpal[i].r + 0.587*RAMpal[i].g + 0.114*RAMpal[i].b;
+            const int grey = 0.299*RAMpal[i].r + 0.587*RAMpal[i].g + 0.114*RAMpal[i].b;
 			RAMpal[i] = _RGB(grey,grey,grey);
 		}
 		//Bit-shifting negatives throws errors. If negative, shift in the other direction.
@@ -4060,8 +4065,8 @@ void shiftColour(int rshift, int gshift, int bshift, int base)
 
 void setMonochromatic(int mode)
 {
-	int base = mode < baseDISTRIBUTED ? baseUNIFORM : baseDISTRIBUTED; //distributed is an additive flag adding 10
-	int colour_mode = mode - base;
+    const int base = mode < baseDISTRIBUTED ? baseUNIFORM : baseDISTRIBUTED; //distributed is an additive flag adding 10
+    const int colour_mode = mode - base;
 	if(isUserTinted()){
 		memcpy(RAMpal, tempgreypal, PAL_SIZE*sizeof(RGB));
 		isUserTinted(false); //Disable custom tint, override with monochrome
@@ -4121,10 +4126,10 @@ void addColour(int radd, int gadd, int badd, int base)
 	for(int i=0; i <= 0xEF; i++)
 	{
 		if(base==baseUNIFORM){//Recolor the palette to uniform greyscale before tinting
-			int grey = (RAMpal[i].r+RAMpal[i].g+RAMpal[i].b)/3;
+            const int grey = (RAMpal[i].r+RAMpal[i].g+RAMpal[i].b)/3;
 			RAMpal[i] = _RGB(grey,grey,grey);
 		} else if(base==baseDISTRIBUTED){//Recolor the palette to distributed greyscale before tinting
-			int grey = 0.299*RAMpal[i].r + 0.587*RAMpal[i].g + 0.114*RAMpal[i].b;
+            const int grey = 0.299*RAMpal[i].r + 0.587*RAMpal[i].g + 0.114*RAMpal[i].b;
 			RAMpal[i] = _RGB(grey,grey,grey);
 		}
 		//Add the r/g/b adds to the r/g/b values, clamping between 0 and 63.
@@ -4334,7 +4339,7 @@ static Triplebuffer;
 
 bool setGraphicsMode(bool windowed)
 {
-    int type=windowed ? GFX_AUTODETECT_WINDOWED : GFX_AUTODETECT_FULLSCREEN;
+    const int type=windowed ? GFX_AUTODETECT_WINDOWED : GFX_AUTODETECT_FULLSCREEN;
     return set_gfx_mode(type, resx, resy, 0, 0)==0;
 }
 
@@ -4357,7 +4362,7 @@ int onFullscreen()
 	    get_palette(oldpal);
 	    
 	    show_mouse(NULL);
-	    bool windowed=is_windowed_mode()!=0;
+        const bool windowed=is_windowed_mode()!=0;
 	    
 	    // these will become ultra corrupted no matter what.
 	    Triplebuffer.Destroy();
@@ -4392,7 +4397,7 @@ int onFullscreen()
 	    set_palette(oldpal);
 	    gui_mouse_focus=0;
 	    show_mouse(screen);
-	    int switch_type = pause_in_background ? SWITCH_PAUSE : SWITCH_BACKGROUND;
+        const int switch_type = pause_in_background ? SWITCH_PAUSE : SWITCH_BACKGROUND;
 	    set_display_switch_mode(fullscreen?SWITCH_BACKAMNESIA:switch_type);
 	//	set_display_switch_callback(SWITCH_OUT, switch_out_callback);/
 	//	set_display_switch_callback(SWITCH_IN,switch_in_callback);
@@ -4935,7 +4940,7 @@ int main(int argc, char* argv[])
     
     //  int mode = VidMode;                                       // from config file
     int tempmode=GFX_AUTODETECT;
-    int res_arg = used_switch(argc,argv,"-res");
+    const int res_arg = used_switch(argc,argv,"-res");
     
     if(used_switch(argc,argv,"-v0")) Throttlefps=false;
     
@@ -4975,7 +4980,7 @@ int main(int argc, char* argv[])
         slot_arg2=1;
     }
     
-    int fast_start = debug_enabled || used_switch(argc,argv,"-fast") || get_config_int("zeldadx","skiplogo",0) || (!standalone_mode && (load_save || (slot_arg && (argc>(slot_arg+1)))));
+    const int fast_start = debug_enabled || used_switch(argc,argv,"-fast") || get_config_int("zeldadx","skiplogo",0) || (!standalone_mode && (load_save || (slot_arg && (argc>(slot_arg+1)))));
     skip_title = used_switch(argc, argv, "-notitle") > 0;
     int save_arg = used_switch(argc,argv,"-savefile");
     
@@ -5299,8 +5304,9 @@ int main(int argc, char* argv[])
         Z_message("used switch: -triplebuffer\n");
     }
     
-    const int wait_ms_on_set_graphics = 20; //formerly 250. -Gleeok
-    
+    constexpr int wait_ms_on_set_graphics = 20; //formerly 250. -Gleeok
+    // initlization skipped if goto is used
+    const int switch_type = pause_in_background ? SWITCH_PAUSE : SWITCH_BACKGROUND;
     // quick quit
     if(used_switch(argc,argv,"-q"))
     {
@@ -5314,8 +5320,8 @@ int main(int argc, char* argv[])
     {
         resx = atoi(argv[res_arg+1]);
         resy = atoi(argv[res_arg+2]);
-        bool old_sbig = (argc>(res_arg+3))? stricmp(argv[res_arg+3],"big")==0 : 0;
-        bool old_sbig2 = (argc>(res_arg+3))? stricmp(argv[res_arg+3],"big2")==0 : 0;
+        const bool old_sbig = (argc>(res_arg+3))? stricmp(argv[res_arg+3],"big")==0 : 0;
+        const bool old_sbig2 = (argc>(res_arg+3))? stricmp(argv[res_arg+3],"big2")==0 : 0;
         
 //    mode = GFX_AUTODETECT;
     }
@@ -5403,7 +5409,6 @@ int main(int argc, char* argv[])
     }
     
     sbig = (screen_scale > 1);
-    int switch_type = pause_in_background ? SWITCH_PAUSE : SWITCH_BACKGROUND;
     set_display_switch_mode(is_windowed_mode()?SWITCH_PAUSE:switch_type);zq_screen_w = resx;
     zq_screen_h = resy;
     
@@ -5427,11 +5432,11 @@ int main(int argc, char* argv[])
     {
         clear_to_color(screen,BLACK);
         system_pal();
-        int ret=jwin_alert3("Multiple Instances",
-                            "Another instance of ZC is already running.",
-                            "Running multiple instances may cause your",
-                            "save file to be deleted. Continue anyway?",
-                            "&No","&Yes", 0, 'n', 'y', 0, lfont);
+        const int ret=jwin_alert3("Multiple Instances",
+                                  "Another instance of ZC is already running.",
+                                  "Running multiple instances may cause your",
+                                  "save file to be deleted. Continue anyway?",
+                                  "&No","&Yes", 0, 'n', 'y', 0, lfont);
         if(ret!=2)
         {
             if(forceExit)

--- a/src/zfix.h
+++ b/src/zfix.h
@@ -6,19 +6,24 @@
 #ifndef ZFIX_H
 #define ZFIX_H
 #include "zdefs.h"
+#include "compat_config.h"
 #include <math.h>
 #include <limits>
+
+#ifndef NAN
 #define NAN 0
+#endif // !NAN
+
 //std::numeric_limits<t>::quiet_NaN()
 
 typedef int32_t ZLong;
 
 class zfix;
 inline zfix zslongToFix(ZLong val);
-inline ZLong toZLong(float val);
-inline ZLong toZLong(double val);
-inline ZLong toZLong(int val);
-inline ZLong toZLong(long val);
+inline constexpr ZLong toZLong(float val);
+inline constexpr ZLong toZLong(double val);
+inline constexpr ZLong toZLong(int val);
+inline constexpr ZLong toZLong(long val);
 inline zfix floor(zfix fx);
 inline zfix abs(zfix fx);
 
@@ -142,8 +147,8 @@ public:
 	zfix& operator ++ ()				{ val += 10000; return *this; }
 	zfix& operator -- ()				{ val -= 10000; return *this; }
 	
-	zfix operator ++ (int)				{ zfix t = copy(); val += 10000; return t; }
-	zfix operator -- (int)				{ zfix t = copy(); val -= 10000; return t; }
+	zfix operator ++ (int)				{ const zfix t = copy(); val += 10000; return t; }
+	zfix operator -- (int)				{ const zfix t = copy(); val -= 10000; return t; }
 	
 	zfix operator - () const			{ zfix t; t.val = -val; return t; }
 	

--- a/src/zfix.inl
+++ b/src/zfix.inl
@@ -6,19 +6,21 @@
 #ifndef ZFIX_INL
 #define ZFIX_INL
 
-inline ZLong toZLong(float val)
+#include "compat_config.h"
+
+inline constexpr ZLong toZLong(float val)
 {
 	return ZLong(val * 10000);
 }
-inline ZLong toZLong(double val)
+inline constexpr ZLong toZLong(double val)
 {
 	return ZLong(val * 10000);
 }
-inline ZLong toZLong(int val)
+inline constexpr ZLong toZLong(int val)
 {
 	return ZLong(val * 10000);
 }
-inline ZLong toZLong(long val)
+inline constexpr ZLong toZLong(long val)
 {
 	return ZLong(val * 10000);
 }

--- a/src/zq_class.cpp
+++ b/src/zq_class.cpp
@@ -571,7 +571,7 @@ bool zmap::isDark()
 }
 void zmap::setCurrMap(int index)
 {
-    int oldmap=currmap;
+    const int oldmap=currmap;
     scrpos[currmap]=currscr;
     currmap=bound(index,0,map_count);
     screens=&TheMaps[currmap*MAPSCRS];
@@ -595,7 +595,7 @@ void zmap::setCurrScr(int scr)
 {
     if(scr==currscr) return;
     
-    int oldscr=currscr;
+    const int oldscr=currscr;
     int oldcolor=getcolor();
     
     if(!(screens[currscr].valid&mVALID))
@@ -636,8 +636,8 @@ void zmap::setlayertarget()
     {
         for(int s=0; s<MAPSCRS; ++s)
         {
-            int i=(m*MAPSCRS+s);
-            mapscr *ts=&TheMaps[i];
+            const int i=(m*MAPSCRS+s);
+            const mapscr* ts=&TheMaps[i];
             
             // Search through each layer
             for(int w=0; w<6; ++w)
@@ -788,7 +788,7 @@ void zmap::Template(int floorcombo, int floorcset, int scr)
         for(int y=2; y<9; y++)
             for(int x=2; x<14; x++)
             {
-                int i=(y<<4)+x;
+                const int i=(y<<4)+x;
                 screens[scr].data[i] = floorcombo;
                 screens[scr].cset[i] = floorcset;
             }
@@ -953,8 +953,8 @@ int zmap::save(const char *path)
     if(!f)
         return 1;
         
-    short version=ZELDA_VERSION;
-    byte  build=VERSION_BUILD;
+    const short version=ZELDA_VERSION;
+    const byte  build=VERSION_BUILD;
     
     if(!p_iputw(version,f))
     {
@@ -1064,15 +1064,15 @@ int zmap::warpindex(int combo)
 
 void zmap::put_walkflags_layered(BITMAP *dest,int x,int y,int pos,int layer)
 {
-    int cx = COMBOX(pos);
-    int cy = COMBOY(pos);
+    const int cx = COMBOX(pos);
+    const int cy = COMBOY(pos);
     
-    newcombo c = combobuf[ MAPCOMBO2(layer,cx,cy) ];
+    const newcombo c = combobuf[ MAPCOMBO2(layer,cx,cy) ];
     
     for(int i=0; i<4; i++)
     {
-        int tx=((i&2)<<2)+x;
-        int ty=((i&1)<<3)+y;
+        const int tx=((i&2)<<2)+x;
+        const int ty=((i&1)<<3)+y;
         
         if(layer==0 && combo_class_buf[c.type].water!=0 && get_bit(quest_rules, qr_DROWN))
             rectfill(dest,tx,ty,tx+7,ty+7,vc(9));
@@ -1100,7 +1100,7 @@ void zmap::put_walkflags_layered(BITMAP *dest,int x,int y,int pos,int layer)
     }
     
     // Draw damage combos
-    bool dmg = combo_class_buf[combobuf[MAPCOMBO2(-1,cx,cy)].type].modify_hp_amount
+    const bool dmg = combo_class_buf[combobuf[MAPCOMBO2(-1,cx,cy)].type].modify_hp_amount
                || combo_class_buf[combobuf[MAPCOMBO2(0,cx,cy)].type].modify_hp_amount
                || combo_class_buf[combobuf[MAPCOMBO2(1,cx,cy)].type].modify_hp_amount;
                
@@ -1115,12 +1115,12 @@ void zmap::put_walkflags_layered(BITMAP *dest,int x,int y,int pos,int layer)
 
 void put_walkflags(BITMAP *dest,int x,int y,word cmbdat,int layer)
 {
-    newcombo c = combobuf[cmbdat];
+    const newcombo c = combobuf[cmbdat];
     
     for(int i=0; i<4; i++)
     {
-        int tx=((i&2)<<2)+x;
-        int ty=((i&1)<<3)+y;
+        const int tx=((i&2)<<2)+x;
+        const int ty=((i&1)<<3)+y;
         
         if(layer==0 && combo_class_buf[c.type].water!=0 && get_bit(quest_rules, qr_DROWN))
             rectfill(dest,tx,ty,tx+7,ty+7,vc(9));
@@ -1160,7 +1160,7 @@ void put_walkflags(BITMAP *dest,int x,int y,word cmbdat,int layer)
 void put_flags(BITMAP *dest,int x,int y,word cmbdat,int cset,int flags,int sflag)
 {
 
-    newcombo c = combobuf[cmbdat];
+    const newcombo c = combobuf[cmbdat];
     
     if((flags&cFLAGS)&&(sflag||combobuf[cmbdat].flag))
     {
@@ -1182,13 +1182,13 @@ void put_flags(BITMAP *dest,int x,int y,word cmbdat,int cset,int flags,int sflag
     
     if(flags&cCSET)
     {
-        bool inv = (((cmbdat&0x7800)==0x7800)&&(flags&cFLAGS));
+        const bool inv = (((cmbdat&0x7800)==0x7800)&&(flags&cFLAGS));
         //    text_mode(inv?vc(15):vc(0));
         textprintf_ex(dest,z3smallfont,x+9,y+9,inv?vc(0):vc(15),inv?vc(15):vc(0),"%d",cset);
     }
     else if(flags&cCTYPE)
     {
-        bool inv = (((cmbdat&0x7800)==0x7800)&&(flags&cFLAGS));
+        const bool inv = (((cmbdat&0x7800)==0x7800)&&(flags&cFLAGS));
         //    text_mode(inv?vc(15):vc(0));
         textprintf_ex(dest,z3smallfont,x+1,y+9,inv?vc(0):vc(15),inv?vc(15):vc(0),"%d",c.type);
     }
@@ -1197,7 +1197,7 @@ void put_flags(BITMAP *dest,int x,int y,word cmbdat,int cset,int flags,int sflag
 void put_combo(BITMAP *dest,int x,int y,word cmbdat,int cset,int flags,int sflag)
 {
 
-    newcombo c = combobuf[cmbdat];
+    const newcombo c = combobuf[cmbdat];
     
     if(c.tile==0)
     {
@@ -1244,13 +1244,13 @@ void put_combo(BITMAP *dest,int x,int y,word cmbdat,int cset,int flags,int sflag
     
     if(flags&cCSET)
     {
-        bool inv = (((cmbdat&0x7800)==0x7800)&&(flags&cFLAGS));
+        const bool inv = (((cmbdat&0x7800)==0x7800)&&(flags&cFLAGS));
         //    text_mode(inv?vc(15):vc(0));
         textprintf_ex(dest,z3smallfont,x+9,y+9,inv?vc(0):vc(15),inv?vc(15):vc(0),"%d",cset);
     }
     else if(flags&cCTYPE)
     {
-        bool inv = (((cmbdat&0x7800)==0x7800)&&(flags&cFLAGS));
+        const bool inv = (((cmbdat&0x7800)==0x7800)&&(flags&cFLAGS));
         //    text_mode(inv?vc(15):vc(0));
         textprintf_ex(dest,z3smallfont,x+1,y+9,inv?vc(0):vc(15),inv?vc(15):vc(0),"%d",c.type);
     }
@@ -1452,7 +1452,7 @@ void copy_mapscr(mapscr *dest, const mapscr *src)
 void zmap::put_door(BITMAP *dest,int pos,int side,int type,int xofs,int yofs,bool ignorepos, int scr)
 {
     int x=0,y=0;
-    mapscr *doorscreen=(prv_mode?get_prvscr():screens+scr);
+    const mapscr* doorscreen=(prv_mode?get_prvscr():screens+scr);
     
     switch(side)
     {
@@ -1551,9 +1551,9 @@ void zmap::put_door(BITMAP *dest,int pos,int side,int type,int xofs,int yofs,boo
 
 void zmap::over_door(BITMAP *dest,int pos,int side,int xofs,int yofs,bool, int scr)
 {
-    int x=((pos&15)<<4)+xofs;
-    int y=(pos&0xF0)+yofs;
-    mapscr *doorscreen=(prv_mode?get_prvscr():screens+scr);
+    const int x=((pos&15)<<4)+xofs;
+    const int y=(pos&0xF0)+yofs;
+    const mapscr* doorscreen=(prv_mode?get_prvscr():screens+scr);
     
     
     switch(side)
@@ -2095,7 +2095,7 @@ int zmap::MAPCOMBO2(int lyr,int x,int y, int map, int scr)
     else
         layer = AbsoluteScr(layermap,screen1->layerscreen[lyr]);
         
-    int combo = COMBOPOS(x,y);
+    const int combo = COMBOPOS(x,y);
     
     if(combo>175 || combo < 0)
         return 0;
@@ -2124,7 +2124,7 @@ int zmap::MAPCOMBO(int x,int y, int map, int scr) //map=-1,scr=-1
     
     x = vbound(x, 0, 16*16);
     y = vbound(y, 0, 11*16);
-    int combo = COMBOPOS(x,y);
+    const int combo = COMBOPOS(x,y);
     
     if(combo>175 || combo < 0)
         return 0;
@@ -2134,7 +2134,7 @@ int zmap::MAPCOMBO(int x,int y, int map, int scr) //map=-1,scr=-1
 
 void zmap::draw(BITMAP* dest,int x,int y,int flags,int map,int scr)
 {
-    int antiflags=flags&~cFLAGS;
+    const int antiflags=flags&~cFLAGS;
     
     if(map<0)
         map=currmap;
@@ -2248,9 +2248,9 @@ void zmap::draw(BITMAP* dest,int x,int y,int flags,int map,int scr)
     {
         for(int i=0; i<176; i++)
         {
-            word cmbdat = layer->data[i];
-            byte cmbcset = layer->cset[i];
-            int cmbflag = layer->sflag[i];
+            const word cmbdat = layer->data[i];
+            const byte cmbcset = layer->cset[i];
+            const int cmbflag = layer->sflag[i];
             
             if(layer->flags7&fLAYER3BG||layer->flags7&fLAYER2BG)
                 overcombo(dest,((i&15)<<4)+x,(i&0xF0)+y,cmbdat,cmbcset);
@@ -2299,8 +2299,8 @@ void zmap::draw(BITMAP* dest,int x,int y,int flags,int map,int scr)
                     {
                         if(!(layer->ffflags[i]&ffOVERLAY))
                         {
-                            int tx=(layer->ffx[i]/10000)+x;
-                            int ty=(layer->ffy[i]/10000)+y;
+                            const int tx=(layer->ffx[i]/10000)+x;
+                            const int ty=(layer->ffy[i]/10000)+y;
                             
                             if(layer->ffflags[i]&ffTRANS)
                             {
@@ -2510,9 +2510,9 @@ void zmap::draw(BITMAP* dest,int x,int y,int flags,int map,int scr)
     {
         for(int i=0; i<176; i++)
         {
-            int ct1=layer->data[i];
+            const int ct1=layer->data[i];
             //     int ct2=(ct1&0xFF)+(screens[currscr].cpage<<8);
-            int ct3=combobuf[ct1].type;
+            const int ct3=combobuf[ct1].type;
             
 //      if (ct3==cOLD_OVERHEAD)
             if(combo_class_buf[ct3].overhead)
@@ -2560,8 +2560,8 @@ void zmap::draw(BITMAP* dest,int x,int y,int flags,int map,int scr)
                         if(layer->ffflags[i]&ffOVERLAY)
                         {
                             //overcombo(framebuf,(int)layer->ffx[i],(int)layer->ffy[i]+56,layer->ffdata[i],layer->ffcset[i]);
-                            int tx=(layer->ffx[i]/10000)+x;
-                            int ty=(layer->ffy[i]/10000)+y;
+                            const int tx=(layer->ffx[i]/10000)+x;
+                            const int ty=(layer->ffy[i]/10000)+y;
                             
                             if(layer->ffflags[i]&ffTRANS)
                             {
@@ -2641,7 +2641,7 @@ void zmap::draw(BITMAP* dest,int x,int y,int flags,int map,int scr)
                     }
                     else
                     {
-                        int _lscr=(layer->layermap[CurrentLayer-1]-1)*MAPSCRS+layer->layerscreen[CurrentLayer-1];
+                        const int _lscr=(layer->layermap[CurrentLayer-1]-1)*MAPSCRS+layer->layerscreen[CurrentLayer-1];
                         
                         if(_lscr>-1 && _lscr<map_count*MAPSCRS)
                         {
@@ -2657,7 +2657,7 @@ void zmap::draw(BITMAP* dest,int x,int y,int flags,int map,int scr)
     }
     
     
-    int dark = layer->flags&cDARK;
+    const int dark = layer->flags&cDARK;
     
     if(dark && !(flags&cNODARK))
     {
@@ -2700,7 +2700,7 @@ void zmap::drawrow(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
         return;
     }
     
-    int dark = layer->flags&4;
+    const int dark = layer->flags&4;
     
     resize_mouse_pos=true;
     
@@ -2740,9 +2740,9 @@ void zmap::drawrow(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
     {
         for(int i=c; i<(c&0xF0)+16; i++)
         {
-            word cmbdat = (i < (int)layer->data.size() ? layer->data[i] : 0);
-            byte cmbcset = (i < (int)layer->data.size() ? layer->cset[i] : 0);
-            int cmbflag = (i < (int)layer->data.size() ? layer->sflag[i] : 0);
+            const word cmbdat = (i < (int)layer->data.size() ? layer->data[i] : 0);
+            const byte cmbcset = (i < (int)layer->data.size() ? layer->cset[i] : 0);
+            const int cmbflag = (i < (int)layer->data.size() ? layer->sflag[i] : 0);
 			if(layer->flags7&fLAYER3BG||layer->flags7&fLAYER2BG)
 				overcombo(dest,((i&15)<<4)+x,y,cmbdat,cmbcset);
 			else put_combo(dest,((i&15)<<4)+x,y,cmbdat,cmbcset,flags|dark,cmbflag);
@@ -2861,9 +2861,9 @@ void zmap::drawrow(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
     {
         for(int i=c; i<(c&0xF0)+16; i++)
         {
-            int ct1=layer->data[i];
+            const int ct1=layer->data[i];
             //     int ct2=(ct1&0xFF)+(screens[currscr].cpage<<8);
-            int ct3=combobuf[ct1].type;
+            const int ct3=combobuf[ct1].type;
             
 //      if (ct3==cOLD_OVERHEAD)
             if(combo_class_buf[ct3].overhead)
@@ -2939,7 +2939,7 @@ void zmap::drawrow(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
                 }
                 else
                 {
-                    int _lscr=(layer->layermap[CurrentLayer-1]-1)*MAPSCRS+layer->layerscreen[CurrentLayer-1];
+                    const int _lscr=(layer->layermap[CurrentLayer-1]-1)*MAPSCRS+layer->layerscreen[CurrentLayer-1];
                     
                     if(_lscr>-1 && _lscr<map_count*MAPSCRS)
                     {
@@ -3002,7 +3002,7 @@ void zmap::drawcolumn(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
         return;
     }
     
-    int dark = layer->flags&4;
+    const int dark = layer->flags&4;
     
     resize_mouse_pos=true;
     
@@ -3043,9 +3043,9 @@ void zmap::drawcolumn(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
     {
         for(int i=c; i<176; i+=16)
         {
-            word cmbdat = layer->data[i];
-            byte cmbcset = layer->cset[i];
-            int cmbflag = layer->sflag[i];
+            const word cmbdat = layer->data[i];
+            const byte cmbcset = layer->cset[i];
+            const int cmbflag = layer->sflag[i];
 			if(layer->flags7&fLAYER3BG||layer->flags7&fLAYER2BG)
 				overcombo(dest,x,(i&0xF0)+y,cmbdat,cmbcset);
             else put_combo(dest,x,(i&0xF0)+y,cmbdat,cmbcset,flags|dark,cmbflag);
@@ -3166,9 +3166,9 @@ void zmap::drawcolumn(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
     {
         for(int i=c; i<176; i+=16)
         {
-            int ct1=layer->data[i];
+            const int ct1=layer->data[i];
             //     int ct2=(ct1&0xFF)+(screens[currscr].cpage<<8);
-            int ct3=combobuf[ct1].type;
+            const int ct3=combobuf[ct1].type;
             
 //      if (ct3==cOLD_OVERHEAD)
             if(combo_class_buf[ct3].overhead)
@@ -3246,7 +3246,7 @@ void zmap::drawcolumn(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
                 }
                 else
                 {
-                    int _lscr=(layer->layermap[CurrentLayer-1]-1)*MAPSCRS+layer->layerscreen[CurrentLayer-1];
+                    const int _lscr=(layer->layermap[CurrentLayer-1]-1)*MAPSCRS+layer->layerscreen[CurrentLayer-1];
                     
                     if(_lscr>-1 && _lscr<map_count*MAPSCRS)
                     {
@@ -3301,7 +3301,7 @@ void zmap::drawblock(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
         return;
     }
     
-    int dark = layer->flags&4;
+    const int dark = layer->flags&4;
     
     resize_mouse_pos=true;
     
@@ -3336,9 +3336,9 @@ void zmap::drawblock(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
     
     if(LayerMaskInt[0]!=0)
     {
-        word cmbdat = layer->data[c];
-        byte cmbcset = layer->cset[c];
-        int cmbflag = layer->sflag[c];
+        const word cmbdat = layer->data[c];
+        const byte cmbcset = layer->cset[c];
+        const int cmbflag = layer->sflag[c];
         if(layer->flags7&fLAYER3BG||layer->flags7&fLAYER2BG)
 			overcombo(dest,x,y,cmbdat,cmbcset);
 		else put_combo(dest,x,y,cmbdat,cmbcset,flags|dark,cmbflag);
@@ -3368,8 +3368,8 @@ void zmap::drawblock(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
     
     if(LayerMaskInt[0]!=0)
     {
-        int ct1=layer->data[c];
-        int ct3=combobuf[ct1].type;
+        const int ct1=layer->data[c];
+        const int ct3=combobuf[ct1].type;
         
 //    if (ct3==cOLD_OVERHEAD)
         if(combo_class_buf[ct3].overhead)
@@ -3434,7 +3434,7 @@ void zmap::drawblock(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
                 }
                 else
                 {
-                    int _lscr=(layer->layermap[CurrentLayer-1]-1)*MAPSCRS+layer->layerscreen[CurrentLayer-1];
+                    const int _lscr=(layer->layermap[CurrentLayer-1]-1)*MAPSCRS+layer->layerscreen[CurrentLayer-1];
                     
                     if(_lscr>-1 && _lscr<map_count*MAPSCRS)
                     {
@@ -3547,9 +3547,9 @@ void zmap::draw_template(BITMAP* dest,int x,int y)
 {
     for(int i=0; i<176; i++)
     {
-        word cmbdat = screens[TEMPLATE].data[i];
-        byte cmbcset = screens[TEMPLATE].cset[i];
-        int cmbflag = screens[TEMPLATE].sflag[i];
+        const word cmbdat = screens[TEMPLATE].data[i];
+        const byte cmbcset = screens[TEMPLATE].cset[i];
+        const int cmbflag = screens[TEMPLATE].sflag[i];
         put_combo(dest,((i&15)<<4)+x,(i&0xF0)+y,cmbdat,cmbcset,0,cmbflag);
     }
 }
@@ -3558,26 +3558,26 @@ void zmap::draw_template2(BITMAP* dest,int x,int y)
 {
     for(int i=0; i<176; i++)
     {
-        word cmbdat = screens[TEMPLATE2].data[i];
-        byte cmbcset = screens[TEMPLATE2].cset[i];
-        int cmbflag = screens[TEMPLATE2].sflag[i];
+        const word cmbdat = screens[TEMPLATE2].data[i];
+        const byte cmbcset = screens[TEMPLATE2].cset[i];
+        const int cmbflag = screens[TEMPLATE2].sflag[i];
         put_combo(dest,((i&15)<<4)+x,(i&0xF0)+y,cmbdat,cmbcset,0,cmbflag);
     }
 }
 
 void zmap::draw_secret(BITMAP *dest, int pos)
 {
-    word cmbdat = screens[TEMPLATE].data[pos];
-    byte cmbcset = screens[TEMPLATE].cset[pos];
-    int cmbflag = screens[TEMPLATE].sflag[pos];
+    const word cmbdat = screens[TEMPLATE].data[pos];
+    const byte cmbcset = screens[TEMPLATE].cset[pos];
+    const int cmbflag = screens[TEMPLATE].sflag[pos];
     put_combo(dest,0,0,cmbdat,cmbcset,0,cmbflag);
 }
 
 void zmap::draw_secret2(BITMAP *dest, int scombo)
 {
-    word cmbdat =  screens[currscr].secretcombo[scombo];
-    byte cmbcset = screens[currscr].secretcset[scombo];
-    byte cmbflag = screens[currscr].secretflag[scombo];
+    const word cmbdat =  screens[currscr].secretcombo[scombo];
+    const byte cmbcset = screens[currscr].secretcset[scombo];
+    const byte cmbflag = screens[currscr].secretflag[scombo];
     put_combo(dest,0,0,cmbdat,cmbcset,0,cmbflag);
 }
 
@@ -3875,7 +3875,7 @@ void zmap::Paste()
     if(can_paste)
     {
         Ugo();
-        int oldcolor=getcolor();
+        const int oldcolor=getcolor();
         
         if(!(screens[currscr].valid&mVALID))
         {
@@ -4168,7 +4168,7 @@ void zmap::PastePalette()
     if(can_paste)
     {
         Ugo();
-        int oldcolor=getcolor();
+        const int oldcolor=getcolor();
         screens[currscr].color = copymapscr.color;
         int newcolor=getcolor();
         loadlvlpal(newcolor);
@@ -4192,7 +4192,7 @@ void zmap::PasteAll()
     if(can_paste)
     {
         Ugo();
-        int oldcolor=getcolor();
+        const int oldcolor=getcolor();
         copy_mapscr(&screens[currscr], &copymapscr);
         //screens[currscr]=copymapscr;
         int newcolor=getcolor();
@@ -4218,7 +4218,7 @@ void zmap::PasteToAll()
     if(can_paste)
     {
         Ugo();
-        int oldcolor=getcolor();
+        const int oldcolor=getcolor();
         
         for(int x=0; x<128; x++)
         {
@@ -4263,7 +4263,7 @@ void zmap::PasteAllToAll()
     if(can_paste)
     {
         Ugo();
-        int oldcolor=getcolor();
+        const int oldcolor=getcolor();
         
         for(int x=0; x<128; x++)
         {
@@ -4320,6 +4320,8 @@ void zmap::update_combo_cycling()
     }
     
     int x,y;
+    _MAYBE_UNUSED(y);
+
     int newdata[176];
     int newcset[176];
     bool restartanim[MAXCOMBOS];
@@ -4702,9 +4704,8 @@ void zmap::dowarp(int type, int index)
 {
     if(type==0)
     {
-    
-        int dmap=screens[currscr].tilewarpdmap[index];
-        int scr=screens[currscr].tilewarpscr[index];
+        const int dmap=screens[currscr].tilewarpdmap[index];
+        const int scr=screens[currscr].tilewarpscr[index];
         
         switch(screens[currscr].tilewarptype[index])
         {
@@ -4720,8 +4721,8 @@ void zmap::dowarp(int type, int index)
     }
     else if(type==1)
     {
-        int dmap=screens[currscr].sidewarpdmap[index];
-        int scr=screens[currscr].sidewarpscr[index];
+        const int dmap=screens[currscr].sidewarpdmap[index];
+        const int scr=screens[currscr].sidewarpscr[index];
         
         switch(screens[currscr].sidewarptype[index])
         {
@@ -4743,9 +4744,8 @@ void zmap::prv_dowarp(int type, int index)
 {
     if(type==0)
     {
-    
-        int dmap=prvscr.tilewarpdmap[index];
-        int scr=prvscr.tilewarpscr[index];
+        const int dmap=prvscr.tilewarpdmap[index];
+        const int scr=prvscr.tilewarpscr[index];
         
         switch(prvscr.tilewarptype[index])
         {
@@ -4765,8 +4765,8 @@ void zmap::prv_dowarp(int type, int index)
     }
     else if(type==1)
     {
-        int dmap=prvscr.sidewarpdmap[index];
-        int scr=prvscr.sidewarpscr[index];
+        const int dmap=prvscr.sidewarpdmap[index];
+        const int scr=prvscr.sidewarpscr[index];
         
         switch(prvscr.sidewarptype[index])
         {
@@ -4799,8 +4799,8 @@ void zmap::prv_dowarp(int type, int index)
 
 void zmap::dowarp2(int ring,int index)
 {
-    int dmap=misc.warp[ring].dmap[index];
-    int scr=misc.warp[ring].scr[index];
+    const int dmap=misc.warp[ring].dmap[index];
+    const int scr=misc.warp[ring].scr[index];
     setCurrMap(DMaps[dmap].map);
     setCurrScr(scr+DMaps[dmap].xoff);
 }
@@ -5451,9 +5451,9 @@ bool save_zgp(const char *path)
     if(!f)
         return false;
         
-    dword section_id=ID_GRAPHICSPACK;
-    dword section_version=V_GRAPHICSPACK;
-    dword section_cversion=CV_GRAPHICSPACK;
+    const dword section_id=ID_GRAPHICSPACK;
+    const dword section_version=V_GRAPHICSPACK;
+    const dword section_cversion=CV_GRAPHICSPACK;
     
     //section id
     if(!p_mputl(section_id,f))
@@ -5582,9 +5582,9 @@ bool save_subscreen(const char *path, bool *cancel)
     if(!f)
         return false;
         
-    dword section_id=ID_SUBSCREEN;
-    dword section_version=V_SUBSCREEN;
-    dword section_cversion=CV_SUBSCREEN;
+    const dword section_id=ID_SUBSCREEN;
+    const dword section_version=V_SUBSCREEN;
+    const dword section_cversion=CV_SUBSCREEN;
     
     //section id
     if(!p_mputl(section_id,f))
@@ -5695,7 +5695,7 @@ bool load_subscreen(const char *path)
 
 bool setMapCount2(int c)
 {
-    int oldmapcount=map_count;
+    const int oldmapcount=map_count;
     int currmap=Map.getCurrMap();
     
     bound(c,1,MAXMAPS2);
@@ -5785,11 +5785,11 @@ void set_questpwd(const char *pwd, bool use_keyfile)
 }
 
 
-bool is_null_pwd_hash(unsigned char *pwd_hash)
+bool is_null_pwd_hash(const unsigned char* pwd_hash)
 {
     cvs_MD5Context ctx;
     unsigned char md5sum[16];
-    char pwd[2]="";
+    const char pwd[2]="";
     
     cvs_MD5Init(&ctx);
     cvs_MD5Update(&ctx, (const unsigned char*)pwd, (unsigned)strlen(pwd));
@@ -5886,7 +5886,7 @@ int quest_access(const char *filename, zquestheader *hdr, bool compressed)
     bool gotfrompwdfile=false;
     char cheatfilename[2048];
     replace_extension(cheatfilename, filename, "zcheat", 2047);
-    bool gotfromcheatfile=false;
+    const bool gotfromcheatfile=false;
     
     
     
@@ -6012,7 +6012,7 @@ int quest_access(const char *filename, zquestheader *hdr, bool compressed)
     if(is_large)
         large_dialog(pwd_dlg);
         
-    int cancel = zc_popup_dialog(pwd_dlg,6);
+    const int cancel = zc_popup_dialog(pwd_dlg,6);
     
     if(cancel == 8)
         return 2;
@@ -6051,7 +6051,7 @@ int load_quest(const char *filename, bool compressed, bool encrypted)
     }
     else
     {
-        int accessret = quest_access(filename, &header, compressed);
+        const int accessret = quest_access(filename, &header, compressed);
         
         if(accessret != 1)
         {
@@ -6145,9 +6145,9 @@ bool write_music(int format, MIDI* m, PACKFILE *f)
 
 int writeheader(PACKFILE *f, zquestheader *Header)
 {
-    dword section_id=ID_HEADER;
-    dword section_version=V_HEADER;
-    dword section_cversion=CV_HEADER;
+    const dword section_id=ID_HEADER;
+    const dword section_version=V_HEADER;
+    const dword section_cversion=CV_HEADER;
     dword section_size=0;
     
     //file header string
@@ -6471,9 +6471,9 @@ int writerules(PACKFILE *f, zquestheader *Header)
     //these are here to bypass compiler warnings about unused arguments
     Header=Header;
     
-    dword section_id=ID_RULES;
-    dword section_version=V_RULES;
-    dword section_cversion=CV_RULES;
+    const dword section_id=ID_RULES;
+    const dword section_version=V_RULES;
+    const dword section_cversion=CV_RULES;
     dword section_size=0;
     
     //section id
@@ -6533,9 +6533,9 @@ int writedoorcombosets(PACKFILE *f, zquestheader *Header)
     //these are here to bypass compiler warnings about unused arguments
     Header=Header;
     
-    dword section_id=ID_DOORS;
-    dword section_version=V_DOORS;
-    dword section_cversion=CV_DOORS;
+    const dword section_id=ID_DOORS;
+    const dword section_version=V_DOORS;
+    const dword section_cversion=CV_DOORS;
     dword section_size=0;
     
     //section id
@@ -6794,9 +6794,9 @@ int writedmaps(PACKFILE *f, word version, word build, word start_dmap, word max_
     build=build;
     
     word dmap_count=count_dmaps();
-    dword section_id=ID_DMAPS;
-    dword section_version=V_DMAPS;
-    dword section_cversion=CV_DMAPS;
+    const dword section_id=ID_DMAPS;
+    const dword section_version=V_DMAPS;
+    const dword section_cversion=CV_DMAPS;
     dword section_size=0;
     
     //section id
@@ -7053,14 +7053,14 @@ int writedmaps(PACKFILE *f, word version, word build, word start_dmap, word max_
     new_return(0);
 }
 
-int writemisccolors(PACKFILE *f, zquestheader *Header, miscQdata *Misc)
+int writemisccolors(PACKFILE* f, zquestheader* Header, const miscQdata* Misc)
 {
     //these are here to bypass compiler warnings about unused arguments
     Header=Header;
     
-    dword section_id=ID_COLORS;
-    dword section_version=V_COLORS;
-    dword section_cversion=CV_COLORS;
+    const dword section_id=ID_COLORS;
+    const dword section_version=V_COLORS;
+    const dword section_cversion=CV_COLORS;
     dword section_size = 0;
     
     //section id
@@ -7300,14 +7300,14 @@ int writemisccolors(PACKFILE *f, zquestheader *Header, miscQdata *Misc)
     new_return(0);
 }
 
-int writegameicons(PACKFILE *f, zquestheader *Header, miscQdata *Misc)
+int writegameicons(PACKFILE* f, zquestheader* Header, const miscQdata* Misc)
 {
     //these are here to bypass compiler warnings about unused arguments
     Header=Header;
     
-    dword section_id=ID_ICONS;
-    dword section_version=V_ICONS;
-    dword section_cversion=CV_ICONS;
+    const dword section_id=ID_ICONS;
+    const dword section_version=V_ICONS;
+    const dword section_cversion=CV_ICONS;
     dword section_size = 0;
     
     //section id
@@ -7368,13 +7368,13 @@ int writemisc(PACKFILE *f, zquestheader *Header, miscQdata *Misc)
     //these are here to bypass compiler warnings about unused arguments
     Header=Header;
     
-    dword section_id=ID_MISC;
-    dword section_version=V_MISC;
-    dword section_cversion=CV_MISC;
-    word shops=count_shops(Misc);
-    word infos=count_infos(Misc);
-    word warprings=count_warprings(Misc);
-    word triforces=8;
+    const dword section_id=ID_MISC;
+    const dword section_version=V_MISC;
+    const dword section_cversion=CV_MISC;
+    const word shops=count_shops(Misc);
+    const word infos=count_infos(Misc);
+    const word warprings=count_warprings(Misc);
+    const word triforces=8;
     dword section_size = 0;
     
     //section id
@@ -7576,9 +7576,9 @@ int writeitems(PACKFILE *f, zquestheader *Header)
     //these are here to bypass compiler warnings about unused arguments
     Header=Header;
     
-    dword section_id=ID_ITEMS;
-    dword section_version=V_ITEMS;
-    dword section_cversion=CV_ITEMS;
+    const dword section_id=ID_ITEMS;
+    const dword section_version=V_ITEMS;
+    const dword section_cversion=CV_ITEMS;
     //  dword section_size=0;
     dword section_size = 0;
     
@@ -8075,9 +8075,9 @@ int writeweapons(PACKFILE *f, zquestheader *Header)
     //these are here to bypass compiler warnings about unused arguments
     Header=Header;
     
-    dword section_id=ID_WEAPONS;
-    dword section_version=V_WEAPONS;
-    dword section_cversion=CV_WEAPONS;
+    const dword section_id=ID_WEAPONS;
+    const dword section_version=V_WEAPONS;
+    const dword section_cversion=CV_WEAPONS;
     dword section_size = 0;
     
     //section id
@@ -8560,7 +8560,7 @@ int writemapscreen(PACKFILE *f, int i, int j)
                 return qe_invalid;
             }
         }
-        catch(std::out_of_range& e)
+        catch (const std::out_of_range& /*e*/)
         {
             return qe_invalid;
         }
@@ -8575,7 +8575,7 @@ int writemapscreen(PACKFILE *f, int i, int j)
                 return qe_invalid;
             }
         }
-        catch(std::out_of_range& e)
+        catch (const std::out_of_range& /*e*/)
         {
             return qe_invalid;
         }
@@ -8590,7 +8590,7 @@ int writemapscreen(PACKFILE *f, int i, int j)
                 return qe_invalid;
             }
         }
-        catch(std::out_of_range& e)
+        catch (const std::out_of_range& /*e*/)
         {
             return qe_invalid;
         }
@@ -8794,9 +8794,9 @@ int writemapscreen(PACKFILE *f, int i, int j)
 
 int writemaps(PACKFILE *f, zquestheader *)
 {
-    dword section_id=ID_MAPS;
-    dword section_version=V_MAPS;
-    dword section_cversion=CV_MAPS;
+    const dword section_id=ID_MAPS;
+    const dword section_version=V_MAPS;
+    const dword section_cversion=CV_MAPS;
     dword section_size = 0;
     
     //section id
@@ -8863,9 +8863,9 @@ int writecombos(PACKFILE *f, word version, word build, word start_combo, word ma
     build=build;
     
     word combos_used;
-    dword section_id=ID_COMBOS;
-    dword section_version=V_COMBOS;
-    dword section_cversion=CV_COMBOS;
+    const dword section_id=ID_COMBOS;
+    const dword section_version=V_COMBOS;
+    const dword section_cversion=CV_COMBOS;
     //  dword section_size=0;
     combos_used = count_combos()-start_combo;
     combos_used = zc_min(combos_used, max_combos);
@@ -9069,9 +9069,9 @@ int writecomboaliases(PACKFILE *f, word version, word build)
     version=version;
     build=build;
     
-    dword section_id=ID_COMBOALIASES;
-    dword section_version=V_COMBOALIASES;
-    dword section_cversion=CV_COMBOALIASES;
+    const dword section_id=ID_COMBOALIASES;
+    const dword section_version=V_COMBOALIASES;
+    const dword section_cversion=CV_COMBOALIASES;
     dword section_size=0;
     
     //section id
@@ -9116,7 +9116,7 @@ int writecomboaliases(PACKFILE *f, word version, word build)
                 new_return(6);
             }
             
-            int count = ((combo_aliases[j].width+1)*(combo_aliases[j].height+1))*(comboa_lmasktotal(combo_aliases[j].layermask)+1);
+            const int count = ((combo_aliases[j].width+1)*(combo_aliases[j].height+1))*(comboa_lmasktotal(combo_aliases[j].layermask)+1);
             
             if(!p_putc(combo_aliases[j].width,f))
             {
@@ -9175,10 +9175,10 @@ int writecolordata(PACKFILE *f, miscQdata *Misc, word version, word build, word 
     start_cset=start_cset;
     max_csets=max_csets;
     
-    dword section_id=ID_CSETS;
-    dword section_version=V_CSETS;
-    dword section_cversion=CV_CSETS;
-    int palcycles = count_palcycles(Misc);
+    const dword section_id=ID_CSETS;
+    const dword section_version=V_CSETS;
+    const dword section_cversion=CV_CSETS;
+    const int palcycles = count_palcycles(Misc);
 // int palcyccount = count_palcycles(Misc);
     dword section_size = 0;
     
@@ -9279,9 +9279,9 @@ int writestrings(PACKFILE *f, word version, word build, word start_msgstr, word 
     start_msgstr=start_msgstr;
     max_msgstrs=max_msgstrs;
     
-    dword section_id=ID_STRINGS;
-    dword section_version=V_STRINGS;
-    dword section_cversion=CV_STRINGS;
+    const dword section_id=ID_STRINGS;
+    const dword section_version=V_STRINGS;
+    const dword section_cversion=CV_STRINGS;
     dword section_size = 0;
     
     //section id
@@ -9516,9 +9516,9 @@ int writetiles(PACKFILE *f, word version, word build, int start_tile, int max_ti
     build=build;
     
     int tiles_used;
-    dword section_id=ID_TILES;
-    dword section_version=V_TILES;
-    dword section_cversion=CV_TILES;
+    const dword section_id=ID_TILES;
+    const dword section_version=V_TILES;
+    const dword section_cversion=CV_TILES;
 	al_trace("Counting tiles used\n");
     tiles_used = count_tiles(newtilebuf)-start_tile;
     tiles_used = zc_min(tiles_used, max_tiles);
@@ -9627,9 +9627,9 @@ midi		 *
 
 int writemidis(PACKFILE *f)
 {
-    dword section_id=ID_MIDIS;
-    dword section_version=V_MIDIS;
-    dword section_cversion=CV_MIDIS;
+    const dword section_id=ID_MIDIS;
+    const dword section_version=V_MIDIS;
+    const dword section_cversion=CV_MIDIS;
     dword section_size = 0;
     
     //section id
@@ -9741,11 +9741,11 @@ int writemidis(PACKFILE *f)
     new_return(0);
 }
 
-int writecheats(PACKFILE *f, zquestheader *Header)
+int writecheats(PACKFILE* f, const zquestheader* Header)
 {
-    dword section_id=ID_CHEATS;
-    dword section_version=V_CHEATS;
-    dword section_cversion=CV_CHEATS;
+    const dword section_id=ID_CHEATS;
+    const dword section_version=V_CHEATS;
+    const dword section_cversion=CV_CHEATS;
     dword section_size = 0;
     
     //section id
@@ -9817,9 +9817,9 @@ int writeguys(PACKFILE *f, zquestheader *Header)
     //these are here to bypass compiler warnings about unused arguments
     Header=Header;
     
-    dword section_id=ID_GUYS;
-    dword section_version=V_GUYS;
-    dword section_cversion=CV_GUYS;
+    const dword section_id=ID_GUYS;
+    const dword section_version=V_GUYS;
+    const dword section_cversion=CV_GUYS;
     dword section_size=0;
     
     //section id
@@ -10355,9 +10355,9 @@ int writelinksprites(PACKFILE *f, zquestheader *Header)
     //these are here to bypass compiler warnings about unused arguments
     Header=Header;
     
-    dword section_id=ID_LINKSPRITES;
-    dword section_version=V_LINKSPRITES;
-    dword section_cversion=CV_LINKSPRITES;
+    const dword section_id=ID_LINKSPRITES;
+    const dword section_version=V_LINKSPRITES;
+    const dword section_cversion=CV_LINKSPRITES;
     dword section_size=0;
     
     //section id
@@ -10832,9 +10832,9 @@ int writelinksprites(PACKFILE *f, zquestheader *Header)
 
 int writesubscreens(PACKFILE *f, zquestheader *Header)
 {
-    dword section_id=ID_SUBSCREEN;
-    dword section_version=V_SUBSCREEN;
-    dword section_cversion=CV_SUBSCREEN;
+    const dword section_id=ID_SUBSCREEN;
+    const dword section_version=V_SUBSCREEN;
+    const dword section_cversion=CV_SUBSCREEN;
     dword section_size=0;
     
     //section id
@@ -10868,7 +10868,7 @@ int writesubscreens(PACKFILE *f, zquestheader *Header)
         
         for(int i=0; i<MAXCUSTOMSUBSCREENS; i++)
         {
-            int ret = write_one_subscreen(f, Header, i);
+            const int ret = write_one_subscreen(f, Header, i);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -11112,11 +11112,11 @@ extern script_data *comboscripts[NUMSCRIPTSCOMBODATA];
 
 int writeffscript(PACKFILE *f, zquestheader *Header)
 {
-    dword section_id       = ID_FFSCRIPT;
-    dword section_version  = V_FFSCRIPT;
-    dword section_cversion = CV_FFSCRIPT;
+    const dword section_id       = ID_FFSCRIPT;
+    const dword section_version  = V_FFSCRIPT;
+    const dword section_cversion = CV_FFSCRIPT;
     dword section_size     = 0;
-	dword zasmmeta_version = METADATA_V;
+    const dword zasmmeta_version = METADATA_V;
     byte numscripts        = 0;
     numscripts = numscripts; //to avoid unused variables warnings
     
@@ -11156,7 +11156,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
         
         for(int i=0; i<NUMSCRIPTFFC; i++)
         {
-            int ret = write_one_ffscript(f, Header, i, &ffscripts[i]);
+            const int ret = write_one_ffscript(f, Header, i, &ffscripts[i]);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -11167,7 +11167,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
         
         for(int i=0; i<NUMSCRIPTITEM; i++)
         {
-            int ret = write_one_ffscript(f, Header, i, &itemscripts[i]);
+            const int ret = write_one_ffscript(f, Header, i, &itemscripts[i]);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -11178,7 +11178,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
         
         for(int i=0; i<NUMSCRIPTGUYS; i++)
         {
-            int ret = write_one_ffscript(f, Header, i, &guyscripts[i]);
+            const int ret = write_one_ffscript(f, Header, i, &guyscripts[i]);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -11189,7 +11189,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
         
         for(int i=0; i<NUMSCRIPTWEAPONS; i++)
         {
-            int ret = write_one_ffscript(f, Header, i, &wpnscripts[i]);
+            const int ret = write_one_ffscript(f, Header, i, &wpnscripts[i]);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -11200,7 +11200,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
         
         for(int i=0; i<NUMSCRIPTSCREEN; i++)
         {
-            int ret = write_one_ffscript(f, Header, i, &screenscripts[i]);
+            const int ret = write_one_ffscript(f, Header, i, &screenscripts[i]);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -11211,7 +11211,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
         
         for(int i=0; i<NUMSCRIPTGLOBAL; i++)
         {
-            int ret = write_one_ffscript(f, Header, i, &globalscripts[i]);
+            const int ret = write_one_ffscript(f, Header, i, &globalscripts[i]);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -11222,7 +11222,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
         
         for(int i=0; i<NUMSCRIPTLINK; i++)
         {
-            int ret = write_one_ffscript(f, Header, i, &linkscripts[i]);
+            const int ret = write_one_ffscript(f, Header, i, &linkscripts[i]);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -11233,7 +11233,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
 	
         for(int i=0; i<NUMSCRIPTWEAPONS; i++)
         {
-            int ret = write_one_ffscript(f, Header, i, &lwpnscripts[i]);
+            const int ret = write_one_ffscript(f, Header, i, &lwpnscripts[i]);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -11244,7 +11244,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
 	
 	for(int i=0; i<NUMSCRIPTWEAPONS; i++)
         {
-            int ret = write_one_ffscript(f, Header, i, &ewpnscripts[i]);
+        const int ret = write_one_ffscript(f, Header, i, &ewpnscripts[i]);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -11255,7 +11255,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
         
 	for(int i=0; i<NUMSCRIPTSDMAP; i++)
         {
-            int ret = write_one_ffscript(f, Header, i, &dmapscripts[i]);
+            const int ret = write_one_ffscript(f, Header, i, &dmapscripts[i]);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -11266,7 +11266,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
 	
 	for(int i=0; i<NUMSCRIPTSITEMSPRITE; i++)
         {
-            int ret = write_one_ffscript(f, Header, i, &itemspritescripts[i]);
+            const int ret = write_one_ffscript(f, Header, i, &itemspritescripts[i]);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -11277,7 +11277,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
 	al_trace("About to write combo script pt 1.\n");
 	for(int i=0; i<NUMSCRIPTSCOMBODATA; i++)
         {
-            int ret = write_one_ffscript(f, Header, i, &comboscripts[i]);
+            const int ret = write_one_ffscript(f, Header, i, &comboscripts[i]);
             fake_pack_writing=(writecycle==0);
             
             if(ret!=0)
@@ -11726,7 +11726,7 @@ int writeffscript(PACKFILE *f, zquestheader *Header)
     //the irony is that it causes an "unreachable code" warning.
 }
 
-int write_one_ffscript(PACKFILE *f, zquestheader *Header, int i, script_data **script)
+int write_one_ffscript(PACKFILE* f, zquestheader* Header, int i, script_data* const* script)
 {
     //these are here to bypass compiler warnings about unused arguments
     Header=Header;
@@ -11867,9 +11867,9 @@ int writesfx(PACKFILE *f, zquestheader *Header)
     //these are here to bypass compiler warnings about unused arguments
     Header=Header;
     
-    dword section_id=ID_SFX;
-    dword section_version=V_SFX;
-    dword section_cversion=CV_SFX;
+    const dword section_id=ID_SFX;
+    const dword section_version=V_SFX;
+    const dword section_cversion=CV_SFX;
     dword section_size=0;
     
     //section id
@@ -11966,7 +11966,7 @@ int writesfx(PACKFILE *f, zquestheader *Header)
             }
             
             //de-endianfy the data
-            int wordstowrite = (customsfxdata[i].bits==8?1:2)*(customsfxdata[i].stereo==0?1:2)*customsfxdata[i].len/sizeof(word);
+            const int wordstowrite = (customsfxdata[i].bits==8?1:2)*(customsfxdata[i].stereo==0?1:2)*customsfxdata[i].len/sizeof(word);
             
             for(int j=0; j<wordstowrite; j++)
             {
@@ -11998,9 +11998,9 @@ int writeinitdata(PACKFILE *f, zquestheader *Header)
     //these are here to bypass compiler warnings about unused arguments
     Header=Header;
     
-    dword section_id=ID_INITDATA;
-    dword section_version=V_INITDATA;
-    dword section_cversion=CV_INITDATA;
+    const dword section_id=ID_INITDATA;
+    const dword section_version=V_INITDATA;
+    const dword section_cversion=CV_INITDATA;
     dword section_size = 0;
     
     zinit.last_map=Map.getCurrMap();
@@ -12342,12 +12342,12 @@ int writeitemdropsets(PACKFILE *f, zquestheader *Header)
     //these are here to bypass compiler warnings about unused arguments
     Header=Header;
     
-    dword section_id=ID_ITEMDROPSETS;
-    dword section_version=V_ITEMDROPSETS;
-    dword section_cversion=CV_ITEMDROPSETS;
+    const dword section_id=ID_ITEMDROPSETS;
+    const dword section_version=V_ITEMDROPSETS;
+    const dword section_cversion=CV_ITEMDROPSETS;
     //  dword section_size=0;
     dword section_size = 0;
-    word num_item_drop_sets=count_item_drop_sets();
+    const word num_item_drop_sets=count_item_drop_sets();
     
     //section id
     if(!p_mputl(section_id,f))
@@ -12426,9 +12426,9 @@ int writeitemdropsets(PACKFILE *f, zquestheader *Header)
 
 int writefavorites(PACKFILE *f, zquestheader*)
 {
-    dword section_id=ID_FAVORITES;
-    dword section_version=V_FAVORITES;
-    dword section_cversion=CV_FAVORITES;
+    const dword section_id=ID_FAVORITES;
+    const dword section_version=V_FAVORITES;
+    const dword section_cversion=CV_FAVORITES;
     dword section_size = 0;
     
     //section id
@@ -12878,8 +12878,8 @@ int save_unencoded_quest(const char *filename, bool compressed)
 
 int save_quest(const char *filename, bool timed_save)
 {
-    int retention=timed_save?AutoSaveRetention:AutoBackupRetention;
-    bool compress=!(timed_save&&UncompressedAutoSaves);
+    const int retention=timed_save?AutoSaveRetention:AutoBackupRetention;
+    const bool compress=!(timed_save&&UncompressedAutoSaves);
     char ext1[5];
     ext1[0]=0;
     
@@ -13341,7 +13341,7 @@ void zmap::prv_secrets(bool high16only)
         {
             for(int iter=0; iter<1; ++iter)
             {
-                int checkflag=combobuf[s->ffdata[i]].flag;
+                const int checkflag=combobuf[s->ffdata[i]].flag;
                 
                 if(iter==1)
                 {

--- a/src/zq_class.h
+++ b/src/zq_class.h
@@ -255,12 +255,12 @@ void center_zq_class_dialogs();
 
 int writeitems(PACKFILE *f, zquestheader *Header);
 int writeweapons(PACKFILE *f, zquestheader *Header);
-int writemisccolors(PACKFILE *f, zquestheader *Header, miscQdata *Misc);
-int writegameicons(PACKFILE *f, zquestheader *Header, miscQdata *Misc);
+int writemisccolors(PACKFILE* f, zquestheader* Header, const miscQdata* Misc);
+int writegameicons(PACKFILE* f, zquestheader* Header, const miscQdata* Misc);
 int writedoorcombosets(PACKFILE *f, zquestheader *Header);
 int write_one_subscreen(PACKFILE *f, zquestheader *Header, int i);
 int writeffscript(PACKFILE *f, zquestheader *Header, bool keepdata);
-int write_one_ffscript(PACKFILE *f, zquestheader *Header, int i, script_data **script);
+int write_one_ffscript(PACKFILE* f, zquestheader* Header, int i, script_data* const* script);
 int writeitemdropsets(PACKFILE *f, zquestheader *Header);
 int writefavorites(PACKFILE *f, zquestheader *Header);
 #endif

--- a/src/zq_misc.h
+++ b/src/zq_misc.h
@@ -18,6 +18,7 @@
 #include "zdefs.h"
 #include "jwin.h"
 #include "sfx.h"
+#include "compat_config.h"
 
 #define MAXSCREENS 128
 #define MAXROOMTYPES   rMAX
@@ -61,7 +62,7 @@ INLINE int popup_menu(MENU *menu,int x,int y)
     return jwin_do_menu(menu,x,y);
 }
 
-INLINE int bit(int val,int b)
+INLINE constexpr int bit(int val,int b)
 {
     return (val>>b)&1;
 }

--- a/src/zq_tiles.cpp
+++ b/src/zq_tiles.cpp
@@ -34,6 +34,7 @@
 #include "questReport.h"
 #include "mem_debug.h"
 #include "ffasm.h"
+#include "compat_config.h"
 
 extern zcmodule moduledata;
 
@@ -2677,7 +2678,7 @@ int bestfit_cset_color(int cs, int r, int g, int b)
     {
         byte *rgbByte;
         RGB rgb;
-        
+        _MAYBE_UNUSED(rgb);
         // This seems to be right...
         if(cs==2 || cs==3 || cs==4)
             rgbByte = colordata + (CSET((Map.CurrScr()->color+1) * pdLEVEL + cs) + i) * 3;
@@ -2725,7 +2726,7 @@ int bestfit_cset_color_8bit(int r, int g, int b)
     {
         byte *rgbByte;
         RGB rgb;
-        
+        _MAYBE_UNUSED(rgb);
         int cs=i>>4;
         if(cs==2 || cs==3 || cs==4)
             rgbByte = colordata + (CSET((Map.CurrScr()->color+1) * pdLEVEL + cs) + (i%16)) * 3;
@@ -16753,23 +16754,24 @@ static ComboAttributesInfo comboattrinfo[]=
 	},
 	{
 		cDAMAGE1,
-		{ "Custom",NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
-		{ "Amount",NULL,NULL,NULL},{ NULL,NULL,NULL, NULL}
+        // TODO: Placing these as globals can prevent the need of casting
+		{ const_cast<char*>("Custom"),NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
+		{ const_cast<char*>("Amount"),NULL,NULL,NULL},{ NULL,NULL,NULL, NULL}
 	},
 	{
 		cDAMAGE2,
-		{ "Custom",NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
-		{ "Amount",NULL,NULL,NULL},{ NULL,NULL,NULL, NULL}
+		{ const_cast<char*>("Custom"),NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
+		{ const_cast<char*>("Amount"),NULL,NULL,NULL},{ NULL,NULL,NULL, NULL}
 	},
 	{
 		cDAMAGE3,
-		{ "Custom",NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
-		{ "Amount",NULL,NULL,NULL},{ NULL,NULL,NULL, NULL}
+		{ const_cast<char*>("Custom"),NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
+		{ const_cast<char*>("Amount"),NULL,NULL,NULL},{ NULL,NULL,NULL, NULL}
 	},
 	{
 		cDAMAGE4,
-		{ "Custom",NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
-		{ "Amount",NULL,NULL,NULL},{ NULL,NULL,NULL, NULL}
+		{ const_cast<char*>("Custom"),NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
+		{ const_cast<char*>("Amount"),NULL,NULL,NULL},{ NULL,NULL,NULL, NULL}
 	},
 	{ //35
 		cC_STATUE,
@@ -17198,18 +17200,18 @@ static ComboAttributesInfo comboattrinfo[]=
 	},
 	{ //120
 		cDAMAGE5,
-		{ "Custom",NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
-		{ "Amount",NULL,NULL,NULL},{ NULL,NULL,NULL, NULL}
+		{ const_cast<char*>("Custom"),NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
+		{ const_cast<char*>("Amount"),NULL,NULL,NULL},{ NULL,NULL,NULL, NULL}
 	},
 	{
 		cDAMAGE6,
-		{ "Custom",NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
-		{ "Amount",NULL,NULL,NULL},{ NULL,NULL,NULL, NULL}
+		{ const_cast<char*>("Custom"),NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
+		{ const_cast<char*>("Amount"),NULL,NULL,NULL},{ NULL,NULL,NULL, NULL}
 	},
 	{
 		cDAMAGE7,
-		{ "Custom",NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
-		{ NULL,NULL,NULL,NULL},{ "Amount",NULL,NULL, NULL}
+		{ const_cast<char*>("Custom"),NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL},
+		{ NULL,NULL,NULL,NULL},{ const_cast<char*>("Amount"),NULL,NULL, NULL}
 	},
 	{
 		cCHANGE,
@@ -18007,14 +18009,15 @@ static ComboAttributesInfo comboattrinfo[]=
 		// { (char *)"Enable", (char *)"Enable", NULL,NULL,NULL,NULL,NULL,NULL,NULL,(char*)"Clippings",(char*)"Specific Item",NULL,NULL,NULL,NULL,NULL},
 		
 		{ (char *)"Visuals", (char *)"Itemdrop", (char *)"SFX", (char *)"Next",(char *)"Continuous",(char *)"Room Item",(char *)"Secrets",(char *)"Kill Wpn",
-			"Engine",(char*)"Clippings",(char*)"Specific Item",(char*)"Undercombo",(char*)"Always Drop",(char*)"Drop Enemy",NULL,NULL},
+			(char*)"Engine",(char*)"Clippings",(char*)"Specific Item",(char*)"Undercombo",(char*)"Always Drop",(char*)"Drop Enemy",NULL,NULL},
 		{ NULL,NULL,NULL,NULL}, { (char *)"Sprite", (char *)"Dropset", (char *)"Sound", (char *)"Secret Type" },
 	},
 	{ 
 		258,
 		//if dropping an enemy from a script 1 to 20 combo
+        // TODO: a lot of these look like they are supposed to be "const char*"
 		{ (char *)"Visuals", (char *)"Itemdrop", (char *)"SFX", (char *)"Next",(char *)"Continuous",(char *)"No Poof",(char *)"Secrets",(char *)"Kill Wpn",
-			"Engine",(char*)"Clippings",(char*)"Specific Item",(char*)"Undercombo",(char*)"Always Drop",(char*)"Drop Enemy",NULL,NULL},
+			(char*)"Engine",(char*)"Clippings",(char*)"Specific Item",(char*)"Undercombo",(char*)"Always Drop",(char*)"Drop Enemy",NULL,NULL},
 		{ NULL,NULL,NULL,NULL}, { (char *)"Sprite", (char *)"Dropset", (char *)"Sound", (char *)"Secret Type" },
 	},
 	{ 

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -24643,7 +24643,8 @@ int jwin_zmeta_proc(int msg, DIALOG *d, int )
 				d->w = 0;
 				if(!meta.valid())
 				{
-					d->w = txtout(target, "Invalid ZASM metadata found!", d->x, d->y, disabled);
+                    char txt[29] = "Invalid ZASM metadata found!";
+					d->w = txtout(target, txt, d->x, d->y, disabled);
 					++ind;
 				}
 				
@@ -24674,7 +24675,8 @@ int jwin_zmeta_proc(int msg, DIALOG *d, int )
 				t_w = txtout(target, buf, d->x, d->y + ((++ind)*(text_height(font) + 3)), disabled);
 				d->w = zc_max(d->w, t_w);
 				bool indentrun = false;
-				int run_indent = txtout(NULL, "void run(", 0, 0, false);
+                char txt[10] = "void run(";
+				int run_indent = txtout(NULL, txt, 0, 0, false);
 				std::ostringstream oss;
 				oss << "void run(";
 				for(int q = 0; q < 8; ++q)
@@ -24684,7 +24686,7 @@ int jwin_zmeta_proc(int msg, DIALOG *d, int )
 						oss << ", ";
 					string type_name = ZScript::getTypeName(meta.run_types[q]);
 					lowerstr(type_name); //all lowercase for this output
-					if(oss.str().size() > (indentrun ? 41 : 50))
+					if(oss.str().size() > static_cast<size_t>(indentrun ? 41 : 50))
 					{
 						memset(buf, 0, sizeof(buf));
 						sprintf(buf, "%s", oss.str().c_str());
@@ -24712,7 +24714,8 @@ int jwin_zmeta_proc(int msg, DIALOG *d, int )
 			}
 			else
 			{
-				d->w = txtout(target, "No ZASM metadata found!", d->x, d->y, disabled);
+                char txt[24] = "No ZASM metadata found!";
+				d->w = txtout(target, txt, d->x, d->y, disabled);
 				d->h = text_height(font);
 			}
 			

--- a/src/zquest.h
+++ b/src/zquest.h
@@ -11,6 +11,7 @@
 #include "gamedata.h"
 #include "parser/parserDefs.h"
 #include "zfix.h"
+#include "compat_config.h"
 
 #define  INTERNAL_VERSION  0xA721
 
@@ -425,7 +426,7 @@ extern int  pblack,pwhite;
 extern double scale;
 extern bool vp_showpal, vp_showsize, vp_center;
 
-INLINE int pal_sum(RGB p)
+INLINE constexpr int pal_sum(RGB p)
 {
     return p.r + p.g + p.b;
 }

--- a/src/zsys.cpp
+++ b/src/zsys.cpp
@@ -431,7 +431,7 @@ int anim_3_4(int clk, int speed)
 static int seed = 0;
 //#define MASK 0x91B2A2D1
 //static int seed = 7351962;
-static int enc_mask[ENC_METHOD_MAX]= {0x4C358938,0x91B2A2D1,0x4A7C1B87,0xF93941E6,0xFD095E94};
+static int enc_mask[ENC_METHOD_MAX]= {0x4C358938,static_cast<int>(0x91B2A2D1),0x4A7C1B87,static_cast<int>(0xF93941E6),static_cast<int>(0xFD095E94)};
 static int pvalue[ENC_METHOD_MAX]= {0x62E9,0x7D14,0x1A82,0x02BB,0xE09C};
 static int qvalue[ENC_METHOD_MAX]= {0x3619,0xA26B,0xF03C,0x7B12,0x4E8F};
 

--- a/src/zsys.h
+++ b/src/zsys.h
@@ -41,7 +41,7 @@ void chop_path(char *path);
 int  vbound(int x,int low,int high);
 float vbound(float x,float low,float high);
 int  used_switch(int argc,char *argv[],const char *s);
-bool isinRect(int x,int y,int rx1,int ry1,int rx2,int ry2);
+constexpr bool isinRect(int x,int y,int rx1,int ry1,int rx2,int ry2);
 
 extern char zeldapwd[8];
 extern char zquestpwd[8];


### PR DESCRIPTION
This PR was tested using VS 2008, ZeldaClassic has a significant performance boost. Never dropped frames even in debug mode.

For ZQ, all that was tested was script compile, moving tiles around, saving, exiting. If there is other things that need testing let me know. Everything should work.

A `config_compat.h` file was made to not break compatibility with the current tootset. 

ffscript.ypp was mostly hard to follow, some the code could be analyzed for `const` variables but most could not, there about 48 warnings about non-class `const` rules but are ignored for now. CMakeList.txt was not touched.

There should a be a way to add the `-permissive` switch in `CMakeList.txt` for all supported compilers but will do that later.

Review comments will be added after this PR is created.