### PR TITLE
Spotlight caching

### DIFF
--- a/src/base/cpos_info.cpp
+++ b/src/base/cpos_info.cpp
@@ -2,6 +2,8 @@
 #include "base/zdefs.h"
 #include "base/combo.h"
 
+void update_cpos_cache(word oldid, word newid);
+
 void cpos_info::push(int dir, bool cancel)
 {
 	if(unsigned(dir) < 4)
@@ -17,11 +19,20 @@ word cpos_info::sumpush() const
 	return pushes[0]+pushes[1]+pushes[2]+pushes[3];
 }
 
+//Clear the info with no regard for the cpos cache
 void cpos_info::clear()
 {
 	*this = cpos_info();
 }
 
+//Clear the info, updating the cpos cache to the change
+void cpos_info::clearInfo()
+{
+	update_cpos_cache(data,0);
+	clear();
+}
+
+//Change the data of the combo, updating the cpos cache and triggering other effects
 void cpos_info::updateData(int32_t newdata)
 {
 	if(data != newdata)
@@ -34,6 +45,7 @@ void cpos_info::updateData(int32_t newdata)
 			cspr = cmb.spr_disappear;
 		}
 		
+		update_cpos_cache(data,newdata);
 		clear();
 		data = newdata;
 		
@@ -41,3 +53,12 @@ void cpos_info::updateData(int32_t newdata)
 		spr_onchange = cspr;
 	}
 }
+
+//Copy from 'other', updating the cpos cache with the changes
+void cpos_info::updateInfo(cpos_info const& other)
+{
+	if(data != other.data)
+		update_cpos_cache(data,other.data);
+	*this = other;
+}
+

--- a/src/base/cpos_info.cpp
+++ b/src/base/cpos_info.cpp
@@ -2,7 +2,7 @@
 #include "base/zdefs.h"
 #include "base/combo.h"
 
-void update_cpos_cache(word oldid, word newid);
+void cpos_update_cache(word oldid, word newid);
 
 void cpos_info::push(int dir, bool cancel)
 {
@@ -28,7 +28,7 @@ void cpos_info::clear()
 //Clear the info, updating the cpos cache to the change
 void cpos_info::clearInfo()
 {
-	update_cpos_cache(data,0);
+	cpos_update_cache(data,0);
 	clear();
 }
 
@@ -45,7 +45,7 @@ void cpos_info::updateData(int32_t newdata)
 			cspr = cmb.spr_disappear;
 		}
 		
-		update_cpos_cache(data,newdata);
+		cpos_update_cache(data,newdata);
 		clear();
 		data = newdata;
 		
@@ -58,7 +58,7 @@ void cpos_info::updateData(int32_t newdata)
 void cpos_info::updateInfo(cpos_info const& other)
 {
 	if(data != other.data)
-		update_cpos_cache(data,other.data);
+		cpos_update_cache(data,other.data);
 	*this = other;
 }
 

--- a/src/base/cpos_info.h
+++ b/src/base/cpos_info.h
@@ -26,6 +26,8 @@ struct cpos_info
 	word sumpush() const;
 	void clear();
 	void updateData(int32_t newdata);
+	void updateInfo(cpos_info const& other);
+	void clearInfo();
 };
 
 #endif

--- a/src/zc/combos.h
+++ b/src/zc/combos.h
@@ -66,15 +66,13 @@ void trig_trigger_groups();
 
 
 // CPOS stuff
-cpos_info& get_combo_posinfo(int32_t layer, int32_t pos);
-int get_trig_group(int ind);
+cpos_info& cpos_get(int32_t layer, int32_t pos);
+int cpos_trig_group_count(int ind);
 int cpos_exists_spotlight();
 
-void clear_cposes();
-void force_update_cposes();
-void update_cposes();
-
-void force_recalculate_trig_groups();
+void cpos_clear_all();
+void cpos_force_update();
+void cpos_update();
 
 
 #endif

--- a/src/zc/combos.h
+++ b/src/zc/combos.h
@@ -25,10 +25,6 @@ public:
 };
 extern CutsceneState active_cutscene;
 
