### PR TITLE
remove snprintf alias in msvc, and add minimum compiler check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,11 @@ endif()
 if(WIN32)
 	# Prevents definition of min and max macros, which conflict with std::min and std::max
 	add_definitions(-DNOMINMAX)
+
+	string(REGEX MATCH "MSVC" CMAKE_COMPILER_IS_MSVC "${CMAKE_C_COMPILER_ID}")
+	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.20.2750.8)
+		message(FATAL_ERROR "MSVC version ${CMAKE_CXX_COMPILER_VERSION} is too old. Must use at least 2019 version 16.0.0")
+	endif()
 endif()
 
 if(MSVC)

--- a/src/jwin.cpp
+++ b/src/jwin.cpp
@@ -2099,10 +2099,10 @@ int32_t jwin_numedit_swap_byte_proc(int32_t msg, DIALOG *d, int32_t c)
 		switch(ntype)
 		{
 			case typeDEC:
-				sprintf(str, "%d\0", b);
+				sprintf(str, "%d", b);
 				break;
 			case typeHEX:
-				sprintf(str, "%X\0", b);
+				sprintf(str, "%X", b);
 				break;
 		}
 		if(msg != MSG_DRAW) ret |= D_REDRAWME;
@@ -2231,12 +2231,12 @@ int32_t jwin_numedit_swap_sshort_proc(int32_t msg, DIALOG *d, int32_t c)
 		switch(ntype)
 		{
 			case typeDEC:
-				sprintf(str, "%d\0", b);
+				sprintf(str, "%d", b);
 				break;
 			case typeHEX:
 				if(b<0)
-					sprintf(str, "-%X\0", -b);
-				else sprintf(str, "%X\0", b);
+					sprintf(str, "-%X", -b);
+				else sprintf(str, "%X", b);
 				break;
 		}
 		d->d2 = strlen(str);
@@ -2416,23 +2416,23 @@ int32_t jwin_numedit_swap_zsint_proc(int32_t msg, DIALOG *d, int32_t c)
 		{
 			case typeDEC:
 				if(b < 0)
-					sprintf(str, "-%d.%04d\0", abs(b/10000L), abs(b%10000L));
-				else sprintf(str, "%d.%04d\0", b/10000L, b%10000L);
+					sprintf(str, "-%d.%04d", abs(b/10000L), abs(b%10000L));
+				else sprintf(str, "%d.%04d", b/10000L, b%10000L);
 				trim_trailing_0s(str);
 				break;
 			case typeHEX:
 				if(b<0)
-					sprintf(str, "-%X.%04d\0", abs(b/10000L), abs(b%10000L));
-				else sprintf(str, "%X.%04d\0", b/10000L, abs(b%10000L));
+					sprintf(str, "-%X.%04d", abs(b/10000L), abs(b%10000L));
+				else sprintf(str, "%X.%04d", b/10000L, abs(b%10000L));
 				trim_trailing_0s(str);
 				break;
 			case typeLDEC:
-				sprintf(str, "%ld\0", b);
+				sprintf(str, "%ld", b);
 				break;
 			case typeLHEX:
 				if(b<0)
-					sprintf(str, "-%lX\0", -b);
-				else sprintf(str, "%lX\0", b);
+					sprintf(str, "-%lX", -b);
+				else sprintf(str, "%lX", b);
 				break;
 		}
 		d->d2 = strlen(str);

--- a/src/midi.cpp
+++ b/src/midi.cpp
@@ -38,11 +38,6 @@
   *  or non-zero on error.
   */
 
-// snprintf is defined as _snprintf in windows stdio.h
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
-
 int32_t save_midi(char *filename, MIDI *midi)
 {
     int32_t c;

--- a/src/parser/AST.h
+++ b/src/parser/AST.h
@@ -8,12 +8,6 @@ namespace ZScript
 }
 #define YYSTYPE ZScript::AST*
 
-#ifdef _MSC_VER
-#if (_MSC_VER <= 1600)
-#define snprintf _snprintf
-#endif
-#endif
-
 #include <list>
 #include <vector>
 #include <map>

--- a/src/title.cpp
+++ b/src/title.cpp
@@ -37,7 +37,6 @@
 #ifdef _MSC_VER
 #define strupr _strupr
 #define stricmp _stricmp
-#define snprintf _snprintf
 #endif
 
 extern int32_t loadlast;

--- a/src/zinfo.cpp
+++ b/src/zinfo.cpp
@@ -434,7 +434,7 @@ char const* zinfo::getItemClassName(size_t q)
 		return ic_name[q];
 	if(valid_str(default_itype_strings[q]))
 		return default_itype_strings[q];
-	sprintf(zinfbuf, "-zz%03d\0", q);
+	sprintf(zinfbuf, "-zz%03d", q);
 	return zinfbuf;
 }
 char const* zinfo::getItemClassHelp(size_t q)

--- a/src/zquest.cpp
+++ b/src/zquest.cpp
@@ -151,12 +151,6 @@ static const char *qtpath_name      = "macosx_qtpath%d";
 #define zc_max(a,b)  ((a)>(b)?(a):(b))
 #define zc_min(a,b)  ((a)<(b)?(a):(b))
 
-#ifdef _MSC_VER
-#if (_MSC_VER <= 1600)
-#define snprintf _snprintf
-#endif
-#endif
-
 // MSVC fix
 #if _MSC_VER >= 1900
 FILE _iob[] = { *stdin, *stdout, *stderr };


### PR DESCRIPTION
Since ~2010 MSVC has supported `snprintf` so no need to alias it as `_snprintf`, which is _slightly_ different in two ways:

1) return value. Doesn't matter, we never use the return value
2) edge cases re: insertion of \0 null byte. Don't need to hardcode the null byte into the format string to avoid this edge case, so can drop all instances of \0 (which will help with enabling the -Wformat compiler warning as an error)

See [this ](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l?view=msvc-170#remarks) for more.