### PR TITLE
Fix a crash when using ZScript command ArrayCopy; add copyValues to F…

### DIFF
--- a/src/ffscript.cpp
+++ b/src/ffscript.cpp
@@ -31872,12 +31872,13 @@ void FFScript::do_strcpy(const bool a, const bool b)
 }
 void FFScript::do_arraycpy(const bool a, const bool b)
 {
-	long arrayptr_b = SH::get_arg(sarg1, a) / 10000;
-	long arrayptr_a = SH::get_arg(sarg2, b) / 10000;
-	long *P = NULL;
-	FFCore.getValues(arrayptr_a,P, FFCore.getSize(arrayptr_a));
+	long arrayptr_dest = SH::get_arg(sarg1, a) / 10000;
+	long arrayptr_src = SH::get_arg(sarg2, b) / 10000;
+	//long *P = NULL;
+	//FFCore.getValues(arrayptr_a,P, FFCore.getSize(arrayptr_a));
+	FFCore.copyValues(arrayptr_dest, arrayptr_src, FFCore.getSize(arrayptr_src));
 	//ZScriptArray& a = FFCore.getArray(arrayptr_a);
-	FFCore.setArray(arrayptr_b, FFCore.getSize(arrayptr_a), P);
+	//FFCore.setArray(arrayptr_b, FFCore.getSize(arrayptr_a), P);
 
 	//if(ArrayH::setArray(arrayptr_b, a.size(), a) == SH::_Overflow)
 	//	Z_scripterrlog("Dest string supplied to 'ArrayCopy()' not large enough\n");

--- a/src/ffscript.h
+++ b/src/ffscript.h
@@ -1625,7 +1625,24 @@ enum __Error
             num_chars--;
         }
     }
-    
+    //Copies clues for ZS array b to a. 
+    void copyValues(const long ptr, const long ptr2, word num_values)
+    {
+        ZScriptArray& a = getArray(ptr);
+        ZScriptArray& b = getArray(ptr2);
+        
+        if(a == INVALIDARRAY)
+            return;
+	
+	if(b == INVALIDARRAY)
+            return;
+            
+        for(word i = 0; ((checkUserArrayIndex(i, b.Size()) == _NoError) && (checkUserArrayIndex(i, a.Size()) == _NoError) ) && num_values != 0; i++)
+        {
+            a[i] = b[i];
+            num_values--;
+        }
+    }
     //Like getString but for an array of longs instead of chars. *(arrayPtr is not checked for validity)
     void getValues(const long ptr, long* arrayPtr, word num_values)
     {


### PR DESCRIPTION
…FCore.

Changelog: Fixed crash wien using the ZASM command ARRAYCOPY;
	ZScript `ArrayCopy(dest,src)` caused by an illegal pointer in the
	interpreter.

Added FFCore.copyValues(arr1, arr2). This functions like strcpy,
	but for ZScript long arrays.