-void clear_combo_posinfo();
-cpos_info& get_combo_posinfo(int32_t layer, int32_t pos);
-void set_combo_posinfo(int32_t layer, int32_t pos, cpos_info& posinfo);
-
 bool do_cswitch_combo(newcombo const& cmb, weapon* w = NULL);
 void do_generic_combo2(int32_t bx, int32_t by, int32_t cid, int32_t flag, int32_t flag2, int32_t ft, int32_t scombo, bool single16, int32_t layer);
 void do_generic_combo_ffc2(int32_t pos, int32_t cid, int32_t ft);
@@ -64,13 +60,22 @@ bool do_trigger_combo_ffc(int32_t pos, int32_t special = 0, weapon* w = NULL);
 
 bool do_lift_combo(int32_t lyr, int32_t pos, int32_t gloveid);
 
-int get_trig_group(int ind);
-void update_trig_group(int oldc, int newc);
-void calculate_trig_groups();
+void handle_cpos_type(newcombo const& cmb, cpos_info& timer, int lyr, int pos);
+void handle_ffcpos_type(newcombo const& cmb, cpos_info& timer, ffcdata& f);
 void trig_trigger_groups();
-void init_combo_timers();
-void update_combo_timers();
-bool on_cooldown(int32_t lyr, int32_t pos);
+
+
+// CPOS stuff
+cpos_info& get_combo_posinfo(int32_t layer, int32_t pos);
+int get_trig_group(int ind);
+int cpos_exists_spotlight();
+
+void clear_cposes();
+void force_update_cposes();
+void update_cposes();
+
+void force_recalculate_trig_groups();
+
 
 #endif
 

--- a/src/zc/ffscript.cpp
+++ b/src/zc/ffscript.cpp
@@ -8481,7 +8481,7 @@ int32_t get_register(const int32_t arg)
 			int32_t ind = (ri->d[rINDEX])/10000;
 			if(unsigned(ind)>255)
 				Z_scripterrlog("Invalid index %d supplied to Game->TrigGroups[]\n",ind);
-			ret = get_trig_group(ind)*10000;
+			ret = cpos_trig_group_count(ind)*10000;
 			break;
 		}
 		

--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -20266,7 +20266,7 @@ void HeroClass::checkpushblock()
 		if(get_qr(qr_HESITANTPUSHBLOCKS)&&(pushing<4)) break;
 		if(lyr && !get_qr(qr_PUSHBLOCK_LAYER_1_2))
 			continue;
-		cpos_info& cpinfo = get_combo_posinfo(lyr, combopos);
+		cpos_info& cpinfo = cpos_get(lyr, combopos);
 		mapscr* m = FFCore.tempScreens[lyr];
 		int cid = lyr == 0 ? MAPCOMBO(bx,by) : MAPCOMBOL(lyr,bx,by);
 		newcombo const& cmb = combobuf[cid];
@@ -21502,7 +21502,7 @@ void HeroClass::checksigns() //Also checks for generic trigger buttons
 		didsign = true;
 	}
 endsigns:
-	if(get_combo_posinfo(found_lyr, COMBOPOS(fx,fy)).trig_cd) return;
+	if(cpos_get(found_lyr, COMBOPOS(fx,fy)).trig_cd) return;
 	switch(dir)
 	{
 		case down:

--- a/src/zc/maps.cpp
+++ b/src/zc/maps.cpp
@@ -4993,7 +4993,7 @@ void loadscr(int32_t tmp,int32_t destdmap, int32_t scr,int32_t ldir,bool overlay
 	{
 		slopes.clear();
 		triggered_screen_secrets = false; //Reset var
-		init_combo_timers();
+		clear_cposes();
 		Hero.clear_platform_ffc();
 		timeExitAllGenscript(GENSCR_ST_CHANGE_SCREEN);
 	}
@@ -5149,7 +5149,7 @@ void loadscr(int32_t tmp,int32_t destdmap, int32_t scr,int32_t ldir,bool overlay
 	
 	if(!tmp)
 	{
-		calculate_trig_groups();
+		force_update_cposes();
 		trig_trigger_groups();
 	}
 	if(canPermSecret(destdmap,scr)/*||TheMaps[(currmap*MAPSCRS)+currscr].flags6&fTRIGGERFPERM*/)
@@ -5211,7 +5211,7 @@ void loadscr(int32_t tmp,int32_t destdmap, int32_t scr,int32_t ldir,bool overlay
 	
 	if(!tmp)
 	{
-		calculate_trig_groups();
+		force_update_cposes();
 		trig_trigger_groups();
 	}
 	// check doors

--- a/src/zc/maps.cpp
+++ b/src/zc/maps.cpp
@@ -4993,7 +4993,7 @@ void loadscr(int32_t tmp,int32_t destdmap, int32_t scr,int32_t ldir,bool overlay
 	{
 		slopes.clear();
 		triggered_screen_secrets = false; //Reset var
-		clear_cposes();
+		cpos_clear_all();
 		Hero.clear_platform_ffc();
 		timeExitAllGenscript(GENSCR_ST_CHANGE_SCREEN);
 	}
@@ -5149,7 +5149,7 @@ void loadscr(int32_t tmp,int32_t destdmap, int32_t scr,int32_t ldir,bool overlay
 	
 	if(!tmp)
 	{
-		force_update_cposes();
+		cpos_force_update();
 		trig_trigger_groups();
 	}
 	if(canPermSecret(destdmap,scr)/*||TheMaps[(currmap*MAPSCRS)+currscr].flags6&fTRIGGERFPERM*/)
@@ -5211,7 +5211,7 @@ void loadscr(int32_t tmp,int32_t destdmap, int32_t scr,int32_t ldir,bool overlay
 	
 	if(!tmp)
 	{
-		force_update_cposes();
+		cpos_force_update();
 		trig_trigger_groups();
 	}
 	// check doors

--- a/src/zc/zc_sprite.cpp
+++ b/src/zc/zc_sprite.cpp
@@ -771,7 +771,7 @@ bool movingblock::animate(int32_t)
 			
 			if(m->data[combopos] == bcombo)
 			{
-				set_combo_posinfo(blockLayer, combopos, blockinfo);
+				get_combo_posinfo(blockLayer, combopos).updateInfo(blockinfo);
 			}
 		}
 		else

--- a/src/zc/zc_sprite.cpp
+++ b/src/zc/zc_sprite.cpp
@@ -771,7 +771,7 @@ bool movingblock::animate(int32_t)
 			
 			if(m->data[combopos] == bcombo)
 			{
-				get_combo_posinfo(blockLayer, combopos).updateInfo(blockinfo);
+				cpos_get(blockLayer, combopos).updateInfo(blockinfo);
 			}
 		}
 		else

--- a/src/zc/zelda.cpp
+++ b/src/zc/zelda.cpp
@@ -3284,7 +3284,7 @@ void game_loop()
 		if ( !FFCore.system_suspend[susptCOMBOANIM] )
 		{
 			animate_combos();
-			update_combo_timers();
+			update_cposes();
 		}
 		run_gswitch_timers();
 		FFCore.runGenericPassiveEngine(SCR_TIMING_POST_COMBO_ANIM);

--- a/src/zc/zelda.cpp
+++ b/src/zc/zelda.cpp
@@ -3284,7 +3284,7 @@ void game_loop()
 		if ( !FFCore.system_suspend[susptCOMBOANIM] )
 		{
 			animate_combos();
-			update_cposes();
+			cpos_update();
 		}
 		run_gswitch_timers();
 		FFCore.runGenericPassiveEngine(SCR_TIMING_POST_COMBO_ANIM);


### PR DESCRIPTION
Refactored the `cpos_info` code, now can cleanly cache any number of bits of information about the combos on-screen. This PR uses this to cache whether or not any cSPOTLIGHT combos are present, and skips portions of `handleSpotlights()` when 0 such combos are present.