### PR TITLE
Add GitHub actions CI

### DIFF
--- a/.github/dependencies.config
+++ b/.github/dependencies.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="winflexbison3" version="2.5.24.20210105" />
+</packages>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [2.55]
+    branches: [2.55-master]
   pull_request: # run on all PRs, not just PRs to a particular branch
 
 jobs:
@@ -24,5 +24,5 @@ jobs:
 
     - run: cp src/metadata/*.h.sig src/metadata/sigs/
     - run: cmake . -A win32
-    - run: cmake --build . --config Debug --verbose --target zquest
-    - run: cmake --build . --config Debug --verbose --target zelda
+    - run: cmake --build . --config Release --verbose --target zquest
+    - run: cmake --build . --config Release --verbose --target zelda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [2.55]
+  pull_request: # run on all PRs, not just PRs to a particular branch
+
+jobs:
+  compile:
+    runs-on: windows-2019
+
+    steps:
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: win32
+
+    - name: git clone
+      uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      uses: crazy-max/ghaction-chocolatey@v1
+      with:
+        args: install .github/dependencies.config -y
+
+    - run: cp src/metadata/*.h.sig src/metadata/sigs/
+    - run: cmake . -A win32
+    - run: cmake --build . --config Debug --verbose --target zquest
+    - run: cmake --build . --config Debug --verbose --target zelda


### PR DESCRIPTION
This simply builds zquest and zelda targets on every PR, as a quick verification that changes at least build properly.

Only builds for windows. Toolchain is MSVC 19.29.30038.1

(to actually see it run, a repo admin needs to accept "allow actions from new contributors" near the bottom of this page. Here is it running on my fork: https://github.com/connorjclark/ZeldaClassic/runs/5299387281?check_suite_focus=true )