### PR TITLE
Smart screen scrolling fixes

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -19858,6 +19858,8 @@ bool LinkClass::nextcombo_solid(int d2)
         
     // want actual screen index, not game->maps[] index
     ns = (ns&127) + (ns>>7)*MAPSCRS;
+    int screen = (ns%MAPSCRS);
+    int map = (ns - screen) / MAPSCRS;
     
     int cx = x;
     int cy = y;
@@ -19885,6 +19887,7 @@ bool LinkClass::nextcombo_solid(int d2)
     
     if(d2==left||d2==right) cy+=bigHitbox?0:8;
     
+    
     // from MAPCOMBO()
     
     for(int i=0; i<=((bigHitbox&&!(d2==up||d2==down))?((cy&7)?2:1):((cy&7)?1:0)); cy+=8,i++)
@@ -19896,16 +19899,36 @@ bool LinkClass::nextcombo_solid(int d2)
             return true;
         }
         
-        newcombo c = combobuf[TheMaps[ns].data[cmb]];
-        bool dried = iswater_type(c.type) && DRIEDLAKE;
-        bool swim = iswater_type(c.type) && (current_item(itype_flippers) || action==rafting) && !dried;
-        int b=1;
+        newcombo const& c = combobuf[MAPCOMBO3(map, screen, -1,cx,cy, true)];
+	
+	int b=1;
         
         if(cx&8) b<<=2;
         
         if(cy&8) b<<=1;
+	
+	//bool bridgedetected = false;
+	
+	int walk = c.walk;
+	
+	for (int m = 0; m <= 1; m++)
+	{
+		newcombo const& cmb = combobuf[MAPCOMBO3(map, screen, m,cx,cy, true)];
+		if (cmb.type == cBRIDGE && !(cmb.walk&b)) 
+		{
+			walk &= cmb.walk;
+		}
+		else walk |= cmb.walk;
+        }
+	/*
+	if (bridgedetected)
+	{
+		continue;
+	}*/
+	
+        bool swim = iswater_type(c.type) && (current_item(itype_flippers) || action==rafting);
         
-        if((c.walk&b) && !dried && !swim)
+        if((walk&b) && !swim)
         {
             return true;
         }

--- a/src/maps.cpp
+++ b/src/maps.cpp
@@ -403,20 +403,49 @@ int MAPCOMBO2(int layer,int x,int y)
     return tmpscr2[layer].data[combo];                        // entire combo code
 }
 
+int MAPCOMBO3(int map, int screen, int layer, int x,int y)
+{
+	return MAPCOMBO3(map, screen, layer, COMBOPOS(x,y));
+}
+
+int MAPCOMBO3(int map, int screen, int layer, int pos)
+{ 
+	if (map < 0 || screen < 0) return 0;
+	
+	if(pos>175 || pos < 0)
+		return 0;
+		
+	mapscr const* m = &TheMaps[(map*MAPSCRS)+screen];
+	
+	if(m->data.empty()) return 0;
+    
+	if(m->valid==0) return 0;
+	
+	int mapid = (layer < 0 ? -1 : ((m->layermap[layer] - 1) * MAPSCRS + m->layerscreen[layer]));
+	
+	mapscr const* scr = ((mapid < 0 || mapid > MAXMAPS2*MAPSCRS) ? m : &TheMaps[mapid]);
+	
+	if(scr->data.empty()) return 0;
+    
+	if(scr->valid==0) return 0;
+		
+	return scr->data[pos];						// entire combo code
+}
+
 int MAPCSET2(int layer,int x,int y)
 {
-    if(layer==-1) return MAPCSET(x,y);
-    
-    if(tmpscr2[layer].cset.empty()) return 0;
-    
-    if(tmpscr2[layer].valid==0) return 0;
-    
-    int combo = COMBOPOS(x,y);
-    
-    if(combo>175 || combo < 0)
-        return 0;
-        
-    return tmpscr2[layer].cset[combo];                        // entire combo code
+	if(layer==-1) return MAPCSET(x,y);
+	
+	if(tmpscr2[layer].cset.empty()) return 0;
+	
+	if(tmpscr2[layer].valid==0) return 0;
+	
+	int combo = COMBOPOS(x,y);
+	
+	if(combo>175 || combo < 0)
+		return 0;
+		
+	return tmpscr2[layer].cset[combo];						// entire combo code
 }
 
 int MAPFLAG2(int layer,int x,int y)
