### PR TITLE
2.55 link defend GUI

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -1195,7 +1195,7 @@ void LinkClass::init()
 	walkspeed = 0; //not used, yet. -Z
 	for ( int q = 0; q < NUM_HIT_TYPES_USED; q++ ) lastHitBy[q][0] = 0; 
 	for ( int q = 0; q < NUM_HIT_TYPES_USED; q++ ) lastHitBy[q][1] = 0; 
-	for ( int q = 0; q < wMax; q++ ) defence[q] = 0; //we will need to have a Link section in the quest load/save code! -Z
+	for ( int q = 0; q < wMax; q++ ) defence[q] = link_defence[q]; //we will need to have a Link section in the quest load/save code! -Z Added 3/26/21 - Jman
 	
 	//Run script!
 	if (( FFCore.getQuestHeaderInfo(vZelda) >= 0x255 ) && (game->get_hasplayed()) ) //if (!hasplayed) runs in game_loop()

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -9335,6 +9335,7 @@ int readlinksprites2(PACKFILE *f, int v_linksprites, int cv_linksprites, bool ke
     {
         zinit.link_swim_speed=67; //default
         setuplinktiles(zinit.linkanimationstyle);
+        setuplinkdefenses();
     }
     
     if(v_linksprites>=0)
@@ -9728,6 +9729,7 @@ int readlinksprites3(PACKFILE *f, int v_linksprites, int cv_linksprites, bool ke
     {
         zinit.link_swim_speed=67; //default
         setuplinktiles(zinit.linkanimationstyle);
+        setuplinkdefenses();
     }
     
     int tile, tile2;
@@ -10561,6 +10563,29 @@ int readlinksprites3(PACKFILE *f, int v_linksprites, int cv_linksprites, bool ke
 				}
 			}
 		}
+        if (v_linksprites > 7)
+        {
+            int num_defense = wMax;
+            byte def = 0;
+
+            //Set num_defense accordingly if changes to enum require version upgrade - Jman
+            /*if(v_linksprites > [x])
+            * {
+            *     num_defense = 146 //value of wMax on version 8
+            * }
+            */
+
+            for (int q = 0; q < num_defense; q++)
+            {
+                if (!p_getc(&def, f, keepdata))
+                    return qe_invalid;
+
+                if (keepdata)
+                {
+                    link_defence[q] = def;
+                }
+            }
+        }
     }
     
     return 0;

--- a/src/zc_custom.cpp
+++ b/src/zc_custom.cpp
@@ -25,6 +25,8 @@ int script_link_sprite = 0;
 int script_link_flip = -1;
 int script_link_cset = -1;
 
+byte link_defence[wMax];
+
 int old_floatspr, old_slashspr, linkspr;
 int walkspr[4][3];                                   //dir,                           tile/flip/extend
 int stabspr[4][3];                                   //dir,                           tile/flip/extend
@@ -685,5 +687,15 @@ void setuplinktiles(int style)
     default:
         break;
     }
+}
+
+void setuplinkdefenses()
+{
+    //For now this just zeroes out Link's defenses by default, set these to appropriate defaults if necessary if defense implementation is extended. -Jman
+    for (int i = 0; i < wMax; i++)
+    {
+        link_defence[i] = 0;
+    }
+    
 }
 

--- a/src/zc_custom.h
+++ b/src/zc_custom.h
@@ -11,6 +11,8 @@
 #ifndef _ZC_CUSTOM_H_
 #define _ZC_CUSTOM_H_
 
