### PR TITLE
Use MessageBox on Win32 to display fatal errors

### DIFF
--- a/src/base/zsys.cpp
+++ b/src/base/zsys.cpp
@@ -299,7 +299,10 @@ int32_t get_bitl(int32_t bitstr,int32_t bit)
 #if defined(ALLEGRO_DOS ) || defined(ALLEGRO_MAXOSX)
     printf("%s",buf);
 #elif defined(ALLEGRO_WINDOWS)
-    MessageBoxA(NULL, buf, "Zelda Classic", MB_OK | MB_ICONERROR);
+	if (!zscript_coloured_console.valid())
+	{
+		MessageBoxA(NULL, buf, "Zelda Classic", MB_OK | MB_ICONERROR);
+	}
 #endif
     zscript_coloured_console.cprintf((CConsoleLoggerEx::COLOR_RED | CConsoleLoggerEx::COLOR_INTENSITY | 
 		CConsoleLoggerEx::COLOR_BACKGROUND_BLACK), "%s", buf);

--- a/src/base/zsys.cpp
+++ b/src/base/zsys.cpp
@@ -287,7 +287,7 @@ int32_t get_bitl(int32_t bitstr,int32_t bit)
 }
 
 
-void Z_error_fatal(const char *format,...)
+[[noreturn]] void Z_error_fatal(const char *format,...)
 {
     char buf[256];
     
@@ -298,6 +298,8 @@ void Z_error_fatal(const char *format,...)
     
 #if defined(ALLEGRO_DOS ) || defined(ALLEGRO_MAXOSX)
     printf("%s",buf);
+#elif defined(ALLEGRO_WINDOWS)
+    MessageBoxA(NULL, buf, "Zelda Classic", MB_OK | MB_ICONERROR);
 #endif
     zscript_coloured_console.cprintf((CConsoleLoggerEx::COLOR_RED | CConsoleLoggerEx::COLOR_INTENSITY | 
 		CConsoleLoggerEx::COLOR_BACKGROUND_BLACK), "%s", buf);

--- a/src/base/zsys.h
+++ b/src/base/zsys.h
@@ -64,7 +64,7 @@ bool toggle_bit(byte *bitstr,int32_t bit);
 int32_t  get_bitl(int32_t bitstr,int32_t bit);
 void set_bitl(int32_t bitstr,int32_t bit,byte val);
 
-void Z_error_fatal(const char *format,...);
+[[noreturn]] void Z_error_fatal(const char *format,...);
 void Z_error(const char *format,...);
 void Z_title(const char *format,...);
 void set_should_zprint_cb(std::function<bool()> cb);

--- a/src/zc/zelda.cpp
+++ b/src/zc/zelda.cpp
@@ -4707,7 +4707,7 @@ int main(int argc, char **argv)
 	//al_trace("Before zcm.init, the current module is: %s\n", moduledata.module_name)
 	if ( !(zcm.init(true)) ) 
 	{
-		exit(1);    
+		Z_error_fatal("ZC Player I/O Error: No module definitions found. Please check your settings in %s.cfg.\n", "zc");
 	}
 	
 #ifdef _WIN32


### PR DESCRIPTION
Whenever a fatal error happened, Zelda Classic used to simply die with no message on Windows.  Now it displays a message box with the error message if the zquest console isn't up.

![image](https://user-images.githubusercontent.com/23563/208824014-cc94d36f-9514-4764-9ad7-c81bb7f5c750.png)

This is my first PR for this project, please let me know if I overlooked something.  In particular, due to the mix of spaces and tabs I went with whatever the editor spat out by default.