@@ -1048,6 +1077,43 @@ bool ishookshottable(int bx, int by)
     }
     
     return ret;
+}
+
+bool ishookshottable(int map, int screen, int bx, int by)
+{
+	if (map < 0 || screen < 0) return false;
+		
+	mapscr *m = &TheMaps[(map*MAPSCRS)+screen];
+	
+	if(m->data.empty()) return false;
+	
+	if(m->valid==0) return false;
+	
+	if(!_walkflag(bx,by,1, m))
+		return true;
+		
+	bool ret = true;
+	
+	for(int i=2; i>=0; i--)
+	{
+		int c = MAPCOMBO3(map, screen, i-1,bx,by);
+		int t = combobuf[c].type;
+		
+		if(i == 0 && (t == cHOOKSHOTONLY || t == cLADDERHOOKSHOT)) return true;
+		
+		//bool dried = (iswater_type(t) && DRIEDLAKE);
+		
+		int b=1;
+		
+		if(bx&8) b<<=2;
+		
+		if(by&8) b<<=1;
+		
+		if(combobuf[c].walk&b && !(combo_class_buf[t].ladder_pass && t!=cLADDERONLY) && t!=cHOOKSHOTONLY)
+			ret = false;
+	}
+	
+	return ret;
 }
 
 bool hiddenstair(int tmp,bool redraw)                       // tmp = index of tmpscr[]

--- a/src/maps.h
+++ b/src/maps.h
@@ -33,8 +33,8 @@ int FFORCOMBOTYPE(int x, int y);
 int FFORCOMBO_L(int layer, int x, int y);
 int FFORCOMBOTYPE_L(int layer, int x, int y);
 int MAPCOMBO2(int layer,int x,int y);
-int MAPCOMBO3(int map, int screen, int layer,int x,int y);
-int MAPCOMBO3(int map, int screen, int layer,int pos);
+int MAPCOMBO3(int map, int screen, int layer,int x,int y, bool secrets = false);
+int MAPCOMBO3(int map, int screen, int layer,int pos, bool secrets = false);
 int MAPCSET2(int layer,int x,int y);
 int MAPFLAG2(int layer,int x,int y);
 int MAPCOMBOFLAG2(int layer,int x,int y);
@@ -78,6 +78,8 @@ bool isstepable(int combo);                                 //can use ladder on 
 bool ishookshottable(int bx, int by);
 bool ishookshottable(int map, int screen, int bx, int by);
 bool hiddenstair(int tmp, bool redraw);                      // tmp = index of tmpscr[]
+bool hiddenstair2(mapscr *s, bool redraw);                      
+bool remove_screenstatecombos2(mapscr *s, mapscr *t, int what1, int what2);
 bool remove_lockblocks(int tmp);                // tmp = index of tmpscr[]
 bool remove_bosslockblocks(int tmp);            // tmp = index of tmpscr[]
 bool remove_chests(int tmp);                    // tmp = index of tmpscr[]
@@ -86,6 +88,7 @@ bool remove_bosschests(int tmp);                // tmp = index of tmpscr[]
 bool overheadcombos(mapscr *s);
 void delete_fireball_shooter(mapscr *s, int i);
 void hidden_entrance(int tmp,bool refresh, bool high16only=false,int single=-1);
+void hidden_entrance2(mapscr *s, mapscr *t, bool high16only=false,int single=-1);
 void update_freeform_combos();
 bool findentrance(int x, int y, int flag, bool setflag);
 bool hitcombo(int x, int y, int combotype);

--- a/src/maps.h
+++ b/src/maps.h
@@ -33,6 +33,8 @@ int FFORCOMBOTYPE(int x, int y);
 int FFORCOMBO_L(int layer, int x, int y);
 int FFORCOMBOTYPE_L(int layer, int x, int y);
 int MAPCOMBO2(int layer,int x,int y);
+int MAPCOMBO3(int map, int screen, int layer,int x,int y);
+int MAPCOMBO3(int map, int screen, int layer,int pos);
 int MAPCSET2(int layer,int x,int y);
 int MAPFLAG2(int layer,int x,int y);
 int MAPCOMBOFLAG2(int layer,int x,int y);
@@ -74,6 +76,7 @@ bool isCuttableType(int type);
 bool isCuttableItemType(int type);
 bool isstepable(int combo);                                 //can use ladder on it
 bool ishookshottable(int bx, int by);