+#include "zdefs.h";
+
 enum
 {
     ls_walk, ls_slash, ls_stab, ls_pound, ls_float, ls_dive,
@@ -26,6 +28,8 @@ enum { las_original, las_bszelda, las_zelda3, las_zelda3slow, las_max };
 extern int script_link_sprite;
 extern int script_link_cset;
 extern int script_link_flip;
+
+extern byte link_defence[wMax];
 
 extern int old_floatspr, old_slashspr, linkspr;
 extern int walkspr[4][3];                                   //dir,                           tile/flip/extend
@@ -68,5 +72,6 @@ void linktile(int *tile, int *flip, int state, int dir, int style);
 void linktile(int *tile, int *flip, int *extend, int state, int dir, int style);
 void setuplinktiles(int style);
 void setlinktile(int tile, int flip, int extend, int state, int dir);
+void setuplinkdefenses();
 #endif
 

--- a/src/zdefs.h
+++ b/src/zdefs.h
@@ -229,7 +229,7 @@ enum {ENC_METHOD_192B104=0, ENC_METHOD_192B105, ENC_METHOD_192B185, ENC_METHOD_2
 #define V_CHEATS           1
 #define V_SAVEGAME        18 //skipped 13->15 for 2.53.1
 #define V_COMBOALIASES     3
-#define V_LINKSPRITES      7
+#define V_LINKSPRITES      8
 #define V_SUBSCREEN        6
 #define V_ITEMDROPSETS     2
 #define V_FFSCRIPT         18

--- a/src/zq_class.cpp
+++ b/src/zq_class.cpp
@@ -10845,6 +10845,11 @@ int writelinksprites(PACKFILE *f, zquestheader *Header)
 			if(!p_putc((byte)medallionsprs[q][spr_extend],f))
 				new_return(15);
 		}
+        for (int q = 0; q < wMax; q++) // Link defense values
+        {
+            if (!p_putc(link_defence[q], f))
+                new_return(15);
+        }
 		//}
 		
         if(writecycle==0)

--- a/src/zq_custom.cpp
+++ b/src/zq_custom.cpp
@@ -9743,7 +9743,7 @@ static int linktile_land_slash_list[] =
 static int linktile_land_stab_list[] =
 {
     // dialog control number
-    27, 28, 29, 30, 31, 32, 33, 34, -1
+    27, 28, 29, 30, 31, 32, 33, 34,  -1
 };
 
 static int linktile_land_pound_list[] =
@@ -9838,6 +9838,41 @@ static TABPANEL linktile_water_tabs[] =
     { NULL,                 0,           NULL,                     0, NULL }
 };
 
+static int linktile_defense_enemy1_list[] =
+{
+    //dialog control number
+    114, 115, 116, 117, 118, 119, 120, 121, 122, 137, 138, 139, 140, 141, 142, 143, 144, 145, 160, -1
+};
+
+static int linktile_defense_enemy2_list[] =
+{
+    //dialog control number
+    123, 124, 125, 126, 127, 128, 129, 130, 146, 147, 148, 149, 150, 151, 152, 153, -1
+};
+
+static int linktile_defense_other1_list[] =
+{
+    //dialog control number
+    131, 132, 133, 134, 135, 136, 154, 155, 156, 157, 158, 159, -1
+};
+
+static int linktile_defense_script_list[] =
+{
+    //dialog control number
+    161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, -1
+};
+
+static TABPANEL linktile_defense_tabs[] =
+{
+    // (text)
+    { (char*)"Enemy 1",     D_SELECTED,  linktile_defense_enemy1_list, 0, NULL },
+    { (char*)"Enemy 2",     0,           linktile_defense_enemy2_list, 0, NULL },
+    { (char*)"Other",       0,           linktile_defense_other1_list, 0, NULL },
+    { (char*)"Script",      0,           linktile_defense_script_list, 0, NULL },
+    { NULL,                 0,           NULL,                     0, NULL }
+};
+
+
 static int linktile_land_list[] =
 {
     // dialog control number
@@ -9850,11 +9885,25 @@ static int linktile_water_list[] =
     10, -1
 };
 
+static int linktile_defense_list[] =
+{
+    // dialog control number
+    113, -1
+};
+
+static int linktile_option_list[] =
+{
+    // dialog control number
+    181, 182, 183, 184, 185, 186, -1
+};
+
 static TABPANEL linktile_tabs[] =
 {
     // (text)
-    { (char *)"Land",       D_SELECTED,   linktile_land_list, 0, NULL },
-    { (char *)"Water",      0,            linktile_water_list, 0, NULL },
+    { (char *)"Sprites (Land)",       D_SELECTED,   linktile_land_list, 0, NULL },
+    { (char *)"Sprites (Water)",      0,            linktile_water_list, 0, NULL },
+    { (char *)"Defenses",             0,            linktile_defense_list, 0, NULL},
+    { (char *)"Options",              0,            linktile_option_list, 0, NULL  }, 
     { NULL,                 0,            NULL,                0, NULL }
 };
 
