### PR TITLE
Fix bad release tagging for non-nightlies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         project: zelda-classic
 
     - run: bash .github/workflows/configure-signatures.sh win ${{ inputs.versiontype }} ${{ inputs.full_release }} ${{ inputs.number }}
-    - run: cmake . -A ${{ matrix.arrays.arch }} -DWANT_SENTRY=ON -DRELEASE_TAG=${{ needs.create-tag.outputs.release_tag_name }}
+    - run: cmake . -A ${{ matrix.arrays.arch }} -DWANT_SENTRY=ON -DRELEASE_TAG="${{ needs.create-tag.outputs.release_tag_name }}"
     - run: cmake --build . --config RelWithDebInfo
     - run: mv RelWithDebInfo Release
     - run: echo y | ./buildpack.bat


### PR DESCRIPTION
All the alphas were built with the tag "2" because of some stupid command line parsing problem:

```
Run cmake . -A x64 -DWANT_SENTRY=ON -DSENTRY_RELEASE_TAG=2.55-alpha-111
CMake Warning:
  Ignoring extra path from command line:

   ".55-alpha-111"
```

https://github.com/ArmageddonGames/ZQuestClassic/actions/runs/3306528832/jobs/5457492806#step:7:57