+bool ishookshottable(int map, int screen, int bx, int by);
 bool hiddenstair(int tmp, bool redraw);                      // tmp = index of tmpscr[]
 bool remove_lockblocks(int tmp);                // tmp = index of tmpscr[]
 bool remove_bosslockblocks(int tmp);            // tmp = index of tmpscr[]

--- a/src/zq_class.cpp
+++ b/src/zq_class.cpp
@@ -1217,8 +1217,7 @@ void zmap::put_walkflags_layered_external(BITMAP *dest,int x,int y,int pos,int l
         }
 	if (bridgedetected & (1<<i))
 	{
-		if (i >= 3) break;
-		else continue;
+		continue;
 	}
         if(layer==-1 && combo_class_buf[c.type].water!=0 && get_bit(quest_rules, qr_DROWN))
             rectfill(dest,tx,ty,tx+7,ty+7,vc(9));
@@ -1882,8 +1881,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         //check main screen
         cmbcheck1 = vbound(AbsoluteScr(map, scr)->data[i], 0, MAXCOMBOS-1);
         cmbcheck2 = vbound(AbsoluteScr(map, scr-16)->data[i+160], 0, MAXCOMBOS-1);
-        combocheck1.walk|=combobuf[cmbcheck1].walk;
-        combocheck2.walk|=combobuf[cmbcheck2].walk;
+        if (combobuf[cmbcheck1].type != cBRIDGE) combocheck1.walk|=combobuf[cmbcheck1].walk;
+        if (combobuf[cmbcheck2].type != cBRIDGE) combocheck2.walk|=combobuf[cmbcheck2].walk;
         
         //check layer 1
         layermap=AbsoluteScr(map, scr)->layermap[0]-1;
@@ -1892,7 +1891,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr)->layerscreen[0];
             cmbcheck1 = AbsoluteScr(layermap, layerscreen)->data[i];
-            combocheck1.walk|=combobuf[cmbcheck1].walk;
+            if (combobuf[cmbcheck1].type == cBRIDGE) combocheck1.walk&=combobuf[cmbcheck1].walk;
+	    else combocheck1.walk|=combobuf[cmbcheck1].walk;
         }
         
         layermap=AbsoluteScr(map, scr-16)->layermap[0]-1;
@@ -1901,7 +1901,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr-16)->layerscreen[0];
             cmbcheck2 = AbsoluteScr(layermap, layerscreen)->data[i+160];
-            combocheck2.walk|=combobuf[cmbcheck2].walk;
+            if (combobuf[cmbcheck2].type == cBRIDGE) combocheck2.walk&=combobuf[cmbcheck2].walk;
+	    else combocheck2.walk|=combobuf[cmbcheck2].walk;
         }
         
         //check layer 2
@@ -1912,7 +1913,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
             layerscreen=AbsoluteScr(map, scr)->layerscreen[1];
             
             cmbcheck1 = AbsoluteScr(layermap, layerscreen)->data[i];
-            combocheck1.walk|=combobuf[cmbcheck1].walk;
+            if (combobuf[cmbcheck1].type == cBRIDGE) combocheck1.walk&=combobuf[cmbcheck1].walk;
+	    else combocheck1.walk|=combobuf[cmbcheck1].walk;
         }
         
         layermap=AbsoluteScr(map, scr-16)->layermap[1]-1;
@@ -1921,7 +1923,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr-16)->layerscreen[1];
             cmbcheck2 = AbsoluteScr(layermap, layerscreen)->data[i+160];
-            combocheck2.walk|=combobuf[cmbcheck2].walk;
+            if (combobuf[cmbcheck2].type == cBRIDGE) combocheck2.walk&=combobuf[cmbcheck2].walk;
+	    else combocheck2.walk|=combobuf[cmbcheck2].walk;
         }
         
         if(((combocheck1.walk&5)*2)!=(combocheck2.walk&10))
@@ -1945,8 +1948,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         //check main screen
         cmbcheck1 = vbound(AbsoluteScr(map, scr)->data[i], 0, MAXCOMBOS-1);
         cmbcheck2 = vbound(AbsoluteScr(map, scr+16)->data[i-160], 0, MAXCOMBOS-1);