@@ -9916,16 +9965,16 @@ static DIALOG linktile_dlg[] =
     {  jwin_win_proc,                        0,      0,    320,    240,    vc(14),                 vc(1),                   0,    D_EXIT,     0,          0, (void *) "Link Sprites",         NULL,   NULL                   },
     {  d_vsync_proc,                         0,      0,      0,      0,    0,                      0,                       0,    0,          0,          0,               NULL,                            NULL,   NULL                   },
     {  d_keyboard_proc,                      0,      0,      0,      0,    0,                      0,                       0,    0,          KEY_F1,     0, (void *) onHelp,                 NULL,   NULL                   },
-    {  jwin_button_proc,                    90,    215,     61,     21,    vc(14),                 vc(1),                  13,    D_EXIT,     0,          0, (void *) "OK",                   NULL,   NULL                   },
-    {  jwin_button_proc,                   170,    215,     61,     21,    vc(14),                 vc(1),                  27,    D_EXIT,     0,          0, (void *) "Cancel",               NULL,   NULL                   },
+    {  jwin_button_proc,                    90,    217,     61,     21,    vc(14),                 vc(1),                  13,    D_EXIT,     0,          0, (void *) "OK",                   NULL,   NULL                   },
+    {  jwin_button_proc,                   170,    217,     61,     21,    vc(14),                 vc(1),                  27,    D_EXIT,     0,          0, (void *) "Cancel",               NULL,   NULL                   },
     // 5
-    {  jwin_check_proc,                    217,    200,      0,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void *) "Large Link Hit Box",   NULL,   NULL                   },
-    {  jwin_text_proc,                       4,    201,     17,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void *) "Animation Style:",     NULL,   NULL                   },
-    {  jwin_as_droplist_proc,               77,    197,     78,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,          0,          0, (void *) &animationstyle_list,   NULL,   NULL                   },
-    {  jwin_tab_proc,                        4,     25,    312,    150,    0,                      0,                       0,    0,          0,          0, (void *) linktile_tabs,          NULL, (void *)linktile_dlg   },
+    {  d_dummy_proc,                       217,    200,      0,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void *) "Large Link Hit Box",   NULL,   NULL                   },
+    {  d_dummy_proc,                         4,    201,     17,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void *) "Animation Style:",     NULL,   NULL                   },
+    {  d_dummy_proc,                        77,    197,     78,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,          0,          0, (void *) &animationstyle_list,   NULL,   NULL                   },
+    {  jwin_tab_proc,                        4,     17,    312,    200,    0,                      0,                       0,    0,          0,          0, (void *) linktile_tabs,          NULL, (void *)linktile_dlg   },
     // 9
-    {  jwin_tab_proc,                        7,     46,    305,    125,    0,                      0,                       0,    0,          0,          0, (void *) linktile_land_tabs,     NULL, (void *)linktile_dlg   },
-    {  jwin_tab_proc,                        7,     46,    305,    125,    0,                      0,                       0,    0,          0,          0, (void *) linktile_water_tabs,    NULL, (void *)linktile_dlg   },
+    {  jwin_tab_proc,                        7,     33,    305,    183,    0,                      0,                       0,    0,          0,          0, (void *) linktile_land_tabs,     NULL, (void *)linktile_dlg   },
+    {  jwin_tab_proc,                        7,     33,    305,    183,    0,                      0,                       0,    0,          0,          0, (void *) linktile_water_tabs,    NULL, (void *)linktile_dlg   },
     // 11 (walk sprite titles)
     {  jwin_rtext_proc,                     33,     88,     32,      8,    jwin_pal[jcBOXFG],      jwin_pal[jcBOX],         0,    0,          0,          0, (void *) "Up",                   NULL,   NULL                   },
     {  jwin_rtext_proc,                    101,     88,     32,      8,    jwin_pal[jcBOXFG],      jwin_pal[jcBOX],         0,    0,          0,          0, (void *) "Down",                 NULL,   NULL                   },
@@ -10011,7 +10060,7 @@ static DIALOG linktile_dlg[] =
     // 74 (hold sprites)
     {  d_ltile_proc,                        70,     74,     40,     40,    6,                      jwin_pal[jcBOX],         0,    0,          up,         ls_waterhold1,   NULL,                            NULL,   NULL                   },
     {  d_ltile_proc,                        70,    112,     40,     40,    6,                      jwin_pal[jcBOX],         0,    0,          left,       ls_waterhold2,   NULL,                            NULL,   NULL                   },
