### PR TITLE
Various fixes.

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -3041,7 +3041,8 @@ void LinkClass::check_slash_block_layer(int bx, int by, int layer)
         //{
             if(get_bit(quest_rules,qr_MORESOUNDS))
             {
-		if ( isGenericType(type) )
+		//if ( isGenericType(type) )
+		if (!isBushType(type) && !isFlowersType(type) && !isGrassType(type))
 		{
 			if (combobuf[cid].usrflags&cflag3)
 			{
@@ -3049,7 +3050,13 @@ void LinkClass::check_slash_block_layer(int bx, int by, int layer)
 			}
 		}
 		else
-			sfx(WAV_ZN1GRASSCUT,int(bx));
+		{
+			if (combobuf[cid].usrflags&cflag3)
+			{
+				sfx(combobuf[cid].attribytes[2],int(bx));
+			}
+			else sfx(WAV_ZN1GRASSCUT,int(bx));
+		}
             }
             
             if(isBushType(type))
@@ -3201,7 +3208,7 @@ void LinkClass::check_slash_block(int bx, int by)
     if ( isNextType(type) ) //->Next combos should not trigger secrets. Their child combo, may want to do that! -Z 17th December, 2019
     {
 		//if an emulation bit says to use buggy code
-		if (FFCore.emulation[emuBUGGYNEXTCOMBOS] || get_bit(quest_rules,qr_IDIOTICSHASHNEXTSECRETBUGSUPPORT))
+		if (FFCore.emulation[emuBUGGYNEXTCOMBOS] || get_bit(quest_rules,qr_IDIOTICSHASHNEXTSECRETBUGSUPPORT)) //Haha wow Zoria you really named it that huh -Dimi
 		{
 			skipsecrets = 0;
 		}
@@ -3359,7 +3366,7 @@ void LinkClass::check_slash_block(int bx, int by)
         //{
             if(get_bit(quest_rules,qr_MORESOUNDS))
             {
-		if ( isGenericType(type) )
+		if(!(isBushType(type) || isFlowersType(type) || isGrassType(type)))
 		{
 			if (combobuf[cid].usrflags&cflag3)
 			{
@@ -3367,7 +3374,13 @@ void LinkClass::check_slash_block(int bx, int by)
 			}
 		}
 		else
-			sfx(WAV_ZN1GRASSCUT,int(bx));
+		{
+			if (combobuf[cid].usrflags&cflag3)
+			{
+				sfx(combobuf[cid].attribytes[2],int(bx));
+			}
+			else sfx(WAV_ZN1GRASSCUT,int(bx));
+		}
             }
             
             if(isBushType(type))
@@ -4247,18 +4260,25 @@ void LinkClass::check_slash_block2(int bx, int by, weapon *w)
             }
         }
         
-        if(isBushType(type2) || isFlowersType(type2) || isGrassType(type2) || isGenericType(type2))
-        {
+        //if(isBushType(type2) || isFlowersType(type2) || isGrassType(type2) || isGenericType(type2))
+        //{
             if(get_bit(quest_rules,qr_MORESOUNDS))
             {
-		if ( isGenericType(type) )
+		if(!(isBushType(type2) || isFlowersType(type2) || isGrassType(type2)))
 		{
 			if (combobuf[cid].usrflags&cflag3)
 			{
 				sfx(combobuf[cid].attribytes[2],int(bx));
 			}
 		}
-                else sfx(WAV_ZN1GRASSCUT,int(bx));
+                else 
+		{
+			if (combobuf[cid].usrflags&cflag3)
+			{
+				sfx(combobuf[cid].attribytes[2],int(bx));
+			}
+			else sfx(WAV_ZN1GRASSCUT,int(bx));
+		}
             }
             
             if(isBushType(type2))
@@ -4336,7 +4356,7 @@ void LinkClass::check_slash_block2(int bx, int by, weapon *w)
 				decorations.add(new comboSprite((zfix)fx, (zfix)fy, 0, 0, combobuf[cid].attribytes[0]));
 		}
             }
-        }
+        //}
     }
 }
 
@@ -4795,18 +4815,25 @@ void LinkClass::check_slash_block(weapon *w)
         
         putcombo(scrollbuf,(i&15)<<4,i&0xF0,s->data[i],s->cset[i]);
         
-        if(isBushType(type) || isFlowersType(type) || isGrassType(type) || isGenericType(type))
-        {
+        //if(isBushType(type) || isFlowersType(type) || isGrassType(type) || isGenericType(type))
+        //{
             if(get_bit(quest_rules,qr_MORESOUNDS))
             {
-		if ( isGenericType(type) )
+		if(!(isBushType(type) || isFlowersType(type) || isGrassType(type)))
 		{
 			if (combobuf[MAPCOMBO(bx,by)-1].usrflags&cflag3)
 			{
 				sfx(combobuf[MAPCOMBO(bx,by)-1].attribytes[2],int(bx));
 			}
 		}
-                else sfx(WAV_ZN1GRASSCUT,int(bx));
+                else 
+		{
+			if (combobuf[MAPCOMBO(bx,by)-1].usrflags&cflag3)
+			{
+				sfx(combobuf[MAPCOMBO(bx,by)-1].attribytes[2],int(bx));
+			}
+			else sfx(WAV_ZN1GRASSCUT,int(bx));
+		}
             }
             
             if(isBushType(type))
@@ -4866,7 +4893,7 @@ void LinkClass::check_slash_block(weapon *w)
 		}
                 else decorations.add(new dGrassClippings((zfix)fx, (zfix)fy, dGRASSCLIPPINGS, 0, 0));
             }