-        combocheck1.walk|=combobuf[cmbcheck1].walk;
-        combocheck2.walk|=combobuf[cmbcheck2].walk;
+        if (combobuf[cmbcheck1].type != cBRIDGE) combocheck1.walk|=combobuf[cmbcheck1].walk;
+        if (combobuf[cmbcheck2].type != cBRIDGE) combocheck2.walk|=combobuf[cmbcheck2].walk;
         
         
         //check layer 1
@@ -1956,7 +1959,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr)->layerscreen[0];
             cmbcheck1 = AbsoluteScr(layermap, layerscreen)->data[i];
-            combocheck1.walk|=combobuf[cmbcheck1].walk;
+            if (combobuf[cmbcheck1].type == cBRIDGE) combocheck1.walk&=combobuf[cmbcheck1].walk; 
+		else combocheck1.walk|=combobuf[cmbcheck1].walk;
         }
         
         layermap=AbsoluteScr(map, scr+16)->layermap[0]-1;
@@ -1965,7 +1969,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr+16)->layerscreen[0];
             cmbcheck2 = AbsoluteScr(layermap, layerscreen)->data[i-160];
-            combocheck2.walk|=combobuf[cmbcheck2].walk;
+            if (combobuf[cmbcheck2].type == cBRIDGE) combocheck2.walk&=combobuf[cmbcheck2].walk; 
+		else combocheck2.walk|=combobuf[cmbcheck2].walk;
         }
         
         //check layer 2
@@ -1975,7 +1980,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr)->layerscreen[1];
             cmbcheck1 = AbsoluteScr(layermap, layerscreen)->data[i];
-            combocheck1.walk|=combobuf[cmbcheck1].walk;
+            if (combobuf[cmbcheck1].type == cBRIDGE) combocheck1.walk&=combobuf[cmbcheck1].walk; 
+		else combocheck1.walk|=combobuf[cmbcheck1].walk;
         }
         
         layermap=AbsoluteScr(map, scr+16)->layermap[1]-1;
@@ -1984,7 +1990,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr+16)->layerscreen[1];
             cmbcheck2 = AbsoluteScr(layermap, layerscreen)->data[i-160];
-            combocheck2.walk|=combobuf[cmbcheck2].walk;
+            if (combobuf[cmbcheck2].type == cBRIDGE) combocheck2.walk&=combobuf[cmbcheck2].walk; 
+		else combocheck2.walk|=combobuf[cmbcheck2].walk;
         }
         
         if((combocheck1.walk&10)!=((combocheck2.walk&5)*2))
@@ -2008,8 +2015,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         //check main screen
         cmbcheck1 = AbsoluteScr(map, scr)->data[i];
         cmbcheck2 = AbsoluteScr(map, scr-1)->data[i+15];
-        combocheck1.walk|=combobuf[cmbcheck1].walk;
-        combocheck2.walk|=combobuf[cmbcheck2].walk;
+        if (combobuf[cmbcheck1].type != cBRIDGE) combocheck1.walk|=combobuf[cmbcheck1].walk;
+        if (combobuf[cmbcheck2].type != cBRIDGE) combocheck2.walk|=combobuf[cmbcheck2].walk;
         
         //check layer 1
         layermap=AbsoluteScr(map, scr)->layermap[0]-1;
@@ -2018,7 +2025,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr)->layerscreen[0];
             cmbcheck1 = AbsoluteScr(layermap, layerscreen)->data[i];
-            combocheck1.walk|=combobuf[cmbcheck1].walk;
+            if (combobuf[cmbcheck1].type == cBRIDGE) combocheck1.walk&=combobuf[cmbcheck1].walk; 
+		else combocheck1.walk|=combobuf[cmbcheck1].walk;
         }
         
         layermap=AbsoluteScr(map, scr-1)->layermap[0]-1;
@@ -2027,7 +2035,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr-1)->layerscreen[0];
             cmbcheck2 = AbsoluteScr(layermap, layerscreen)->data[i+15];
-            combocheck2.walk|=combobuf[cmbcheck2].walk;
+            if (combobuf[cmbcheck2].type == cBRIDGE) combocheck2.walk&=combobuf[cmbcheck2].walk; 
+		else combocheck2.walk|=combobuf[cmbcheck2].walk;
         }
         
         //check layer 2
@@ -2037,7 +2046,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr)->layerscreen[1];
             cmbcheck1 = AbsoluteScr(layermap, layerscreen)->data[i];
