### PR TITLE
Add /MP to MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,9 @@ if(MSVC)
 	# Turn off warnings for all targets that aren't ours (set later in Misc. section)
 	add_compile_options(/W0)
 
+	# Build in parallel - speeds up the build on multicore machines.
+	add_compile_options(/MP)
+
 	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 	
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCD /SUBSYSTEM:WINDOWS /LARGEADDRESSAWARE /OPT:NOICF")


### PR DESCRIPTION
This should significantly speed the build up on multicore machines building with MSVC from within the IDE.  On my system, a 5800X with 32GB of RAM, this change cut the build time from 5 minutes and change to around 2.