### PR TITLE
fix(zq)!: preview in screen enemy dialog not updating

### DIFF
--- a/src/dialog/info_lister.cpp
+++ b/src/dialog/info_lister.cpp
@@ -434,19 +434,24 @@ void EnemyListerDialog::update()
 			selected_val, enemy.tile, enemy.s_tile,
 			enemy.e_tile, enemy.hp, enemy.dp, enemy.wdp, enemy.family, enemy.item_set, enemy.script, enemy.weaponscript,
 			copied_name));
-		widgPrev->setDisabled(false);
-		if (get_qr(qr_NEWENEMYTILES))
-			widgPrev->setTile(enemy.e_tile + efrontfacingtile(selected_val));
+		if(unsigned(selected_val) > 0)
+		{
+			widgPrev->setDisabled(false);
+			if (get_qr(qr_NEWENEMYTILES))
+				widgPrev->setTile(enemy.e_tile + efrontfacingtile(selected_val));
+			else
+				widgPrev->setTile(enemy.tile + efrontfacingtile(selected_val));
+			widgPrev->setCSet(enemy.cset & 0xF);
+			widgPrev->setFrames(0);
+			widgPrev->setSpeed(0);
+			widgPrev->setDelay(0);
+			widgPrev->setSkipX((enemy.SIZEflags & OVERRIDE_TILE_WIDTH)
+				? enemy.txsz - 1 : 0);
+			widgPrev->setSkipY((enemy.SIZEflags & OVERRIDE_TILE_HEIGHT)
+				? enemy.tysz - 1 : 0);
+		}
 		else
-			widgPrev->setTile(enemy.tile + efrontfacingtile(selected_val));
-		widgPrev->setCSet(enemy.cset & 0xF);
-		widgPrev->setFrames(0);
-		widgPrev->setSpeed(0);
-		widgPrev->setDelay(0);
-		widgPrev->setSkipX((enemy.SIZEflags & OVERRIDE_TILE_WIDTH)
-			? enemy.txsz - 1 : 0);
-		widgPrev->setSkipY((enemy.SIZEflags & OVERRIDE_TILE_HEIGHT)
-			? enemy.tysz - 1 : 0);
+			widgPrev->setDisabled(true);
 	}
 	else
 	{

--- a/src/dialog/screen_enemies.cpp
+++ b/src/dialog/screen_enemies.cpp
@@ -82,16 +82,7 @@ void ScreenEnemiesDialog::UpdatePreview()
 				? enemy.tysz - 1 : 0);
 		}
 		else
-		{
 			widgPrev->setDisabled(true);
-			widgPrev->setTile(0);
-			widgPrev->setCSet(0);
-			widgPrev->setFrames(0);
-			widgPrev->setSpeed(0);
-			widgPrev->setDelay(0);
-			widgPrev->setSkipX(0);
-			widgPrev->setSkipY(0);
-		}
 	}
 	widgPrev->setVisible(true);
 	widgPrev->setDoSized(true);
@@ -130,9 +121,8 @@ std::shared_ptr<GUI::Widget> ScreenEnemiesDialog::view()
 					fitParent = true,
 					onSelectFunc = [&](int32_t val)
 					{
-						//selectedValue = scr_enemies->getSelectedValue();
-						//selectedIndex = scr_enemies->getSelectedIndex();
-						message::SELECT;
+						selectedIndex = val;
+						UpdatePreview();
 					},
 					onDClick = message::EDIT
 				),
@@ -194,8 +184,6 @@ bool ScreenEnemiesDialog::handleMessage(const GUI::DialogMessage<message>& msg)
 	{
 	case message::COPY:
 		copied_enemy_id = thescr->enemy[scr_enemies->getSelectedIndex()];
-		[[fallthrough]];
-	case message::SELECT:
 		UpdatePreview();
 		refresh = true;
 		break;

--- a/src/dialog/screen_enemies.h
+++ b/src/dialog/screen_enemies.h
@@ -19,7 +19,7 @@ class ScreenEnemiesDialog : public GUI::Dialog<ScreenEnemiesDialog>
 public:
     enum class message
     {
-        REFR_INFO, COPY, PASTE, SELECT, EDIT, CLEAR, PASTEFROMSCREEN, FLAGS, PATTERN, OK, CANCEL
+        REFR_INFO, COPY, PASTE, EDIT, CLEAR, PASTEFROMSCREEN, FLAGS, PATTERN, OK, CANCEL
     };
 
     void RebuildList();


### PR DESCRIPTION
1) (None) now has the tile preview disabled
2) Preview should always update now, their where some issues when the selection was changed and the preview didn't update in screen enemies.