-            combocheck1.walk|=combobuf[cmbcheck1].walk;
+            if (combobuf[cmbcheck1].type == cBRIDGE) combocheck1.walk&=combobuf[cmbcheck1].walk; 
+		else combocheck1.walk|=combobuf[cmbcheck1].walk;
         }
         
         layermap=AbsoluteScr(map, scr-1)->layermap[1]-1;
@@ -2046,7 +2056,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr-1)->layerscreen[1];
             cmbcheck2 = AbsoluteScr(layermap, layerscreen)->data[i+15];
-            combocheck2.walk|=combobuf[cmbcheck2].walk;
+            if (combobuf[cmbcheck2].type == cBRIDGE) combocheck2.walk&=combobuf[cmbcheck2].walk; 
+		else combocheck2.walk|=combobuf[cmbcheck2].walk;
         }
         
         if(((combocheck1.walk&3)*4)!=(combocheck2.walk&12))
@@ -2071,8 +2082,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         //check main screen
         cmbcheck1 = AbsoluteScr(map, scr)->data[i];
         cmbcheck2 = AbsoluteScr(map, scr+1)->data[i-15];
-        combocheck1.walk|=combobuf[cmbcheck1].walk;
-        combocheck2.walk|=combobuf[cmbcheck2].walk;
+        if (combobuf[cmbcheck1].type != cBRIDGE) combocheck1.walk|=combobuf[cmbcheck1].walk;
+        if (combobuf[cmbcheck2].type != cBRIDGE) combocheck2.walk|=combobuf[cmbcheck2].walk;
         
         //check layer 1
         layermap=AbsoluteScr(map, scr)->layermap[0]-1;
@@ -2081,7 +2092,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr)->layerscreen[0];
             cmbcheck1 = AbsoluteScr(layermap, layerscreen)->data[i];
-            combocheck1.walk|=combobuf[cmbcheck1].walk;
+            if (combobuf[cmbcheck1].type == cBRIDGE) combocheck1.walk&=combobuf[cmbcheck1].walk; 
+		else combocheck1.walk|=combobuf[cmbcheck1].walk;
         }
         
         layermap=AbsoluteScr(map, scr+1)->layermap[0]-1;
@@ -2090,7 +2102,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr+1)->layerscreen[0];
             cmbcheck2 = AbsoluteScr(layermap, layerscreen)->data[i-15];
-            combocheck2.walk|=combobuf[cmbcheck2].walk;
+            if (combobuf[cmbcheck2].type == cBRIDGE) combocheck2.walk&=combobuf[cmbcheck2].walk; 
+		else combocheck2.walk|=combobuf[cmbcheck2].walk;
         }
         
         //check layer 2
@@ -2100,7 +2113,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
         {
             layerscreen=AbsoluteScr(map, scr)->layerscreen[1];
             cmbcheck1 = AbsoluteScr(layermap, layerscreen)->data[i];
-            combocheck1.walk|=combobuf[cmbcheck1].walk;
+            if (combobuf[cmbcheck1].type == cBRIDGE) combocheck1.walk&=combobuf[cmbcheck1].walk; 
+		else combocheck1.walk|=combobuf[cmbcheck1].walk;
         }
         
         layermap=AbsoluteScr(map, scr+1)->layermap[1]-1;
@@ -2110,7 +2124,8 @@ bool zmap::misaligned(int map, int scr, int i, int dir)
             layerscreen=AbsoluteScr(map, scr+1)->layerscreen[1];
             
             cmbcheck2 = AbsoluteScr(layermap, layerscreen)->data[i-15];
-            combocheck2.walk|=combobuf[cmbcheck2].walk;
+            if (combobuf[cmbcheck2].type == cBRIDGE) combocheck2.walk&=combobuf[cmbcheck2].walk; 
+		else combocheck2.walk|=combobuf[cmbcheck2].walk;
         }
         
         if((combocheck1.walk&12)!=((combocheck2.walk&3)*4))
@@ -2290,6 +2305,8 @@ int zmap::MAPCOMBO3(int map, int screen, int layer, int pos)
 	if(m->valid==0) return 0;
 	
 	int mapid = (layer < 0 ? -1 : ((m->layermap[layer] - 1) * MAPSCRS + m->layerscreen[layer]));
