### PR TITLE
build: add include to fix missing atoi on VS2022

### DIFF
--- a/src/zfix.h
+++ b/src/zfix.h
@@ -10,6 +10,7 @@
 #include <limits>
 #include <assert.h>
 #include <cstring>
+#include <cstdlib>
 
 #define FIX_NAN 0
 //std::numeric_limits<t>::quiet_NaN()


### PR DESCRIPTION
Ran into some "identifier not found" messages when compiling on MSVC 17.7.4.

```
13>...\Workspace\ZQuestClassic\src\zfix.h(61,9): error C3861: 'atoi': identifier not found
13>...\Workspace\ZQuestClassic\src\zfix.h(64,11): error C3861: 'atoi': identifier not found
13>...\Workspace\ZQuestClassic\src\zfix.h(65,15): error C3861: 'atoi': identifier not found
13>...\Workspace\ZQuestClassic\src\zfix.h(69,9): error C3861: 'atoi': identifier not found
14>...\Workspace\ZQuestClassic\src\zfix.h(61,9): error C3861: 'atoi': identifier not found
14>...\Workspace\ZQuestClassic\src\zfix.h(64,11): error C3861: 'atoi': identifier not found
14>...\Workspace\ZQuestClassic\src\zfix.h(65,15): error C3861: 'atoi': identifier not found
14>...\Workspace\ZQuestClassic\src\zfix.h(69,9): error C3861: 'atoi': identifier not found
```

Adding a header made these go away.