### PR TITLE
Create zscript.exe. Validates script and prints errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,15 @@ if(MSVC AND USE_PCH)
 endif()
 
 #############################################################
+# ZScript parser
+#############################################################
+
+if(${BISON_FOUND} AND ${FLEX_FOUND} AND WANT_ZSCRIPT)
+	add_executable(zscript src/parser/ZScript_main.cpp src/util.cpp ${ZQUEST_ZSCRIPT_SOURCES} ${BISON_ZScriptParser_OUTPUTS} ${FLEX_ZScriptLexer_OUTPUTS})
+	target_link_libraries(zscript ${ALLEGROLIB})
+endif()
+
+#############################################################
 # ZQuest
 #############################################################
 
@@ -269,4 +278,3 @@ if(Boost_FOUND)
 		target_compile_definitions(zquest PRIVATE ZCM_DLL_IMPORT)
 	endif()
 endif()
-

--- a/output/common/zscript.cfg
+++ b/output/common/zscript.cfg
@@ -1,0 +1,6 @@
+[Compiler]
+include_path = include/;scripts/;headers/;
+NO_ERROR_HALT = 1
+HEADER_GUARD = 1
+number_of_include_paths = 3
+run_string = run

--- a/src/parser/CompileError.cpp
+++ b/src/parser/CompileError.cpp
@@ -296,6 +296,7 @@ CompileError::CompileError(CompileError::Impl* pimpl) : pimpl_(pimpl) {}
 
 void ZScript::box_out_err(CompileError const& error)
 {
+	printf("%s\n", error.toString().c_str());
 	box_out_nl(error.toString().c_str());
 	box_eol();
 }

--- a/src/parser/ZScript_main.cpp
+++ b/src/parser/ZScript_main.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
     std::string script_path = argv[script_path_index + 1];
 
     allegro_init();
-    set_config_file("zquest.cfg");
+    set_config_file("zscript.cfg");
     memset(FFCore.scriptRunString,0,sizeof(FFCore.scriptRunString));
 	strcpy(FFCore.scriptRunString, get_config_string("Compiler","run_string","run"));
 

--- a/src/parser/ZScript_main.cpp
+++ b/src/parser/ZScript_main.cpp
@@ -71,8 +71,9 @@ int main(int argc, char **argv)
     std::string script_path = argv[script_path_index + 1];
 
     allegro_init();
+    set_config_file("zquest.cfg");
     memset(FFCore.scriptRunString,0,sizeof(FFCore.scriptRunString));
-	strcpy(FFCore.scriptRunString,"run");
+	strcpy(FFCore.scriptRunString, get_config_string("Compiler","run_string","run"));
 
     // Any errors will be printed to stdout.
     int res = compile(script_path);

--- a/src/parser/ZScript_main.cpp
+++ b/src/parser/ZScript_main.cpp
@@ -1,0 +1,82 @@
+#include "parser/zscript.h"
+#include "ffscript.h"
+#include <string>
+
+FFScript FFCore;
+char ZQincludePaths[MAX_INCLUDE_PATHS][512];
+byte quest_rules[QUESTRULES_NEW_SIZE];
+
+int get_bit(byte *bitstr,int bit)
+{
+    bitstr += bit>>3;
+    return ((*bitstr) >> (bit&7))&1;
+}
+void box_out(const char *msg) {}
+void box_out_nl(const char *msg) {}
+void box_eol() {}
+
+int used_switch(int argc,char *argv[],const char *s)
+{
+    // assumes a switch won't be in argv[0]
+    for(int i=1; i<argc; i++)
+        if(stricmp(argv[i],s)==0)
+            return i;
+            
+    return 0;
+}
+
+int compile(std::string script_path)
+{
+    printf("compiling %s\n", script_path.c_str());
+
+    // copy to tmp file
+    std::string zScript;
+    FILE *zscript = fopen(script_path.c_str(),"r");
+    if(zscript == NULL)
+    {
+        printf("Error: Cannot open specified file!\n");
+        return 1;
+    }
+    
+    char c = fgetc(zscript);
+    while(!feof(zscript))
+    {
+        zScript += c;
+        c = fgetc(zscript);
+    }
+    fclose(zscript);
+
+    FILE *tempfile = fopen("tmp","w");
+    if(!tempfile)
+    {
+        printf("Error: Unable to create a temporary file in current directory!\n");
+        return 1;
+    }
+    fwrite(zScript.c_str(), sizeof(char), zScript.size(), tempfile);
+    fclose(tempfile);
+
+    boost::movelib::unique_ptr<ZScript::ScriptsData> result(ZScript::compile("tmp"));
+    unlink("tmp");
+    
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    int script_path_index = used_switch(argc, argv, "-input");
+    if (!script_path_index) {
+        printf("Error: missing required flag: -input\n");
+        return 1;
+    }
+    std::string script_path = argv[script_path_index + 1];
+
+    allegro_init();
+    memset(FFCore.scriptRunString,0,sizeof(FFCore.scriptRunString));
+	strcpy(FFCore.scriptRunString,"run");
+
+    // Any errors will be printed to stdout.
+    int res = compile(script_path);
+    allegro_exit();
+    return res;
+}
+END_OF_MAIN()

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -1622,6 +1622,7 @@ void yymsg(string const& message, int row, int col)
 	if (yyleng)
 	    out << " '" << yytext << "'";
 	out << "]";
+	printf("%s\n", out.str().c_str());
 	box_out(out.str().c_str());
     box_eol();
 }

--- a/testscripts/shop.zs
+++ b/testscripts/shop.zs
@@ -88,7 +88,7 @@ ffc script Automatic_Z3_Shop
 					{
 						if ( Game->Counter[CR_RUPEES] >= sd->Price[q] )
 						{
-							if ( Below(shopitems[q]) 
+							if ( Below(shopitems[q]) ) 
 							{
 								if ( DistXY(shopitems[q], 12) )
 								{


### PR DESCRIPTION
Currently only does one thing: given path to script, will print any warnings/errors.

I added the print statements because I plan to use this .exe to make a [VS Code language server](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide) for ZScript.