-	    else if (isGenericType(type))
+	    else
 	    {
 		if ( combobuf[MAPCOMBO(bx,by)-1].usrflags&cflag1 )
 		{
@@ -4884,7 +4911,7 @@ void LinkClass::check_slash_block(weapon *w)
 				decorations.add(new comboSprite((zfix)fx, (zfix)fy, 0, 0, combobuf[MAPCOMBO(bx,by)-1].attribytes[0]));
 		}
             }
-        }
+        //}
     }
     
     if(!ignoreffc)
@@ -4925,18 +4952,25 @@ void LinkClass::check_slash_block(weapon *w)
             }
         }
         
-        if(isBushType(type2) || isFlowersType(type2) || isGrassType(type2) || isGenericType(type2))
-        {
+        //if(isBushType(type2) || isFlowersType(type2) || isGrassType(type2) || isGenericType(type2))
+        //{
             if(get_bit(quest_rules,qr_MORESOUNDS))
             {
-		if ( isGenericType(type) )
+		if(!(isBushType(type2) || isFlowersType(type2) || isGrassType(type2)))
 		{
 			if (combobuf[MAPCOMBO(bx,by)-1].usrflags&cflag3)
 			{
 				sfx(combobuf[MAPCOMBO(bx,by)-1].attribytes[2],int(bx));
 			}
 		}
-                else sfx(WAV_ZN1GRASSCUT,int(bx));
+                else 
+		{
+			if (combobuf[MAPCOMBO(bx,by)-1].usrflags&cflag3)
+			{
+				sfx(combobuf[MAPCOMBO(bx,by)-1].attribytes[2],int(bx));
+			}
+			else sfx(WAV_ZN1GRASSCUT,int(bx));
+		}
             }
             
             if(isBushType(type2))
@@ -5014,7 +5048,7 @@ void LinkClass::check_slash_block(weapon *w)
 				decorations.add(new comboSprite((zfix)fx, (zfix)fy, 0, 0, combobuf[MAPCOMBO(bx,by)-1].attribytes[0]));
 		}
             }
-        }
+        //}
     }
 }
 

--- a/src/qst.cpp
+++ b/src/qst.cpp
@@ -14360,7 +14360,7 @@ int readguys(PACKFILE *f, zquestheader *Header, bool keepdata)
 					case eeFAIRY: case eeGUY: case eeNONE: case eeZORA:
 					case eeAQUA: case eeDIG: case eeGHOMA: case eeGANON:
 					case eePATRA: case eeGLEEOK: case eeMOLD: case eeMANHAN:
-						tempguy.moveflags = FLAG_CAN_PITWALK;
+						tempguy.moveflags = FLAG_CAN_PITWALK|FLAG_CAN_WATERWALK;
 						break;
 					//No gravity, but falls in pits
 					case eeLEV:
@@ -14375,7 +14375,7 @@ int readguys(PACKFILE *f, zquestheader *Header, bool keepdata)
 						break;
 					//Gravity, floats over pits
 					case eeWIZZ: case eeWALLM: case eeGHINI:
-						tempguy.moveflags = FLAG_OBEYS_GRAV | FLAG_CAN_PITWALK;
+						tempguy.moveflags = FLAG_OBEYS_GRAV | FLAG_CAN_PITWALK | FLAG_CAN_WATERWALK;
 						break;
 					//Gravity and falls in pits
 					case eeWALK: case eeOTHER:

--- a/src/subscr.h
+++ b/src/subscr.h
@@ -178,8 +178,8 @@ struct subscreen_object
 {
     byte  type;
     byte  pos;
-    word  x;
-    word  y;
+    short  x;
+    short  y;
     word  w;
     word  h;
     byte  colortype1;

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -4896,6 +4896,7 @@ bool weapon::animate(int index)
         
         if(specialinfo==1 && dead==-1 && x==(int)wrx && y==(int)wry)
         {
+	    stop_sfx(WAV_ZN1WHIRLWIND);
             dead=2;
         }
         else if(LinkAction() !=inwind && ((dir==right && x>=240) || (dir==down && y>=160) || (dir==left && x<=0) || (dir==up && y<=0)))
@@ -4903,7 +4904,7 @@ bool weapon::animate(int index)
             stop_sfx(WAV_ZN1WHIRLWIND);
             dead=1;
         }
