### PR TITLE
fix allegro legacy alt key press

### DIFF
--- a/allegro-legacy/src/a5/a5_keyboard.c
+++ b/allegro-legacy/src/a5/a5_keyboard.c
@@ -61,7 +61,12 @@ static void * a5_keyboard_thread_proc(ALLEGRO_THREAD * thread, void * data)
                 {
                     if(event.keyboard.unichar >= 0)
                     {
-                        _handle_key_press(event.keyboard.unichar, event.keyboard.keycode);
+                        // local edit
+                        if ((ALLEGRO_KEYMOD_ALT & event.keyboard.modifiers) != 0) {
+                            _handle_key_press(0, event.keyboard.keycode);
+                        } else {
+                            _handle_key_press(event.keyboard.unichar, event.keyboard.keycode);
+                        }
                     }
                     break;
                 }


### PR DESCRIPTION
see https://www.allegro.cc/manual/4/api/keyboard-routines/readkey#:~:text=Pressing%20alt%2Bkey%20returns%20only%20the%20scancode%2C%20with%20a%20zero%20ASCII%20code%20in%20the%20low%20byte.