### PR TITLE
Fix unused values from 2.53 being left-over

### DIFF
--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -7197,6 +7197,1378 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
                     tempitem.flags |= ITEM_FLAG3; // Sideview gravity flag
             }
             
+	    if( version <= 0x253) //Nuke greyed-out flags/values from <=2.53, in case they are used in 2.54/2.55
+		{
+			switch(tempitem.family)
+			{
+				case itype_sword:
+				{
+					tempitem.flags &= ~(ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_brang:
+				{
+					tempitem.flags &= ~(ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_arrow:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_candle:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG3 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_whistle:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_bait:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_letter:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_potion:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_wand:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_ring:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_wallet:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_amulet:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_shield:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_bow:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_raft:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_ladder:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_book:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_magickey:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_bracelet:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_flippers:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_boots:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_hookshot:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_lens:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_hammer:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_dinsfire:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_faroreswind:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_nayruslove:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					break;
+				}
+				case itype_bomb:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_sbomb:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_clock:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_key:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_magiccontainer:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_triforcepiece:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_map:	case itype_compass:	case itype_bosskey:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_quiver:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_lkey:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_cbyrna:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG5);
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_rupee: case itype_arrowammo:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_fairy:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_magic: case itype_heart: case itype_heartcontainer: case itype_heartpiece: case itype_killem: case itype_bombammo:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_bombbag:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_rocs:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_hoverboots:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_spinscroll:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_crossscroll:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_quakescroll:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_whispring:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_chargering:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_perilscroll:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_wealthmedal:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_heartring:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_magicring:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_spinscroll2:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_quakescroll2:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_agony:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_stompboots:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_whimsicalring:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_perilring:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+				case itype_custom1: case itype_custom2: case itype_custom3: case itype_custom4: case itype_custom5:
+				case itype_custom6: case itype_custom7: case itype_custom8: case itype_custom9: case itype_custom10:
+				case itype_custom11: case itype_custom12: case itype_custom13: case itype_custom14: case itype_custom15:
+				case itype_custom16: case itype_custom17: case itype_custom18: case itype_custom19: case itype_custom20:
+				case itype_bowandarrow: case itype_letterpotion: case itype_misc:
+				{
+					tempitem.flags &= ~ (ITEM_FLAG1 | ITEM_FLAG2 | ITEM_FLAG3 | ITEM_FLAG4 | ITEM_FLAG5);
+					tempitem.misc1 = 0;
+					tempitem.misc2 = 0;
+					tempitem.misc3 = 0;
+					tempitem.misc4 = 0;
+					tempitem.misc5 = 0;
+					tempitem.misc6 = 0;
+					tempitem.misc7 = 0;
+					tempitem.misc8 = 0;
+					tempitem.misc9 = 0;
+					tempitem.misc10 = 0;
+					tempitem.wpn1 = 0;
+					tempitem.wpn2 = 0;
+					tempitem.wpn3 = 0;
+					tempitem.wpn4 = 0;
+					tempitem.wpn5 = 0;
+					tempitem.wpn6 = 0;
+					tempitem.wpn7 = 0;
+					tempitem.wpn8 = 0;
+					tempitem.wpn9 = 0;
+					tempitem.wpn10 = 0;
+					break;
+				}
+			}
+		}
 	    //Port quest rules to items
 	    if( s_version <= 31) 
 	    {

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -7197,7 +7197,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
                     tempitem.flags |= ITEM_FLAG3; // Sideview gravity flag
             }
             
-	    if( version <= 0x253) //Nuke greyed-out flags/values from <=2.53, in case they are used in 2.54/2.55
+	    if( version < 0x254) //Nuke greyed-out flags/values from <=2.53, in case they are used in 2.54/2.55
 		{
 			switch(tempitem.family)
 			{

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -7341,7 +7341,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7364,7 +7364,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7410,7 +7410,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7433,7 +7433,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7458,7 +7458,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7481,7 +7481,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7506,7 +7506,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7531,7 +7531,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7556,7 +7556,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7604,7 +7604,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7629,7 +7629,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7654,7 +7654,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7679,7 +7679,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7720,7 +7720,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7785,7 +7785,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7863,7 +7863,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7888,7 +7888,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7913,7 +7913,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7936,7 +7936,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7961,7 +7961,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -7984,7 +7984,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8009,7 +8009,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8051,7 +8051,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8073,7 +8073,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8098,7 +8098,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8121,7 +8121,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8146,7 +8146,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8193,7 +8193,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8218,7 +8218,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8241,7 +8241,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8265,7 +8265,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8288,7 +8288,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8312,7 +8312,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8336,7 +8336,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8359,7 +8359,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8382,7 +8382,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8406,7 +8406,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8429,7 +8429,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8453,7 +8453,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8478,7 +8478,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8502,7 +8502,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8526,7 +8526,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;
@@ -8555,7 +8555,7 @@ int readitems(PACKFILE *f, word version, word build, bool keepdata, bool zgpmode
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn1 = 0;
+					tempitem.wpn = 0;
 					tempitem.wpn2 = 0;
 					tempitem.wpn3 = 0;
 					tempitem.wpn4 = 0;


### PR DESCRIPTION
Nuke 'unused' (greyed-out) item editor values that were not
	script-readable in 2.53, though may have new use in 2.55.
	These values were presumed to always be 0 in 2.53 and prior,
	though an edge case allowed them to be set when they should
	not have been able to.