+	
+	if (layer >= 0 && (mapid < 0 || mapid > MAXMAPS2*MAPSCRS)) return 0;
 	
 	mapscr const* scr = ((mapid < 0 || mapid > MAXMAPS2*MAPSCRS) ? m : &TheMaps[mapid]);
 	
@@ -3536,7 +3553,42 @@ void zmap::drawblock(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
         rectfill(dest,x,y,x+15,y+15,0);
     }
     
+    for(int k=1; k<3; k++)
+    {
+        if(LayerMaskInt[k+1]!=0 && (k==1)?(layer->flags7&fLAYER2BG):(layer->flags7&fLAYER3BG))
+        {
+            layermap=layer->layermap[k]-1;
+            
+            if(layermap>-1 && layermap<map_count)
+            {
+                layerscreen=layermap*MAPSCRS+layer->layerscreen[2-1];
+                
+                for(int i=c; i<176; i+=16)
+                {
+                    if(layer->layeropacity[k]<255)
+                    {
+                        overcombotranslucent(dest,x,y,TheMaps[layerscreen].data[i],TheMaps[layerscreen].cset[i],layer->layeropacity[k]);
+                    }
+                    else
+                    {
+                        overcombo(dest,x,y,TheMaps[layerscreen].data[i],TheMaps[layerscreen].cset[i]);
+                    }
+                }
+            }
+        }
+    }
+    
     // int cs=2;
+    if(LayerMaskInt[0]!=0)
+    {
+        word cmbdat = layer->data[c];
+        byte cmbcset = layer->cset[c];
+        int cmbflag = layer->sflag[c];
+        if(layer->flags7&fLAYER3BG||layer->flags7&fLAYER2BG)
+			overcombo(dest,x,y,cmbdat,cmbcset);
+		else put_combo(dest,x,y,cmbdat,cmbcset,((flags|dark)&~cWALK),cmbflag);
+    }
+    
     
     for(int k=0; k<2; k++)
     {
@@ -3558,16 +3610,6 @@ void zmap::drawblock(BITMAP* dest,int x,int y,int flags,int c,int map,int scr)
                 }
             }
         }
-    }
-    
-    if(LayerMaskInt[0]!=0)
-    {
-        word cmbdat = layer->data[c];
-        byte cmbcset = layer->cset[c];
-        int cmbflag = layer->sflag[c];
-        if(layer->flags7&fLAYER3BG||layer->flags7&fLAYER2BG)
-			overcombo(dest,x,y,cmbdat,cmbcset);
-		else put_combo(dest,x,y,cmbdat,cmbcset,((flags|dark)&~cWALK),cmbflag);
     }
 	
     for(int k=2; k<4; k++)

--- a/src/zq_class.h
+++ b/src/zq_class.h
@@ -83,6 +83,7 @@ public:
     bool isDungeon(int scr);
     bool isstepable(int combo);
     bool ishookshottable(int bx, int by, int i);
+    bool ishookshottable(int map, int screen, int bx, int by, int i);
     int warpindex(int combo);
     bool clearall(bool validate);
     bool reset_templates(bool validate);
@@ -91,9 +92,12 @@ public:
     void clearzcmap(int map);
     int  load(const char *path);
     int  save(const char *path);
+    int MAPCOMBO3(int map, int screen, int layer, int x,int y);
+    int MAPCOMBO3(int map, int screen, int layer, int pos);
     int MAPCOMBO2(int lyr,int x,int y, int map = -1, int scr = -1);
     int MAPCOMBO(int x,int y, int map = -1, int scr = -1);
     void put_walkflags_layered(BITMAP *dest,int x,int y,int pos,int layer);
+    void put_walkflags_layered_external(BITMAP *dest,int x,int y,int pos,int layer, int map, int screen);
     bool misaligned(int map, int scr, int i, int dir);
     void check_alignments(BITMAP* dest,int x,int y,int scr=-1);
     void draw(BITMAP *dest,int x,int y,int flags,int map,int scr);


### PR DESCRIPTION
WARNING: please merge the "Show Walkability" pull request I made first. This is built on top of that because I lack foresight.

Smart Screen Scrolling has been infamous for being a gigantic buggy mess prior to this point. I have fixed a massive amount of bugginess with this behavior; from layer solidity not being respected, to screen flags such as secrets and locks and chests not being respected, and more. Also made bridges compatible with this.

Also made bridges compatible with the show misalignments feature, and fixed an oversight that the Show Walkability changes had with bridges.