-        else if(get_bit(quest_rules,qr_MORESOUNDS))
+        else if(get_bit(quest_rules,qr_MORESOUNDS) && dead < 1)
             sfx(WAV_ZN1WHIRLWIND,pan(int(x)),true,false);
             
         if((parentitem==-1 && get_bit(quest_rules,qr_WHIRLWINDMIRROR)) || (parentitem > -1 && itemsbuf[parentitem].flags & ITEM_FLAG3))
@@ -7940,6 +7941,7 @@ bool weapon::animateandrunscript(int ii)
         
         if(specialinfo==1 && dead==-1 && x==(int)wrx && y==(int)wry)
         {
+	    stop_sfx(WAV_ZN1WHIRLWIND);
             dead=2;
         }
         else if(LinkAction() !=inwind && ((dir==right && x>=240) || (dir==down && y>=160) || (dir==left && x<=0) || (dir==up && y<=0)))
@@ -7947,7 +7949,7 @@ bool weapon::animateandrunscript(int ii)
             stop_sfx(WAV_ZN1WHIRLWIND);
             dead=1;
         }
-        else if(get_bit(quest_rules,qr_MORESOUNDS))
+        else if(get_bit(quest_rules,qr_MORESOUNDS) && dead < 1)
             sfx(WAV_ZN1WHIRLWIND,pan(int(x)),true,false);
             
         if((parentitem==-1 && get_bit(quest_rules,qr_WHIRLWINDMIRROR)) || (parentitem > -1 && itemsbuf[parentitem].flags & ITEM_FLAG3))

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -631,8 +631,9 @@ void ResetSaveScreenSettings()
 	SaveScreenSettings[SAVESC_TEXT_SAVE_FLASH] = QMisc.colors.caption; 
 	SaveScreenSettings[SAVESC_TEXT_RETRY_FLASH] = QMisc.colors.caption;
 	SaveScreenSettings[SAVESC_MIDI] = -4;
-	SaveScreenSettings[SAVESC_BACKGROUND] = BLACK;
-	SaveScreenSettings[SAVESC_TEXT] = WHITE;
+	//SaveScreenSettings[SAVESC_BACKGROUND] = BLACK;
+	SaveScreenSettings[SAVESC_BACKGROUND] = 0; //Isle of Rebirth changed the game over background by changing color 0 of the palette; this needs to be respected!
+	SaveScreenSettings[SAVESC_TEXT] = QMisc.colors.msgtext;
 	SaveScreenSettings[SAVESC_USETILE] = SAVESC_DEF_TILE;
 	SaveScreenSettings[SAVESC_CURSOR_CSET] = 1;
 	SaveScreenSettings[SAVESC_CUR_SOUND] =  WAV_CHINK;
@@ -2000,8 +2001,9 @@ int init_game()
 //Copy saved data to RAM data (but not global arrays)
     game->Copy(saves[currgame]);
     flushItemCache();
+    ResetSaveScreenSettings();
     
-	ResetSaveScreenSettings();
+	//ResetSaveScreenSettings();
     
 //Load the quest
     //setPackfilePassword(datapwd);
@@ -2013,6 +2015,8 @@ int init_game()
         //setPackfilePassword(NULL);
         return 1;
     }
+    
+    ResetSaveScreenSettings();
     
     //setPackfilePassword(NULL);
     
@@ -3564,7 +3568,8 @@ void game_loop()
 	default: break;
     }
     bool freezemsg = ((msg_active || (intropos && intropos<72) || (linkedmsgclk && get_bit(quest_rules,qr_MSGDISAPPEAR)))
-                      && (get_bit(quest_rules,qr_MSGFREEZE)&&!isshop));
+			&& (get_bit(quest_rules,qr_MSGFREEZE)));
+                      //&& (get_bit(quest_rules,qr_MSGFREEZE)&&!isshop));
                       
     // Messages also freeze FF combos.
     bool freezeff = freezemsg;

--- a/src/zelda.cpp
+++ b/src/zelda.cpp
@@ -3568,8 +3568,8 @@ void game_loop()
 	default: break;
     }
     bool freezemsg = ((msg_active || (intropos && intropos<72) || (linkedmsgclk && get_bit(quest_rules,qr_MSGDISAPPEAR)))
-			&& (get_bit(quest_rules,qr_MSGFREEZE)));
-                      //&& (get_bit(quest_rules,qr_MSGFREEZE)&&!isshop));
+			&& (get_bit(quest_rules,qr_MSGFREEZE)&&!isshop));
+			//&& (get_bit(quest_rules,qr_MSGFREEZE)));
                       
     // Messages also freeze FF combos.
     bool freezeff = freezemsg;


### PR DESCRIPTION
Changed subscreen object x/y from word to short to fix problem of objects not drawing with negative coords; needs further testing.

Fixed Game Over screen using wrong default colors and not loading correctly when switching quests; default background needs to be 0 as some quests (like Isle of Rebirth) rely on that to change the color of their game over background.

Fixed a dumb oversight I made with slash->next using the bush sfx when it's not supposed to.

Fixed continuous whirlwind SFX.

Fixed being able to walk during message strings on shop screens (or screens with shop caves)