### PR TITLE
use python script to print release name

### DIFF
--- a/.github/workflows/print-release-name-vars.py
+++ b/.github/workflows/print-release-name-vars.py
@@ -1,0 +1,44 @@
+import argparse
+
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--github_org', required=True)
+parser.add_argument('--full_release', required=True, type=str2bool)
+parser.add_argument('--version_type', required=True)
+parser.add_argument('--formatted_time', required=True)
+parser.add_argument('--number')
+parser.add_argument('--nightly_number')
+args = parser.parse_args()
+
+if args.number:
+    args.number = int(args.number)
+if args.nightly_number:
+    args.nightly_number = int(args.nightly_number)
+
+release_tag_name = ''
+release_name = ''
+
+if args.full_release:
+    release_tag_name = f'2.55-{args.version_type}-{args.number}'
+    release_name = f'2.55 {args.version_type.capitalize()} {args.number}'
+else:
+    release_tag_name = f'nightly-{args.formatted_time}'
+    release_name = f'Nightly {args.formatted_time}'
+    if args.nightly_number and args.nightly_number != 1:
+        release_tag_name += f'-{args.nightly_number}'
+        release_name += f' ({args.nightly_number})'
+
+if args.github_org != 'ArmageddonGames':
+    release_tag_name = f'{args.github_org}-{release_tag_name}'
+
+print(f'::set-output name=release_tag_name::{release_tag_name}')
+print(f'::set-output name=release_name::{release_name}')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,15 +41,19 @@ jobs:
 
       - id: should_run
         continue-on-error: true
-        if: ${{ github.event_name == 'schedule' }}
+        if: github.event_name == 'schedule' && github.event.pull_request.head.repo.full_name == 'ArmageddonGames/ZQuestClassic'
         run: test -z $(git rev-list --after="1 week" ${{ github.sha }}) && echo "::set-output name=should_run::false"
 
   create-tag:
     runs-on: ubuntu-latest
+    env:
+       HAVE_SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN != '' }}
     outputs:
       release_tag_name: ${{ steps.make-vars.outputs.release_tag_name }}
       release_name: ${{ steps.make-vars.outputs.release_name }}
     steps:
+      - name: git clone
+        uses: actions/checkout@v2
       - name: Get current time
         uses: josStorer/get-current-time@v2
         id: current-time
@@ -57,42 +61,23 @@ jobs:
           format: YYYY-MM-DD
       - id: make-vars
         run: |
-          if [ '${{ github.event.inputs.full_release }}' == 'true' ]; then
-            if [ '${{ github.event.inputs.versiontype }}' == 'alpha' ]; then
-              # Alpha
-              echo "::set-output name=release_tag_name::2.55-alpha-${{ inputs.number }}"
-              echo "::set-output name=release_name::2.55 Alpha ${{ inputs.number }}"
-            elif [ '${{ github.event.inputs.versiontype }}' == 'beta' ]; then
-              # Beta
-              echo "::set-output name=release_tag_name::2.55-beta-${{ inputs.number }}"
-              echo "::set-output name=release_name::2.55 Beta ${{ inputs.number }}"
-            elif [ '${{ github.event.inputs.versiontype }}' == 'gamma' ]; then
-              # Gamma
-              echo "::set-output name=release_tag_name::2.55-gamma-${{ inputs.number }}"
-              echo "::set-output name=release_name::2.55 Gamma ${{ inputs.number }}"
-            else
-              # Release
-              echo "::set-output name=release_tag_name::2.55-release-${{ inputs.number }}"
-              echo "::set-output name=release_name::2.55 Release ${{ inputs.number }}"
-            fi
-          else
-            # Nightly
-            if [ '${{ inputs.nightly_number }}' == '1' ] || [ '${{ inputs.nightly_number }}' == '' ]; then
-                echo "::set-output name=release_tag_name::nightly-${{ steps.current-time.outputs.formattedTime }}"
-                echo "::set-output name=release_name::Nightly ${{ steps.current-time.outputs.formattedTime }}"
-            else
-                echo "::set-output name=release_tag_name::nightly-${{ steps.current-time.outputs.formattedTime }}-${{ inputs.nightly_number }}"
-                echo "::set-output name=release_name::Nightly ${{ steps.current-time.outputs.formattedTime }} (${{ inputs.nightly_number }})"
-            fi
-          fi
+          python3 .github/workflows/print-release-name-vars.py \
+            --github_org=${{ github.repository_owner }} \
+            --full_release=${{ github.event.inputs.full_release }} \
+            --version_type=${{ github.event.inputs.versiontype }} \
+            --formatted_time=${{ steps.current-time.outputs.formattedTime }} \
+            --number=${{ inputs.number }} \
+            --nightly_number=${{ inputs.nightly_number }}
 
       - name: Setup Sentry CLI
         uses: mathieu-bour/setup-sentry-cli@1.2.0
+        if: ${{ env.HAVE_SENTRY_TOKEN == 'true' }}
         with:
           token: ${{ secrets.SENTRY_TOKEN }}
           organization: zeldaclassic
           project: zelda-classic
       - run: sentry-cli releases new ${{ steps.make-vars.outputs.release_tag_name }}
+        if: ${{ env.HAVE_SENTRY_TOKEN == 'true' }}
 
   release-win:
     needs:
@@ -101,6 +86,8 @@ jobs:
     if: ${{ needs.check-date.outputs.should_run != 'false' }}
 
     runs-on: windows-2022
+    env:
+       HAVE_SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN != '' }}
     strategy:
       matrix:
         arrays: [
@@ -122,6 +109,7 @@ jobs:
       with:
         args: install .github/dependencies.config -y
     - name: Setup Sentry CLI
+      if: ${{ env.HAVE_SENTRY_TOKEN == 'true' }}
       uses: mathieu-bour/setup-sentry-cli@1.2.0
       with:
         token: ${{ secrets.SENTRY_TOKEN }}
@@ -137,6 +125,7 @@ jobs:
     - run: mv output/_auto/buildpack.zip "output/_auto/${{ needs.create-tag.outputs.release_tag_name }}-${{ matrix.arrays.name }}.zip"
 
     - name: Upload debugging symbols
+      if: ${{ env.HAVE_SENTRY_TOKEN == 'true' }}
       run: sentry-cli upload-dif ${{ needs.create-tag.outputs.release_tag_name }} --include-sources --wait Release
 
     - name: Release
@@ -195,17 +184,21 @@ jobs:
       - release-win
       - release-mac
     runs-on: ubuntu-latest
+    env:
+       HAVE_SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN != '' }}
 
     steps:
       - name: git clone
         uses: actions/checkout@v2
       - name: Setup Sentry CLI
+        if: ${{ env.HAVE_SENTRY_TOKEN == 'true' }}
         uses: mathieu-bour/setup-sentry-cli@1.2.0
         with:
           token: ${{ secrets.SENTRY_TOKEN }}
           organization: zeldaclassic
           project: zelda-classic
       - name: Finalize sentry
+        if: ${{ env.HAVE_SENTRY_TOKEN == 'true' }}
         run: |
           sentry-cli releases set-commits ${{ needs.create-tag.outputs.release_tag_name }} --auto
           sentry-cli releases finalize ${{ needs.create-tag.outputs.release_tag_name }}


### PR DESCRIPTION
Also uploads to Sentry even on forks, just need a token. Release
name will be prefixed with the github org name. Will be used for my
fork releases of the scrolling beta, so I can get crash reports in
Sentry segregated from the official release channels.