### PR TITLE
generate_release_notes: true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,4 +62,4 @@ jobs:
         files: output/_auto/buildpack.zip
         prerelease: true
         fail_on_unmatched_files: true
-        # generate_release_notes: true
+        generate_release_notes: true


### PR DESCRIPTION
forgot this.

the first release changelog is gonna be really really off and big b/c the last github release was awhile ago. the next ones should be better.