### PR TITLE
Show Walkability fixes

### DIFF
--- a/src/maps.cpp
+++ b/src/maps.cpp
@@ -403,20 +403,49 @@ int MAPCOMBO2(int layer,int x,int y)
     return tmpscr2[layer].data[combo];                        // entire combo code
 }
 
+int MAPCOMBO3(int map, int screen, int layer, int x,int y)
+{
+	return MAPCOMBO3(map, screen, layer, COMBOPOS(x,y));
+}
+
+int MAPCOMBO3(int map, int screen, int layer, int pos)
+{ 
+	if (map < 0 || screen < 0) return 0;
+	
+	if(pos>175 || pos < 0)
+		return 0;
+		
+	mapscr const* m = &TheMaps[(map*MAPSCRS)+screen];
+	
+	if(m->data.empty()) return 0;
+    
+	if(m->valid==0) return 0;
+	
+	int mapid = (layer < 0 ? -1 : ((m->layermap[layer] - 1) * MAPSCRS + m->layerscreen[layer]));
+	
+	mapscr const* scr = ((mapid < 0 || mapid > MAXMAPS2*MAPSCRS) ? m : &TheMaps[mapid]);
+	
+	if(scr->data.empty()) return 0;
+    
+	if(scr->valid==0) return 0;
+		
+	return scr->data[pos];						// entire combo code
+}
+
 int MAPCSET2(int layer,int x,int y)
 {
-    if(layer==-1) return MAPCSET(x,y);
-    
-    if(tmpscr2[layer].cset.empty()) return 0;
-    
-    if(tmpscr2[layer].valid==0) return 0;
-    
-    int combo = COMBOPOS(x,y);
-    
-    if(combo>175 || combo < 0)
-        return 0;
-        
-    return tmpscr2[layer].cset[combo];                        // entire combo code
+	if(layer==-1) return MAPCSET(x,y);
+	
+	if(tmpscr2[layer].cset.empty()) return 0;
+	
+	if(tmpscr2[layer].valid==0) return 0;
+	
+	int combo = COMBOPOS(x,y);
+	
+	if(combo>175 || combo < 0)
+		return 0;
+		
+	return tmpscr2[layer].cset[combo];						// entire combo code
 }
 
 int MAPFLAG2(int layer,int x,int y)
@@ -1048,6 +1077,43 @@ bool ishookshottable(int bx, int by)
     }
     
     return ret;
+}
+
+bool ishookshottable(int map, int screen, int bx, int by)
+{
+	if (map < 0 || screen < 0) return false;
+		
+	mapscr *m = &TheMaps[(map*MAPSCRS)+screen];
+	
+	if(m->data.empty()) return false;
+	
+	if(m->valid==0) return false;
+	
+	if(!_walkflag(bx,by,1, m))
+		return true;
+		
+	bool ret = true;
+	
+	for(int i=2; i>=0; i--)
+	{
+		int c = MAPCOMBO3(map, screen, i-1,bx,by);
+		int t = combobuf[c].type;
+		
+		if(i == 0 && (t == cHOOKSHOTONLY || t == cLADDERHOOKSHOT)) return true;
+		
+		//bool dried = (iswater_type(t) && DRIEDLAKE);
+		
+		int b=1;
+		
+		if(bx&8) b<<=2;
+		
+		if(by&8) b<<=1;
+		
+		if(combobuf[c].walk&b && !(combo_class_buf[t].ladder_pass && t!=cLADDERONLY) && t!=cHOOKSHOTONLY)
+			ret = false;
+	}
+	
+	return ret;
 }
 
 bool hiddenstair(int tmp,bool redraw)                       // tmp = index of tmpscr[]

--- a/src/maps.h
+++ b/src/maps.h
@@ -33,6 +33,8 @@ int FFORCOMBOTYPE(int x, int y);
 int FFORCOMBO_L(int layer, int x, int y);
 int FFORCOMBOTYPE_L(int layer, int x, int y);
 int MAPCOMBO2(int layer,int x,int y);
+int MAPCOMBO3(int map, int screen, int layer,int x,int y);
+int MAPCOMBO3(int map, int screen, int layer,int pos);
 int MAPCSET2(int layer,int x,int y);
 int MAPFLAG2(int layer,int x,int y);
 int MAPCOMBOFLAG2(int layer,int x,int y);
@@ -74,6 +76,7 @@ bool isCuttableType(int type);
 bool isCuttableItemType(int type);
 bool isstepable(int combo);                                 //can use ladder on it
 bool ishookshottable(int bx, int by);
+bool ishookshottable(int map, int screen, int bx, int by);
 bool hiddenstair(int tmp, bool redraw);                      // tmp = index of tmpscr[]
 bool remove_lockblocks(int tmp);                // tmp = index of tmpscr[]
 bool remove_bosslockblocks(int tmp);            // tmp = index of tmpscr[]

--- a/src/zq_class.h
+++ b/src/zq_class.h
@@ -83,6 +83,7 @@ public:
     bool isDungeon(int scr);
     bool isstepable(int combo);
     bool ishookshottable(int bx, int by, int i);
+    bool ishookshottable(int map, int screen, int bx, int by, int i);
     int warpindex(int combo);
     bool clearall(bool validate);
     bool reset_templates(bool validate);
@@ -91,9 +92,12 @@ public:
     void clearzcmap(int map);
     int  load(const char *path);
     int  save(const char *path);
+    int MAPCOMBO3(int map, int screen, int layer, int x,int y);
+    int MAPCOMBO3(int map, int screen, int layer, int pos);
     int MAPCOMBO2(int lyr,int x,int y, int map = -1, int scr = -1);
     int MAPCOMBO(int x,int y, int map = -1, int scr = -1);
     void put_walkflags_layered(BITMAP *dest,int x,int y,int pos,int layer);
+    void put_walkflags_layered_external(BITMAP *dest,int x,int y,int pos,int layer, int map, int screen);
     bool misaligned(int map, int scr, int i, int dir);
     void check_alignments(BITMAP* dest,int x,int y,int scr=-1);
     void draw(BITMAP *dest,int x,int y,int flags,int map,int scr);


### PR DESCRIPTION
Fixed many bugs, some longstanding, with solidity drawing on screen previews.

The Show Walkability stuff both in ZQuest and with ZC's level 4 cheat should both work properly with bridge combos now.

Also fixed minor bug with solidity drawing if water is on layer 1 where it erroneously gets marked as swimmable.