-    {  jwin_check_proc,                    217,    186,      0,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void *) "Diagonal Movement",    NULL,   NULL                   },
+    {  d_dummy_proc,                       217,    186,      0,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void *) "Diagonal Movement",    NULL,   NULL                   },
     // 77 (jump sprite titles)
     {  jwin_rtext_proc,                     33,     88,     32,      8,    jwin_pal[jcBOXFG],      jwin_pal[jcBOX],         0,    0,          0,          0, (void *) "Up",                   NULL,   NULL                   },
     {  jwin_rtext_proc,                    101,     88,     32,      8,    jwin_pal[jcBOXFG],      jwin_pal[jcBOX],         0,    0,          0,          0, (void *) "Down",                 NULL,   NULL                   },
@@ -10034,8 +10083,8 @@ static DIALOG linktile_dlg[] =
     {  d_ltile_proc,                       104,    112,     40,     40,    6,                      jwin_pal[jcBOX],         0,    0,          right,      ls_charge,       NULL,                            NULL,   NULL                   },
     // 93
     {  d_timer_proc,                         0,      0,      0,      0,    0,                      0,                       0,    0,          0,          0,               NULL,                            NULL,   NULL                   },
-    {  jwin_text_proc,                       4,    183,     17,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void *) "Swim Speed:",          NULL,   NULL                   },
-    {  jwin_droplist_proc,                  77,    179,     78,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,          0,          0, (void *) &swimspeed_list,        NULL,   NULL                   },
+    {  d_dummy_proc,                         4,    183,     17,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void *) "Swim Speed:",          NULL,   NULL                   },
+    {  d_dummy_proc,                        77,    179,     78,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,          0,          0, (void *) &swimspeed_list,        NULL,   NULL                   },
     {  d_keyboard_proc,   0,    0,    0,    0,    0,    0,    0,       0,       KEY_F12,          0, (void *) onSnapshot, NULL, NULL },
     // 97 (drown sprite titles)
     {  jwin_rtext_proc,                     33,     88,     32,      8,    jwin_pal[jcBOXFG],      jwin_pal[jcBOX],         0,    0,          0,          0, (void *) "Up",                   NULL,   NULL                   },
@@ -10057,7 +10106,97 @@ static DIALOG linktile_dlg[] =
     {  d_ltile_proc,                       104,     74,     40,     40,    6,                      jwin_pal[jcBOX],         0,    0,          down,       ls_falling,         NULL,                            NULL,   NULL                   },
     {  d_ltile_proc,                        36,    112,     40,     40,    6,                      jwin_pal[jcBOX],         0,    0,          left,       ls_falling,         NULL,                            NULL,   NULL                   },
     {  d_ltile_proc,                       104,    112,     40,     40,    6,                      jwin_pal[jcBOX],         0,    0,          right,      ls_falling,         NULL,                            NULL,   NULL                   },
