### PR TITLE
consistent cross-platform fp math for replay mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,8 +206,6 @@ if(MSVC)
 	# Turn off warnings for all targets that aren't ours (set later in Misc. section)
 	add_compile_options(/W0)
 
-	# REQUIRED or else MSVC throws internal compiler error(!)
-	add_compile_options("$<$<CONFIG:RELEASE>:/fp:fast>")
 	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 	
 	if(MSVC_VERSION GREATER 1600)
@@ -241,6 +239,13 @@ elseif(LINUX)
 	add_compile_options("-m32")
 	SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -m32 -static-libgcc -export-dynamic")
 	SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -m32 -static-libgcc")
+endif()
+
+if(MSVC)
+	# REQUIRED or else MSVC throws internal compiler error(!)
+	add_compile_options("/fp:fast")
+else(UNIX)
+	add_compile_options("-ffp-model=fast")
 endif()
 
 #############################################################
@@ -287,6 +292,7 @@ add_library(zcbase STATIC
 	src/base/module.cpp
 	src/base/process_management.cpp
 	src/base/random.cpp
+	src/base/sin1.cpp
 	src/base/util.cpp
 	src/base/win32.cpp
 	src/base/zapp.cpp

--- a/src/base/sin1.cpp
+++ b/src/base/sin1.cpp
@@ -1,0 +1,92 @@
+/**
+ * Example for a sine/cosine table lookup
+ * Implementation of sin1() / cos1().
+ * We "outsource" this implementation so that the precompiler constants/macros
+ * are only defined here.
+ *
+ * @file sin1.cpp
+ * @author stfwi
+ **/
+ 
+#include "sin1.h"
+ 
+/*
+ * The number of bits of our data type: here 16 (sizeof operator returns bytes).
+ */
+#define INT16_BITS  (8 * sizeof(int16_t))
+#ifndef INT16_MAX
+#define INT16_MAX   ((1<<(INT16_BITS-1))-1)
+#endif
+ 
+/*
+ * "5 bit" large table = 32 values. The mask: all bit belonging to the table
+ * are 1, the all above 0.
+ */
+#define TABLE_BITS  (5)
+#define TABLE_SIZE  (1<<TABLE_BITS)
+#define TABLE_MASK  (TABLE_SIZE-1)
+ 
+/*
+ * The lookup table is to 90DEG, the input can be -360 to 360 DEG, where negative
+ * values are transformed to positive before further processing. We need two
+ * additional bits (*4) to represent 360 DEG:
+ */
+#define LOOKUP_BITS (TABLE_BITS+2)
+#define LOOKUP_MASK ((1<<LOOKUP_BITS)-1)
+#define FLIP_BIT    (1<<TABLE_BITS)
+#define NEGATE_BIT  (1<<(TABLE_BITS+1))
+#define INTERP_BITS (INT16_BITS-1-LOOKUP_BITS)
+#define INTERP_MASK ((1<<INTERP_BITS)-1)
+ 
+/**
+ * "5 bit" lookup table for the offsets. These are the sines for exactly
+ * at 0deg, 11.25deg, 22.5deg etc. The values are from -1 to 1 in Q15.
+ */
+static int16_t sin90[TABLE_SIZE+1] = {
+  0x0000,0x0647,0x0c8b,0x12c7,0x18f8,0x1f19,0x2527,0x2b1e,
+  0x30fb,0x36b9,0x3c56,0x41cd,0x471c,0x4c3f,0x5133,0x55f4,
+  0x5a81,0x5ed6,0x62f1,0x66ce,0x6a6c,0x6dc9,0x70e1,0x73b5,
+  0x7640,0x7883,0x7a7c,0x7c29,0x7d89,0x7e9c,0x7f61,0x7fd7,
+  0x7fff
+};
+ 
+/**
+ * Sine calculation using interpolated table lookup.
+ * Instead of radiants or degrees we use "turns" here. Means this
+ * sine does NOT return one phase for 0 to 2*PI, but for 0 to 1.
+ * Input: -1 to 1 as int16 Q15  == -32768 to 32767.
+ * Output: -1 to 1 as int16 Q15 == -32768 to 32767.
+ *
+ * See the full description at www.AtWillys.de for the detailed
+ * explanation.
+ *
+ * @param int16_t angle Q15
+ * @return int16_t Q15
+ */
+int16_t sin1(int16_t angle)
+{
+  int16_t v0, v1;
+  if(angle < 0) { angle += INT16_MAX; angle += 1; }
+  v0 = (angle >> INTERP_BITS);
+  if(v0 & FLIP_BIT) { v0 = ~v0; v1 = ~angle; } else { v1 = angle; }
+  v0 &= TABLE_MASK;
+  v1 = sin90[v0] + (int16_t) (((int32_t) (sin90[v0+1]-sin90[v0]) * (v1 & INTERP_MASK)) >> INTERP_BITS);
+  if((angle >> INTERP_BITS) & NEGATE_BIT) v1 = -v1;
+  return v1;
+}
+ 
+/**
+ * Cosine calculation using interpolated table lookup.
+ * Instead of radiants or degrees we use "turns" here. Means this
+ * cosine does NOT return one phase for 0 to 2*PI, but for 0 to 1.
+ * Input: -1 to 1 as int16 Q15  == -32768 to 32767.
+ * Output: -1 to 1 as int16 Q15 == -32768 to 32767.
+ *
+ * @param int16_t angle Q15
+ * @return int16_t Q15
+ */
+int16_t cos1(int16_t angle)
+{
+  if(angle < 0) { angle += INT16_MAX; angle += 1; }
+  return sin1(angle - (int16_t)(((int32_t)INT16_MAX * 270) / 360));
+}

--- a/src/base/sin1.h
+++ b/src/base/sin1.h
@@ -1,0 +1,39 @@
+// https://www.atwillys.de/content/cc/sine-lookup-for-embedded-in-c/
+
+/**
+ * An interpolated sine/cosine table lookup
+ *
+ * @file sin1.h
+ * @author stfwi
+ *
+ */
+#ifndef __SW__SIN1_H__
+#define __SW__SIN1_H__
+ 
+#include <stdint.h>
+ 
+/**
+ * Sine calculation using interpolated table lookup.
+ * Instead of radiants or degrees we use "turns" here. Means this
+ * sine does NOT return one phase for 0 to 2*PI, but for 0 to 1.
+ * Input: -1 to 1 as int16 Q15  == -32768 to 32767.
+ * Output: -1 to 1 as int16 Q15 == -32768 to 32767.
+ *
+ * @param int16_t angle Q15
+ * @return int16_t Q15
+ */
+int16_t sin1(int16_t angle);
+ 
+/**
+ * Cosine calculation using interpolated table lookup.
+ * Instead of radiants or degrees we use "turns" here. Means this
+ * cosine does NOT return one phase for 0 to 2*PI, but for 0 to 1.
+ * Input: -1 to 1 as int16 Q15  == -32768 to 32767.
+ * Output: -1 to 1 as int16 Q15 == -32768 to 32767.
+ *
+ * @param int16_t angle Q15
+ * @return int16_t Q15
+ */
+int16_t cos1(int16_t angle);
+
+#endif

--- a/src/base/zc_math.h
+++ b/src/base/zc_math.h
@@ -2,6 +2,8 @@
 #define __zc_math_h_
 
 #include <math.h>
+#include "sin1.h"
+#include "replay.h"
 
 namespace zc
 {
@@ -78,7 +80,40 @@ inline float CalculateBezier(const float p1, const float t1, const float t2, con
     return ((p1 * A) + (t1 * B) + (t2 * C) + (t3 * D) + (p2 * E));
 }
 
+#define Q15 (1.0/(double)((1<<15)-1))
+inline double Sin(double x)
+{
+	if (replay_is_active())
+	{
+		// x needs to be converted from radians -> angles -> sin1 domain
+		x = x * (180/PI * 32768.0/360.0);
+		return sin1(x) * Q15;
+	}
+	else
+		return std::sin(x);
+}
 
+inline double Cos(double x)
+{
+	if (replay_is_active())
+	{
+		x = x * (180/PI * 32768.0/360.0);
+		return cos1(x) * Q15;
+	}
+	else
+		return std::cos(x);
+}
+
+inline double Tan(double x)
+{
+	if (replay_is_active())
+	{
+		x = x * (180/PI * 32768.0/360.0);
+		return (sin1(x) * Q15) / (cos1(x) * Q15);
+	}
+	else
+		return std::tan(x);
+}
 
 
 

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -2,6 +2,7 @@
 #include "drawing.h"
 #include "zelda.h"
 #include "base/util.h"
+#include "base/zc_math.h"
 #include <allegro/internal/aintern.h>
 
 using namespace util;
@@ -62,7 +63,7 @@ static inline bool dithercheck(byte type, byte arg, int32_t x, int32_t y, int32_
 		case dithStatic:
 		{
 		dthr_static:
-			double diff = abs(sin((double)((x*double(x))+(y*double(y)))) - (cos((double(x)*y))));
+			double diff = abs(zc::math::Sin((double)((x*double(x))+(y*double(y)))) - (zc::math::Cos((double(x)*y))));
 			double filt = ((arg/255.0)*(2000))/1000.0;
 			ret = diff < filt;
 			break;

--- a/src/guys.cpp
+++ b/src/guys.cpp
@@ -24,6 +24,7 @@
 #include "defdata.h"
 #include "zscriptversion.h"
 #include "particles.h"
+#include "base/zc_math.h"
 extern particle_list particles;
 
 extern FFScript FFCore;
@@ -3067,7 +3068,7 @@ bool enemy::moveDir(int32_t dir, zfix px, int32_t special, bool kb)
 bool enemy::moveAtAngle(zfix degrees, zfix px, int32_t special, bool kb)
 {
 	double v = degrees.getFloat() * PI / 180.0;
-	zfix dx = cos(v)*px, dy = sin(v)*px;
+	zfix dx = zc::math::Cos(v)*px, dy = zc::math::Sin(v)*px;
 	return movexy(dx, dy, special, kb);
 }
 
@@ -18280,13 +18281,13 @@ bool ePatra::animate(int32_t index)
 				//maybe playing_field_offset here?
 				if(loopcnt>0)
 				{
-					guys.spr(i)->x =  cos(a2+PI/2)*abs(dmisc31) - sin(pos2*PI*2/(dmisc1 == 0 ? 1 : dmisc1))*((int64_t)abs(dmisc31)-abs(dmisc29));
-					guys.spr(i)->y = -sin(a2+PI/2)*abs(dmisc31) + cos(pos2*PI*2/(dmisc1 == 0 ? 1 : dmisc1))*((int64_t)abs(dmisc31)-abs(dmisc29));
+					guys.spr(i)->x =  zc::math::Cos(a2+PI/2)*abs(dmisc31) - zc::math::Sin(pos2*PI*2/(dmisc1 == 0 ? 1 : dmisc1))*((int64_t)abs(dmisc31)-abs(dmisc29));
+					guys.spr(i)->y = -zc::math::Sin(a2+PI/2)*abs(dmisc31) + zc::math::Cos(pos2*PI*2/(dmisc1 == 0 ? 1 : dmisc1))*((int64_t)abs(dmisc31)-abs(dmisc29));
 				}
 				else
 				{
-					guys.spr(i)->x =  cos(a2+PI/2)*abs(dmisc29);
-					guys.spr(i)->y = -sin(a2+PI/2)*abs(dmisc29);
+					guys.spr(i)->x =  zc::math::Cos(a2+PI/2)*abs(dmisc29);
+					guys.spr(i)->y = -zc::math::Sin(a2+PI/2)*abs(dmisc29);
 				}
 				
 				temp_x=guys.spr(i)->x;
@@ -18294,13 +18295,13 @@ bool ePatra::animate(int32_t index)
 			}
 			else //Oval
 			{
-				circle_x =  cos(a2+PI/2)*abs(dmisc29);
-				circle_y = -sin(a2+PI/2)*abs(dmisc29);
+				circle_x =  zc::math::Cos(a2+PI/2)*abs(dmisc29);
+				circle_y = -zc::math::Sin(a2+PI/2)*abs(dmisc29);
 				
 				if(loopcnt>0)
 				{
-					guys.spr(i)->x =  cos(a2+PI/2)*abs(dmisc29);
-					guys.spr(i)->y = (-sin(a2+PI/2)-cos(pos2*PI*2/(dmisc1 == 0 ? 1 : dmisc1)))*abs(dmisc31);
+					guys.spr(i)->x =  zc::math::Cos(a2+PI/2)*abs(dmisc29);
+					guys.spr(i)->y = (-zc::math::Sin(a2+PI/2)-zc::math::Cos(pos2*PI*2/(dmisc1 == 0 ? 1 : dmisc1)))*abs(dmisc31);
 				}
 				else
 				{
@@ -18536,13 +18537,13 @@ bool ePatra::animate(int32_t index)
 				{
 					if(loopcnt>0)
 					{
-						guys.spr(i)->x =  cos(a2+PI/2)*abs(dmisc32) - sin(pos2*PI*2/(dmisc2==0?1:dmisc2))*((int64_t)abs(dmisc32)-abs(dmisc30));
-						guys.spr(i)->y = -sin(a2+PI/2)*abs(dmisc32) + cos(pos2*PI*2/(dmisc2==0?1:dmisc2))*((int64_t)abs(dmisc32)-abs(dmisc30));
+						guys.spr(i)->x =  zc::math::Cos(a2+PI/2)*abs(dmisc32) - zc::math::Sin(pos2*PI*2/(dmisc2==0?1:dmisc2))*((int64_t)abs(dmisc32)-abs(dmisc30));
+						guys.spr(i)->y = -zc::math::Sin(a2+PI/2)*abs(dmisc32) + zc::math::Cos(pos2*PI*2/(dmisc2==0?1:dmisc2))*((int64_t)abs(dmisc32)-abs(dmisc30));
 					}
 					else
 					{
-						guys.spr(i)->x =  cos(a2+PI/2)*abs(dmisc30);
-						guys.spr(i)->y = -sin(a2+PI/2)*abs(dmisc30);
+						guys.spr(i)->x =  zc::math::Cos(a2+PI/2)*abs(dmisc30);
+						guys.spr(i)->y = -zc::math::Sin(a2+PI/2)*abs(dmisc30);
 					}
 					
 					temp_x=guys.spr(i)->x;
@@ -18550,13 +18551,13 @@ bool ePatra::animate(int32_t index)
 				}
 				else
 				{
-					circle_x =  cos(a2+PI/2)*abs(dmisc30);
-					circle_y = -sin(a2+PI/2)*abs(dmisc30);
+					circle_x =  zc::math::Cos(a2+PI/2)*abs(dmisc30);
+					circle_y = -zc::math::Sin(a2+PI/2)*abs(dmisc30);
 					
 					if(loopcnt>0)
 					{
-						guys.spr(i)->x =  cos(a2+PI/2)*abs(dmisc30);
-						guys.spr(i)->y = (-sin(a2+PI/2)-cos(pos2*PI*2/(dmisc2 == 0 ? 1 : dmisc2)))*abs(dmisc32);
+						guys.spr(i)->x =  zc::math::Cos(a2+PI/2)*abs(dmisc30);
+						guys.spr(i)->y = (-zc::math::Sin(a2+PI/2)-zc::math::Cos(pos2*PI*2/(dmisc2 == 0 ? 1 : dmisc2)))*abs(dmisc32);
 					}
 					else
 					{
@@ -19123,13 +19124,13 @@ bool ePatraBS::animate(int32_t index)
 		{
 			int32_t pos2 = ((enemy*)guys.spr(i))->misc;
 			double a2 = ((int64_t)clk2-pos2*90/(dmisc1==0?1:dmisc1))*PI/45;
-			temp_x =  cos(a2+PI/2)*45;
-			temp_y = -sin(a2+PI/2)*45;
+			temp_x =  zc::math::Cos(a2+PI/2)*45;
+			temp_y = -zc::math::Sin(a2+PI/2)*45;
 			
 			if(loopcnt>0)
 			{
-				guys.spr(i)->x =  cos(a2+PI/2)*45;
-				guys.spr(i)->y = (-sin(a2+PI/2)-cos(pos2*PI*2/(dmisc1==0?1:dmisc1)))*22.5;
+				guys.spr(i)->x =  zc::math::Cos(a2+PI/2)*45;
+				guys.spr(i)->y = (-zc::math::Sin(a2+PI/2)-zc::math::Cos(pos2*PI*2/(dmisc1==0?1:dmisc1)))*22.5;
 			}
 			else
 			{

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -5,6 +5,7 @@
 #include "precompiled.h" //always first
 
 #include "particles.h"
+#include "base/zc_math.h"
 
 particle::~particle()
 {
@@ -40,8 +41,8 @@ void particle::move(zfix s)
 {
     if(angular)
     {
-        x += cos(angle)*s;
-        y += sin(angle)*s;
+        x += zc::math::Cos(angle)*s;
+        y += zc::math::Sin(angle)*s;
 		return;
     }
 	

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -26,6 +26,7 @@
 #include "maps.h"
 #include "replay.h"
 #include "guys.h"
+#include "base/zc_math.h"
 #include <fmt/format.h>
 
 #ifndef IS_ZQUEST
@@ -1028,8 +1029,8 @@ void sprite::move(zfix s)
 {
     if(angular)
     {
-        x += cos(angle)*s;
-        y += sin(angle)*s;
+        x += zc::math::Cos(angle)*s;
+        y += zc::math::Sin(angle)*s;
 		return;
     }
     

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -32,6 +32,7 @@
 #include "decorations.h"
 #include "drawing.h"
 #include "combos.h"
+#include "base/zc_math.h"
 
 extern HeroClass Hero;
 extern zinitdata zinit;
@@ -3926,8 +3927,8 @@ bool weapon::animate(int32_t index)
 			
 			int32_t speed = parentitem>-1 ? zc_max(itemsbuf[parentitem].misc1,1) : 1;
 			int32_t radius = parentitem>-1 ? zc_max(itemsbuf[parentitem].misc2,8) : 8;
-			double xdiff = -(sin((double)clk/speed) * radius);
-			double ydiff = (cos((double)clk/speed) * radius);
+			double xdiff = -(zc::math::Sin((double)clk/speed) * radius);
+			double ydiff = (zc::math::Cos((double)clk/speed) * radius);
 			
 			double ddir=atan2(double(ydiff),double(xdiff));
 			

--- a/src/zc/ffscript.cpp
+++ b/src/zc/ffscript.cpp
@@ -20,7 +20,7 @@
 #include "zc_sys.h"
 extern byte use_dwm_flush;
 uint8_t using_SRAM = 0;
-#include "zc_math.h"
+#include "base/zc_math.h"
 #include "base/zc_array.h"
 #include "ffscript.h"
 #include "zc_subscr.h"
@@ -3651,7 +3651,7 @@ int32_t get_register(const int32_t arg)
 		
 		case INPUTMOUSEY:
 		{
-			int32_t mousequakeoffset = 56+((int32_t)(sin((double)(quakeclk*int64_t(2)-frame))*4));
+			int32_t mousequakeoffset = 56+((int32_t)(zc::math::Sin((double)(quakeclk*int64_t(2)-frame))*4));
 			int32_t tempoffset = (quakeclk > 0) ? mousequakeoffset : (get_bit(quest_rules, qr_OLD_DRAWOFFSET)?playing_field_offset:original_playing_field_offset);
 			int32_t topOffset=(resy/2)-((112-tempoffset)*screen_scale);
 			ret=((gui_mouse_y()-topOffset)/screen_scale)*10000;
@@ -3873,7 +3873,7 @@ int32_t get_register(const int32_t arg)
 				}
 				case 1: //MouseY
 				{
-					int32_t mousequakeoffset = 56+((int32_t)(sin((double)(quakeclk*int64_t(2)-frame))*4));
+					int32_t mousequakeoffset = 56+((int32_t)(zc::math::Sin((double)(quakeclk*int64_t(2)-frame))*4));
 					int32_t tempoffset = (quakeclk > 0) ? mousequakeoffset : (get_bit(quest_rules, qr_OLD_DRAWOFFSET)?playing_field_offset:original_playing_field_offset);
 					int32_t topOffset=(resy/2)-((112-tempoffset)*screen_scale);
 					rv=((gui_mouse_y()-topOffset)/screen_scale)*10000;
@@ -6187,7 +6187,7 @@ int32_t get_register(const int32_t arg)
 			if(0!=(s=checkLWpn(ri->lwpn,"Vx")))
 			{
 				if (((weapon*)(s))->angular)
-					ret = int32_t(cos(((weapon*)s)->angle)*10000.0*((weapon*)s)->step);
+					ret = int32_t(zc::math::Cos(((weapon*)s)->angle)*10000.0*((weapon*)s)->step);
 				else
 				{
 					switch(NORMAL_DIR(((weapon*)(s))->dir))
@@ -6217,7 +6217,7 @@ int32_t get_register(const int32_t arg)
 			if(0!=(s=checkLWpn(ri->lwpn,"Vy")))
 			{
 				if (((weapon*)(s))->angular)
-					ret = int32_t(sin(((weapon*)s)->angle)*10000.0*((weapon*)s)->step);
+					ret = int32_t(zc::math::Sin(((weapon*)s)->angle)*10000.0*((weapon*)s)->step);
 				else
 				{
 					switch(NORMAL_DIR(((weapon*)(s))->dir))
@@ -6766,7 +6766,7 @@ int32_t get_register(const int32_t arg)
 			if(0!=(s=checkEWpn(ri->ewpn,"Vx")))
 			{
 				if (((weapon*)(s))->angular)
-					ret = int32_t(cos(((weapon*)s)->angle)*10000.0*((weapon*)s)->step);
+					ret = int32_t(zc::math::Cos(((weapon*)s)->angle)*10000.0*((weapon*)s)->step);
 				else
 				{
 					switch(NORMAL_DIR(((weapon*)(s))->dir))
@@ -6795,7 +6795,7 @@ int32_t get_register(const int32_t arg)
 			if(0!=(s=checkEWpn(ri->ewpn,"Vy")))
 			{
 				if (((weapon*)(s))->angular)
-					ret = int32_t(sin(((weapon*)s)->angle)*10000.0*((weapon*)s)->step);
+					ret = int32_t(zc::math::Sin(((weapon*)s)->angle)*10000.0*((weapon*)s)->step);
 				else
 				{
 					switch(NORMAL_DIR(((weapon*)(s))->dir))
@@ -13465,7 +13465,7 @@ void set_register(const int32_t arg, const int32_t value)
 		
 		case INPUTMOUSEY:
 		{
-			int32_t mousequakeoffset = 56+((int32_t)(sin((double)(quakeclk*int64_t(2)-frame))*4));
+			int32_t mousequakeoffset = 56+((int32_t)(zc::math::Sin((double)(quakeclk*int64_t(2)-frame))*4));
 			int32_t tempoffset = (quakeclk > 0) ? mousequakeoffset : (get_bit(quest_rules, qr_OLD_DRAWOFFSET)?playing_field_offset:original_playing_field_offset);
 			int32_t topOffset=(resy/2)-((112-tempoffset)*screen_scale);
 			position_mouse(gui_mouse_x(), (value/10000)*screen_scale+topOffset);
@@ -13621,7 +13621,7 @@ void set_register(const int32_t arg, const int32_t value)
 				}
 				case 1: //MouseY
 				{
-					int32_t mousequakeoffset = 56+((int32_t)(sin((double)(quakeclk*int64_t(2)-frame))*4));
+					int32_t mousequakeoffset = 56+((int32_t)(zc::math::Sin((double)(quakeclk*int64_t(2)-frame))*4));
 					int32_t tempoffset = (quakeclk > 0) ? mousequakeoffset :(get_bit(quest_rules, qr_OLD_DRAWOFFSET)?playing_field_offset:original_playing_field_offset);
 					int32_t topOffset=(resy/2)-((112-tempoffset)*screen_scale);
 					position_mouse(gui_mouse_x(), (value/10000)*screen_scale+topOffset);
@@ -15182,7 +15182,7 @@ void set_register(const int32_t arg, const int32_t value)
 				double vy;
 				double vx = (value / 10000.0);
 				if (((weapon*)(s))->angular)
-					vy = sin(((weapon*)s)->angle)*((weapon*)s)->step;
+					vy = zc::math::Sin(((weapon*)s)->angle)*((weapon*)s)->step;
 				else
 				{
 					switch(NORMAL_DIR(((weapon*)(s))->dir))
@@ -15217,7 +15217,7 @@ void set_register(const int32_t arg, const int32_t value)
 				double vx;
 				double vy = (value / 10000.0);
 				if (((weapon*)(s))->angular)
-					vx = cos(((weapon*)s)->angle)*((weapon*)s)->step;
+					vx = zc::math::Cos(((weapon*)s)->angle)*((weapon*)s)->step;
 				else
 				{
 					switch(NORMAL_DIR(((weapon*)(s))->dir))
@@ -15782,7 +15782,7 @@ void set_register(const int32_t arg, const int32_t value)
 				double vy;
 				double vx = (value / 10000.0);
 				if (((weapon*)(s))->angular)
-					vy = sin(((weapon*)s)->angle)*((weapon*)s)->step;
+					vy = zc::math::Sin(((weapon*)s)->angle)*((weapon*)s)->step;
 				else
 				{
 					switch(NORMAL_DIR(((weapon*)(s))->dir))
@@ -15817,7 +15817,7 @@ void set_register(const int32_t arg, const int32_t value)
 				double vx;
 				double vy = (value / 10000.0);
 				if (((weapon*)(s))->angular)
-					vx = cos(((weapon*)s)->angle)*((weapon*)s)->step;
+					vx = zc::math::Cos(((weapon*)s)->angle)*((weapon*)s)->step;
 				else
 				{
 					switch(NORMAL_DIR(((weapon*)(s))->dir))
@@ -22138,15 +22138,15 @@ void do_trig(const bool v, const byte type)
 	switch(type)
 	{
 		case 0:
-			set_register(sarg1, int32_t(sin(rangle) * 10000.0));
+			set_register(sarg1, int32_t(zc::math::Sin(rangle) * 10000.0));
 			break;
 			
 		case 1:
-			set_register(sarg1, int32_t(cos(rangle) * 10000.0));
+			set_register(sarg1, int32_t(zc::math::Cos(rangle) * 10000.0));
 			break;
 			
 		case 2:
-			set_register(sarg1, int32_t(tan(rangle) * 10000.0));
+			set_register(sarg1, int32_t(zc::math::Tan(rangle) * 10000.0));
 			break;
 	}
 }

--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -33,6 +33,7 @@
 #include "ffscript.h"
 #include "drawing.h"
 #include "combos.h"
+#include "base/zc_math.h"
 extern FFScript FFCore;
 extern word combo_doscript[176];
 extern byte itemscriptInitialised[256];
@@ -2923,8 +2924,8 @@ attack:
 			ny=y;
 		}
 		
-		double tx = cos(a2)*53  +nx;
-		double ty = -sin(a2)*53 +ny+playing_field_offset;
+		double tx = zc::math::Cos(a2)*53  +nx;
+		double ty = -zc::math::Sin(a2)*53 +ny+playing_field_offset;
 		overtile8(dest,htile,int32_t(tx),int32_t(ty),1,0);
 		a2-=PI/4;
 		++hearts;

--- a/src/zc/zc_sys.cpp
+++ b/src/zc/zc_sys.cpp
@@ -30,6 +30,7 @@
 #include "init.h"
 #include "replay.h"
 #include "cheats.h"
+#include "base/zc_math.h"
 
 #ifdef ALLEGRO_DOS
 #include <unistd.h>
@@ -1903,9 +1904,9 @@ void black_opening(BITMAP *dest,int32_t x,int32_t y,int32_t a,int32_t max_a)
 		double a0=angle;
 		double a2=angle+P23;
 		double a4=angle+P43;
-		triangle(tmp_scr, x+int32_t(cos(a0)*r), y-int32_t(sin(a0)*r),
-				 x+int32_t(cos(a2)*r), y-int32_t(sin(a2)*r),
-				 x+int32_t(cos(a4)*r), y-int32_t(sin(a4)*r),
+		triangle(tmp_scr, x+int32_t(zc::math::Cos(a0)*r), y-int32_t(zc::math::Sin(a0)*r),
+				 x+int32_t(zc::math::Cos(a2)*r), y-int32_t(zc::math::Sin(a2)*r),
+				 x+int32_t(zc::math::Cos(a4)*r), y-int32_t(zc::math::Sin(a4)*r),
 				 0);
 		break;
 	}
@@ -3712,11 +3713,11 @@ void draw_wavy(BITMAP *source, BITMAP *target, int32_t amplitude, bool interpol)
 		if(j&1 && interpol)
 		{
 			// Add 288*2048 to ensure it's never negative. It'll get modded out.
-			ofs=288*2048+int32_t(sin((double(i+j)*2*PI/amp2))*amplitude);
+			ofs=288*2048+int32_t(zc::math::Sin((double(i+j)*2*PI/amp2))*amplitude);
 		}
 		else
 		{
-			ofs=288*2048-int32_t(sin((double(i+j)*2*PI/amp2))*amplitude);
+			ofs=288*2048-int32_t(zc::math::Sin((double(i+j)*2*PI/amp2))*amplitude);
 		}
 		
 		if(ofs)
@@ -5150,7 +5151,7 @@ void wavyout(bool showhero)
 				
 				if((j<i)&&(j&1))
 				{
-					ofs=int32_t(sin((double(i+j)*2*PI/168.0))*amplitude);
+					ofs=int32_t(zc::math::Sin((double(i+j)*2*PI/168.0))*amplitude);
 				}
 				
 				framebuf->line[j+playing_field_offset][k]=wavebuf->line[j+playing_field_offset][k+ofs+16];
@@ -5223,7 +5224,7 @@ void wavyin()
 				
 				if((j<(167-i))&&(j&1))
 				{
-					ofs=int32_t(sin((double(i+j)*2*PI/168.0))*amplitude);
+					ofs=int32_t(zc::math::Sin((double(i+j)*2*PI/168.0))*amplitude);
 				}
 				
 				framebuf->line[j+playing_field_offset][k]=wavebuf->line[j+playing_field_offset][k+ofs+16];

--- a/src/zc/zelda.cpp
+++ b/src/zc/zelda.cpp
@@ -54,6 +54,7 @@
 #include "dialog/info.h"
 #include "replay.h"
 #include "cheats.h"
+#include "base/zc_math.h"
 #include <fmt/format.h>
 #include <fmt/std.h>
 
@@ -4080,7 +4081,7 @@ void game_loop()
 			// Earthquake!
 			if(quakeclk>0 && !FFCore.system_suspend[susptQUAKE] )
 			{
-				playing_field_offset=56+((int32_t)(sin((double)(--quakeclk*2-frame))*4));
+				playing_field_offset=56+((int32_t)(zc::math::Sin((double)(--quakeclk*2-frame))*4));
 			}
 			else
 			{

--- a/src/zq/zquest.cpp
+++ b/src/zq/zquest.cpp
@@ -34228,4 +34228,5 @@ void enter_sys_pal(){}
 void exit_sys_pal(){}
 
 void replay_step_comment(std::string comment) {}
+bool replay_is_active() {return false;}
 bool replay_is_debug() {return false;}

--- a/tests/replays/classic_1st.zplay
+++ b/tests/replays/classic_1st.zplay
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b56698dc11e4df6150de0de975417f6dcadf860d066caf31efa3a464a2074f8c
-size 4734883
+oid sha256:7c2dce947673c0de565e24ff8082c094c31b125280133adf6a7a256cae1c56f6
+size 4734900

--- a/tests/replays/classic_1st_lvl1.zplay
+++ b/tests/replays/classic_1st_lvl1.zplay
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:610722fb8d2f6079a9c546d9e0d5d04662e69e14bc624832692fffad0860dc18
-size 261289
+oid sha256:4146dc658a041fb07d18fa676cc4b314ceb4ff61b66e0dfd1dd6437cbd079e16
+size 261287

--- a/tests/run_replay_tests.py
+++ b/tests/run_replay_tests.py
@@ -60,9 +60,6 @@ if args.ci:
         # Never finishes.
         'new2013.zplay',
     ]
-    if args.ci == 'windows':
-        # Unaddressed graphical difference.
-        replays_failing_in_ci.append('classic_1st.zplay')
     tests = [t for t in tests if t.name not in replays_failing_in_ci]
 
 def run_replay_test(replay_file):


### PR DESCRIPTION
cos, sin and tan can differ across platforms... and even differ within the same binary due to float point register madness. [1] So I found an table-based cos/sin library, and use it when in replay mode. Could have used allegro's, but this is a bit more accurate and probably faster.

Also set clang float point mode to fast (-ffp-model=fast), to match MSVC's /fp:fast. Without this, slight differences in floating point operations would have minor pixel-level differences between windows and osx (ex: the fairy heart circle). [2][3][4]

Note, I did try using `precise` floating point mode, but that hits a compiler bug in MSVC–errors on compiling `ePatra::animate` only for release, 32 bit (MSBuild version 17.3.1+2badb37d1). Besides, `fast` is probably better given we don't need a crazy amount of precision.

[1] https://isocpp.org/wiki/faq/newbie#floating-point-arith2 [2] https://learn.microsoft.com/en-us/cpp/build/reference/fp-specify-floating-point-behavior?view=msvc-170 [3] https://clang.llvm.org/docs/UsersManual.html#controlling-floating-point-behavior [4] https://cpp.godbolt.org/z/d1fcnMM9r