-    {  NULL,                                 0,      0,      0,      0,    0,                      0,                       0,    0,          0,          0,               NULL,                            NULL,   NULL                   }
+    // DEFENSE TAB BEGINS
+    // 113 (Link defenses)
+    { jwin_tab_proc,                        7,      33,    305,    183,    0,                      0,                       0,    0,          0,          0, (void*)linktile_defense_tabs,    NULL, (void*)linktile_dlg },
+    // 114 - Enemy weapons (currently 17)
+    { jwin_text_proc,           9,     54,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Fireball Defense:",                                  NULL,   NULL },
+    { jwin_text_proc,           9,     72,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Arrow Defense:",                                     NULL,   NULL },
+    { jwin_text_proc,           9,     90,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Boomerang Defense:",                                 NULL,   NULL },
+    { jwin_text_proc,           9,    108,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Sword Beam Defense:",                                NULL,   NULL },
+    { jwin_text_proc,           9,    126,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Rock Defense:",                                      NULL,   NULL },
+    { jwin_text_proc,           9,    144,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Magic Defense:",                                     NULL,   NULL },
+    { jwin_text_proc,           9,    162,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Bomb (object) Defense:",                             NULL,   NULL },
+    { jwin_text_proc,           9,    180,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"S. Bomb (object) Defense:",                          NULL,   NULL },
+    { jwin_text_proc,           9,    198,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Bomb (explode) Defense:",                            NULL,   NULL },
+    // 123 - Enemy weapons page 2
+    { jwin_text_proc,           9,     54,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"S. Bomb (explode) Defense:",                          NULL,   NULL },
+    { jwin_text_proc,           9,     72,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Flame Trail Defense:",                                 NULL,   NULL },
+    { jwin_text_proc,           9,     90,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Flame Defense:",                                 NULL,   NULL },
+    { jwin_text_proc,           9,    108,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Wind Defense:",                                NULL,   NULL },
+    { jwin_text_proc,           9,    126,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Flame 2 Defense:",                             NULL,   NULL },
+    { jwin_text_proc,           9,    144,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Flame 2 Trail Defense:",                                 NULL,   NULL },
+    { jwin_text_proc,           9,    162,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Ice Defense:",                                NULL,   NULL },
+    { jwin_text_proc,           9,    180,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Fireball 2 Defense:",                              NULL,   NULL },
+    // 131 - Other weapons (Currently 6)
+    { jwin_text_proc,           9,     54,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Candle Fire Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,     72,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Player Bomb Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,     90,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Refl. Magic Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,    108,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Refl. Fireball Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,    126,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Refl. Rock Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,    144,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Refl. Sword Beam Defense:",                              NULL,   NULL },
+    // 137 - Enemy weapons pulldown 
+    { jwin_droplist_proc,         126,   54 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,   72 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,   90 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  108 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  126 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  144 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  162 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  180 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  198 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    // 146 - Enemy weapons pulldown page 2
+    { jwin_droplist_proc,         126,   54 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,   72 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,   90 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  108 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  126 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  144 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  162 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  180 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    // 154 - Other weapon pulldown
+    { jwin_droplist_proc,         126,   54 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,   72 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,   90 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  108 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  126 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,         126,  144 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    // 160 - Set all button
+    { jwin_button_proc,           255,    54 - 4,     48,     16,    vc(14),                 vc(1),                  13,    D_EXIT,      0,    0, (void*)"Set All",                                            NULL,   NULL },
+    
+    
+    // 161 - Script 1
+    { jwin_text_proc,           6,    51,      80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 1 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           6,    67,      80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 2 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           6,    83,      80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 3 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           6,    99,      80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 4 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           6,    115,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 5 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           6,    131,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 6 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           6,    147,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 7 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           6,    163,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 8 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           6,    179,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 9 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           6,    196,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 10 Weapon Defense:",                              NULL,   NULL },
+    //171 script 1 pulldown
+
+         /* (dialog proc)           (x)   (y)     (w)     (h)      (fg)                   (bg)                    (key) (flags)      (d1)  (d2)  (dp)                                                         (dp2)  (dp3) */
+    { jwin_droplist_proc,      126, 51 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,      126, 67 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,      126, 83 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,      126, 99 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,      126, 115 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,      126, 131 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,      126, 147 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,      126, 163 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,      126, 179 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    { jwin_droplist_proc,      126, 196 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
+    // 181 - Options relocated to handle new tab
+    { jwin_check_proc,                    217,    200,      0,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void*)"Large Link Hit Box",   NULL,   NULL },
+    { jwin_text_proc,                       4,    201,     17,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void*)"Animation Style:",     NULL,   NULL },
+    { jwin_as_droplist_proc,               77,    197,     78,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,          0,          0, (void*)&animationstyle_list,   NULL,   NULL },
+    { jwin_check_proc,                    217,    186,      0,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void*)"Diagonal Movement",    NULL,   NULL },
+    { jwin_text_proc,                       4,    183,     17,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void*)"Swim Speed:",          NULL,   NULL },
+    { jwin_droplist_proc,                  77,    179,     78,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,          0,          0, (void*)&swimspeed_list,        NULL,   NULL },
+    {  NULL,                                 0,      0,      0,      0,    0,                      0,                       0,    0,          0,          0,               NULL,                            NULL,   NULL                   }    
 };
 
 
@@ -10075,10 +10214,10 @@ int onCustomLink()
     }
     
     linktile_dlg[0].dp2=lfont;
-    linktile_dlg[5].flags = get_bit(quest_rules, qr_LTTPCOLLISION)? D_SELECTED : 0;
-    linktile_dlg[76].flags = get_bit(quest_rules, qr_LTTPWALK)? D_SELECTED : 0;
-    linktile_dlg[95].d1=(zinit.link_swim_speed<60)?0:1;
-    linktile_dlg[7].d1=zinit.linkanimationstyle;
+    linktile_dlg[181].flags = get_bit(quest_rules, qr_LTTPCOLLISION)? D_SELECTED : 0;
+    linktile_dlg[184].flags = get_bit(quest_rules, qr_LTTPWALK)? D_SELECTED : 0;
+    linktile_dlg[186].d1=(zinit.link_swim_speed<60)?0:1;
+    linktile_dlg[183].d1=zinit.linkanimationstyle;
     
     if(is_large)
         large_dialog(linktile_dlg, 2.0);
@@ -10110,32 +10249,94 @@ int onCustomLink()
     memcpy(oldDrownSpr, drowningspr, 4*3*sizeof(int));
     memcpy(oldFallSpr, fallingspr, 4*3*sizeof(int));
     
-    
-    int ret = popup_dialog_through_bitmap(screen2,linktile_dlg,3);
-    
-    if(ret==3)
+    //Populate Link defenses
+    for (int i = 0; i < wMax - wEnemyWeapons - 1; i++)
     {
-        saved=false;
-        set_bit(quest_rules, qr_LTTPCOLLISION, (linktile_dlg[5].flags&D_SELECTED)?1:0);
-        set_bit(quest_rules, qr_LTTPWALK, (linktile_dlg[76].flags&D_SELECTED)?1:0);
-        zinit.link_swim_speed=(linktile_dlg[95].d1==0)?50:67;
+        linktile_dlg[137 + i].d1 = link_defence[wEnemyWeapons+i+1];
     }
-    else
+    linktile_dlg[154].d1 = link_defence[wFire];
+    linktile_dlg[155].d1 = link_defence[wBomb];
+    linktile_dlg[156].d1 = link_defence[wRefMagic];
+    linktile_dlg[157].d1 = link_defence[wRefFireball];
+    linktile_dlg[158].d1 = link_defence[wRefRock];
+    linktile_dlg[159].d1 = link_defence[wRefBeam];
+
+    linktile_dlg[171].d1 = link_defence[wScript1];
+    linktile_dlg[172].d1 = link_defence[wScript2];
+    linktile_dlg[173].d1 = link_defence[wScript3];
+    linktile_dlg[174].d1 = link_defence[wScript4];
+    linktile_dlg[175].d1 = link_defence[wScript5];
+    linktile_dlg[176].d1 = link_defence[wScript6];
+    linktile_dlg[177].d1 = link_defence[wScript7];
+    linktile_dlg[178].d1 = link_defence[wScript8];
+    linktile_dlg[179].d1 = link_defence[wScript9];
+    linktile_dlg[180].d1 = link_defence[wScript10];
+
+    int ret = 0;
+    do
     {
-        memcpy(walkspr, oldWalkSpr, 4*3*sizeof(int));
-        memcpy(stabspr, oldStabSpr, 4*3*sizeof(int));
-        memcpy(slashspr, oldSlashSpr, 4*3*sizeof(int));
-        memcpy(floatspr, oldFloatSpr, 4*3*sizeof(int));
-        memcpy(swimspr, oldSwimSpr, 4*3*sizeof(int));
-        memcpy(divespr, oldDiveSpr, 4*3*sizeof(int));
-        memcpy(poundspr, oldPoundSpr, 4*3*sizeof(int));
-        memcpy(jumpspr, oldJumpSpr, 4*3*sizeof(int));
-        memcpy(chargespr, oldChargeSpr, 4*3*sizeof(int));
-        memcpy(castingspr, oldCastSpr, 3*sizeof(int));
-        memcpy(holdspr, oldHoldSpr, 2*2*3*sizeof(int));
-		memcpy(drowningspr, oldDrownSpr, 4*3*sizeof(int));
-		memcpy(fallingspr, oldFallSpr, 4*3*sizeof(int));
-    }
+        ret = popup_dialog_through_bitmap(screen2, linktile_dlg, 3);
+
+        if (ret == 3)
+        {
+            saved = false;
+            set_bit(quest_rules, qr_LTTPCOLLISION, (linktile_dlg[181].flags & D_SELECTED) ? 1 : 0);
+            set_bit(quest_rules, qr_LTTPWALK, (linktile_dlg[184].flags & D_SELECTED) ? 1 : 0);
+            zinit.link_swim_speed = (linktile_dlg[186].d1 == 0) ? 50 : 67;
+
+            //Save Link defenses
+            for (int i = 0; i < wMax - wEnemyWeapons - 1; i++)
+            {
+                link_defence[wEnemyWeapons + i + 1] = linktile_dlg[137 + i].d1;
+            }
+            link_defence[wFire] = linktile_dlg[154].d1;
+            link_defence[wBomb] = linktile_dlg[155].d1;
+            link_defence[wRefMagic] = linktile_dlg[156].d1;
+            link_defence[wRefFireball] = linktile_dlg[157].d1;
+            link_defence[wRefRock] = linktile_dlg[158].d1;
+            link_defence[wRefBeam] = linktile_dlg[159].d1;
+
+            link_defence[wScript1] = linktile_dlg[171].d1;
+            link_defence[wScript2] = linktile_dlg[172].d1;
+            link_defence[wScript3] = linktile_dlg[173].d1;
+            link_defence[wScript4] = linktile_dlg[174].d1;
+            link_defence[wScript5] = linktile_dlg[175].d1;
+            link_defence[wScript6] = linktile_dlg[176].d1;
+            link_defence[wScript7] = linktile_dlg[177].d1;
+            link_defence[wScript8] = linktile_dlg[178].d1;
+            link_defence[wScript9] = linktile_dlg[179].d1;
+            link_defence[wScript10] = linktile_dlg[180].d1;
+        }
+        else if (ret == 160)
+        {
+            for (int i = 138; i < 160; i++)
+            {
+                linktile_dlg[i].d1 = linktile_dlg[137].d1;
+            }
+            for (int i = 171; i < 181; i++)
+            {
+                linktile_dlg[i].d1 = linktile_dlg[137].d1;
+            }
+        }
+        else
+        {
+            memcpy(walkspr, oldWalkSpr, 4 * 3 * sizeof(int));
+            memcpy(stabspr, oldStabSpr, 4 * 3 * sizeof(int));
+            memcpy(slashspr, oldSlashSpr, 4 * 3 * sizeof(int));
+            memcpy(floatspr, oldFloatSpr, 4 * 3 * sizeof(int));
+            memcpy(swimspr, oldSwimSpr, 4 * 3 * sizeof(int));
+            memcpy(divespr, oldDiveSpr, 4 * 3 * sizeof(int));
+            memcpy(poundspr, oldPoundSpr, 4 * 3 * sizeof(int));
+            memcpy(jumpspr, oldJumpSpr, 4 * 3 * sizeof(int));
+            memcpy(chargespr, oldChargeSpr, 4 * 3 * sizeof(int));
+            memcpy(castingspr, oldCastSpr, 3 * sizeof(int));
+            memcpy(holdspr, oldHoldSpr, 2 * 2 * 3 * sizeof(int));
+            memcpy(drowningspr, oldDrownSpr, 4 * 3 * sizeof(int));
+            memcpy(fallingspr, oldFallSpr, 4 * 3 * sizeof(int));
+        }
+    } while (ret == 160);
+    
+    
     
     ret=ret;
     return D_O_K;

--- a/src/zq_custom.cpp
+++ b/src/zq_custom.cpp
@@ -10166,16 +10166,16 @@ static DIALOG linktile_dlg[] =
     
     
     // 161 - Script 1
-    { jwin_text_proc,           6,    51,      80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 1 Weapon Defense:",                              NULL,   NULL },
-    { jwin_text_proc,           6,    67,      80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 2 Weapon Defense:",                              NULL,   NULL },
-    { jwin_text_proc,           6,    83,      80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 3 Weapon Defense:",                              NULL,   NULL },
-    { jwin_text_proc,           6,    99,      80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 4 Weapon Defense:",                              NULL,   NULL },
-    { jwin_text_proc,           6,    115,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 5 Weapon Defense:",                              NULL,   NULL },
-    { jwin_text_proc,           6,    131,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 6 Weapon Defense:",                              NULL,   NULL },
-    { jwin_text_proc,           6,    147,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 7 Weapon Defense:",                              NULL,   NULL },
-    { jwin_text_proc,           6,    163,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 8 Weapon Defense:",                              NULL,   NULL },
-    { jwin_text_proc,           6,    179,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 9 Weapon Defense:",                              NULL,   NULL },
-    { jwin_text_proc,           6,    196,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 10 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,    51,      80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 1 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,    67,      80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 2 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,    83,      80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 3 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,    99,      80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 4 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,    115,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 5 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,    131,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 6 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,    147,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 7 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,    163,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 8 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,    179,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 9 Weapon Defense:",                              NULL,   NULL },
+    { jwin_text_proc,           9,    196,     80,      8,    vc(14),                 vc(1),                   0,    0,           0,    0, (void*)"Script 10 Weapon Defense:",                              NULL,   NULL },
     //171 script 1 pulldown
 
          /* (dialog proc)           (x)   (y)     (w)     (h)      (fg)                   (bg)                    (key) (flags)      (d1)  (d2)  (dp)                                                         (dp2)  (dp3) */
@@ -10190,12 +10190,12 @@ static DIALOG linktile_dlg[] =
     { jwin_droplist_proc,      126, 179 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
     { jwin_droplist_proc,      126, 196 - 4,    115,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,           0,    0, (void*)&defense_list,                                         NULL,   NULL },
     // 181 - Options relocated to handle new tab
-    { jwin_check_proc,                    217,    200,      0,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void*)"Large Link Hit Box",   NULL,   NULL },
-    { jwin_text_proc,                       4,    201,     17,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void*)"Animation Style:",     NULL,   NULL },
-    { jwin_as_droplist_proc,               77,    197,     78,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,          0,          0, (void*)&animationstyle_list,   NULL,   NULL },
-    { jwin_check_proc,                    217,    186,      0,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void*)"Diagonal Movement",    NULL,   NULL },
-    { jwin_text_proc,                       4,    183,     17,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void*)"Swim Speed:",          NULL,   NULL },
-    { jwin_droplist_proc,                  77,    179,     78,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,          0,          0, (void*)&swimspeed_list,        NULL,   NULL },
+    { jwin_check_proc,                      9,    78,      0,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void*)"Large Link Hit Box",   NULL,   NULL },
+    { jwin_text_proc,                       9,    38,     17,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void*)"Animation Style:",     NULL,   NULL },
+    { jwin_as_droplist_proc,               89,    34,     78,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,          0,          0, (void*)&animationstyle_list,   NULL,   NULL },
+    { jwin_check_proc,                      9,    90,      0,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void*)"Diagonal Movement",    NULL,   NULL },
+    { jwin_text_proc,                       9,    54,     17,      9,    vc(14),                 vc(1),                   0,    0,          1,          0, (void*)"Swim Speed:",          NULL,   NULL },
+    { jwin_droplist_proc,                  89,    50,     78,     16,    jwin_pal[jcTEXTFG],     jwin_pal[jcTEXTBG],      0,    0,          0,          0, (void*)&swimspeed_list,        NULL,   NULL },
     {  NULL,                                 0,      0,      0,      0,    0,                      0,                       0,    0,          0,          0,               NULL,                            NULL,   NULL                   }    
 };
 


### PR DESCRIPTION
Link dialog in Graphics->Sprites->Link was reworked a bit to accommodate defense values. As far as I can tell the dialog works at changing the Link->Defense[] values properly based on testing weapon behavior in one of the default quests. Some notes/things to be aware of.

- The V_LINKSPRITES define was increased as the quest format needed to be changed. Keep this in mind when merging other quest format changes
- The defense values as edited by ZQuest are stored in an external array in zc_custom.cpp which are then copied to the Link instance's defense values every time LinkClass::init() is run. This means any runtime script changes to the instance's array will be reset to the ZQuest values at every death/restart. If this behavior is not desired, then initialization will need to be adjusted.
- The Link dialog now has an Options tab which holds the toggleable options that were previously on the bottom of the dialog. This tab can thus be extended to include other editor options we may want to add for editing Link in the future. It will probably be wise to relabel/reposition the Link dialog menu option to reflect its expanded functionality. 