### PR TITLE
refactor: read weapon names from zinfo, not the deprecated module system

### DIFF
--- a/src/base/module.cpp
+++ b/src/base/module.cpp
@@ -18,9 +18,6 @@ bool ZModule::init(bool d) //bool default
 	memset(moduledata.walkmisc7_names, 0, sizeof(moduledata.walkmisc7_names));
 	memset(moduledata.walkmisc9_names, 0, sizeof(moduledata.walkmisc9_names));
 	memset(moduledata.guy_type_names, 0, sizeof(moduledata.guy_type_names));
-	memset(moduledata.enemy_weapon_names, 0, sizeof(moduledata.enemy_weapon_names));
-	memset(moduledata.enemy_weapon_names, 0, sizeof(moduledata.enemy_scriptweaponweapon_names)); 
-	memset(moduledata.player_weapon_names, 0, sizeof(moduledata.player_weapon_names));
 	memset(moduledata.base_NSF_file, 0, sizeof(moduledata.base_NSF_file));
 	memset(moduledata.copyright_strings, 0, sizeof(moduledata.copyright_strings));
 	memset(moduledata.copyright_string_vars, 0, sizeof(moduledata.copyright_string_vars));
@@ -284,94 +281,7 @@ bool ZModule::init(bool d) //bool default
 			strcpy(moduledata.guy_type_names[q],zc_get_config_basic("GUYS",guy_types[q],guy_default_names[q]));
 		}
 		
-		const char enemy_weapon_cats[wMax-wEnemyWeapons][255]=
-		{
-			"ewNone",
-			"ewFireball",
-			"ewArrow",
-			"ewBrang",
-			"ewSword",
-			"ewRock",
-			"ewMagic",
-			"ewBomb",
-			"ewSBomb",
-			"ewLitBomb",
-			"ewLitSBomb",
-			"ewFireTrail",
-			"ewFlame",
-			"ewWind",
-			"ewFlame2",
-			"ewFlame2Trail",
-			"ewIce",
-			"ewFireball2"
-		};
 		
-		const char enemy_weapon_default_names[wMax-wEnemyWeapons][255]=
-		{
-			"(None)",
-			"Fireball",
-			"Arrow",
-			"Boomerang",
-			"Sword",
-			"Rock",
-			"Magic",
-			"Bomb Blast",
-			"Super Bomb Blast",
-			"Lit Bomb",
-			"Lit Super Bomb",
-			"Fire Trail",
-			"Flame",
-			"Wind",
-			"Flame 2",
-			"-Flame 2 Trail <unused>",
-			"-Ice <unused>",
-			"Fireball (Rising)"
-		};
-		
-		for ( int32_t q = 0; q < sizeof(enemy_weapon_default_names)/255; q++ )
-		{
-			strcpy(moduledata.enemy_weapon_names[q],zc_get_config_basic("EWEAPONS",enemy_weapon_cats[q],enemy_weapon_default_names[q]));
-		}
-		
-		
-		strcpy(moduledata.enemy_scriptweaponweapon_names[0],zc_get_config_basic("EWEAPONS","Custom_1","Custom 01"));
-		strcpy(moduledata.enemy_scriptweaponweapon_names[1],zc_get_config_basic("EWEAPONS","Custom_2","Custom 02"));
-		strcpy(moduledata.enemy_scriptweaponweapon_names[2],zc_get_config_basic("EWEAPONS","Custom_3","Custom 03"));
-		strcpy(moduledata.enemy_scriptweaponweapon_names[3],zc_get_config_basic("EWEAPONS","Custom_4","Custom 04"));
-		strcpy(moduledata.enemy_scriptweaponweapon_names[4],zc_get_config_basic("EWEAPONS","Custom_5","Custom 05"));
-		strcpy(moduledata.enemy_scriptweaponweapon_names[5],zc_get_config_basic("EWEAPONS","Custom_6","Custom 06"));
-		strcpy(moduledata.enemy_scriptweaponweapon_names[6],zc_get_config_basic("EWEAPONS","Custom_7","Custom 07"));
-		strcpy(moduledata.enemy_scriptweaponweapon_names[7],zc_get_config_basic("EWEAPONS","Custom_8","Custom 08"));
-		strcpy(moduledata.enemy_scriptweaponweapon_names[8],zc_get_config_basic("EWEAPONS","Custom_9","Custom 09"));
-		strcpy(moduledata.enemy_scriptweaponweapon_names[9],zc_get_config_basic("EWEAPONS","Custom_10","Custom 10"));
-		
-		const char lweapon_cats[wRefFire2+1][255]=
-		{
-			"lwNone","lwSword","lwBeam","lwBrang","lwBomb","lwSBomb","lwLitBomb",
-			"lwLitSBomb","lwArrow","lwFire","lwWhistle","lwMeat","lwWand","lwMagic","lwCatching",
-			"lwWind","lwRefMagic","lwRefFireball","lwRefRock", "lwHammer","lwGrapple", "lwHSHandle", 
-			"lwHSChain", "lwSSparkle","lwFSparkle", "lwSmack", "lwPhantom", 
-			"lwCane","lwRefBeam", "lwStomp","","lwScript1", "lwScript2", "lwScript3", 
-			"lwScript4","lwScript5", "lwScript6", "lwScript7", "lwScript8","lwScript9", "lwScript10", "lwIce",
-			"-wFlame", "-wSound", "-wThrown", "-wPot", "-wLit", "-wBombos", "-wEther", "-wQuake",
-			"-wSword180", "-wSwordLA", "-wBugNet", "lwRefArrow", "lwRefFire", "lwRefFire2"
-		};
-		const char lweapon_default_names[wRefFire2+1][255]=
-		{
-			"(None)","Sword","Sword Beam","Boomerang","Bomb","Super Bomb","Lit Bomb",
-			"Lit Super Bomb","Arrow","Fire","Whistle","Bait","Wand","Magic","-Catching",
-			"Wind","Reflected Magic","Reflected Fireball","Reflected Rock", "Hammer","Hookshot", "-HSHandle", 
-			"-HSChain", "Sparkle","-FSparkle", "-Smack", "-Phantom", 
-			"Cane of Byrna","Reflected Sword Beam", "-Stomp","-lwmax","Script1", "Script2", "Script3", 
-			"Script4","Script5", "Script6", "Script7", "Script8","Script9", "Script10", "Ice",
-			"-wFlame", "-wSound", "-wThrown", "-wPot", "-wLit", "-wBombos", "-wEther", "-wQuake",
-			"-wSword180", "-wSwordLA", "-wBugNet", "Reflected Arrow", "Reflected Fire", "Reflected Fire 2"
-		};
-		for ( int32_t q = 0; q < wRefFire2+1; q++ )
-		{
-			if(lweapon_cats[q][0] != '-')
-				strcpy(moduledata.player_weapon_names[q],(lweapon_cats[q][0] ? zc_get_config_basic("LWEAPONS",lweapon_cats[q],lweapon_default_names[q]) : lweapon_default_names[q]));
-		}
 		
 		al_trace("Module Title: %s\n", moduledata.moduletitle);
 		al_trace("Module Author: %s\n", moduledata.moduleauthor);

--- a/src/zc/zc_module.cpp
+++ b/src/zc/zc_module.cpp
@@ -48,9 +48,6 @@ bool ZModule::init(bool d) //bool default
 	memset(moduledata.walkmisc7_names, 0, sizeof(moduledata.walkmisc7_names));
 	memset(moduledata.walkmisc9_names, 0, sizeof(moduledata.walkmisc9_names));
 	memset(moduledata.guy_type_names, 0, sizeof(moduledata.guy_type_names));
-	memset(moduledata.enemy_weapon_names, 0, sizeof(moduledata.enemy_weapon_names));
-	memset(moduledata.enemy_weapon_names, 0, sizeof(moduledata.enemy_scriptweaponweapon_names));
-	memset(moduledata.player_weapon_names, 0, sizeof(moduledata.player_weapon_names));
 	memset(moduledata.delete_quest_data_on_wingame, 0, sizeof(moduledata.delete_quest_data_on_wingame));
 	memset(moduledata.base_NSF_file, 0, sizeof(moduledata.base_NSF_file));
 	memset(moduledata.copyright_strings, 0, sizeof(moduledata.copyright_strings));
@@ -290,34 +287,7 @@ bool ZModule::init(bool d) //bool default
 		for ( int32_t q = 0; q < rMAX; q++ )
 		{
 			strcpy(moduledata.roomtype_names[q],zc_get_config_basic("ROOMTYPES",roomtype_cats[q],roomtype_defaults[q]));
-		}
-		static const char lweapon_cats[wRefFire2+1][255]=
-		{
-			"lwNone","lwSword","lwBeam","lwBrang","lwBomb","lwSBomb","lwLitBomb",
-			"lwLitSBomb","lwArrow","lwFire","lwWhistle","lwMeat","lwWand","lwMagic","lwCatching",
-			"lwWind","lwRefMagic","lwRefFireball","lwRefRock", "lwHammer","lwGrapple", "lwHSHandle", 
-			"lwHSChain", "lwSSparkle","lwFSparkle", "lwSmack", "lwPhantom", 
-			"lwCane","lwRefBeam", "lwStomp","lwScript1", "lwScript2", "lwScript3", 
-			"lwScript4","lwScript5", "lwScript6", "lwScript7", "lwScript8","lwScript9", "lwScript10", "lwIce",
-			"-wFlame", "-wSound", "-wThrown", "-wPot", "-wLit", "-wBombos", "-wEther", "-wQuake",
-			"-wSword180", "-wSwordLA", "-wBugNet", "wRefArrow", "wRefFire", "wRefFire2"
-		};
-		static const char lweapon_default_names[wRefFire2+1][255]=
-		{
-			"(None)","Sword","Sword Beam","Boomerang","Bomb","Super Bomb","Lit Bomb",
-			"Lit Super Bomb","Arrow","Fire","Whistle","Bait","Wand","Magic","-Catching",
-			"Wind","Reflected Magic","Reflected Fireball","Reflected Rock", "Hammer","Hookshit", "-HSHandle", 
-			"-HSChain", "Sparkle","-FSparkle", "-Smack", "-Phantom", 
-			"Cane of Byrna","Reflected Sword Beam", "-Stomp","Script1", "Script2", "Script3", 
-			"Script4","Script5", "Script6", "Script7", "Script8","Script9", "Script10", "Ice",
-			"-wFlame", "-wSound", "-wThrown", "-wPot", "-wLit", "-wBombos", "-wEther", "-wQuake",
-			"-wSword180", "-wSwordLA", "-wBugNet", "Reflected Arrow", "Reflected Fire", "Reflected Fire 2"
-		};
-		for ( int32_t q = 0; q < wRefFire2+1; q++ )
-		{
-			if(lweapon_cats[q][0] != '-')
-				strcpy(moduledata.player_weapon_names[q],zc_get_config_basic("LWEAPONS",lweapon_cats[q],lweapon_default_names[q]));
-		}
+		}		
 		static const char counter_cats[33][255]=
 		{
 			"crNONE","crLIFE","crMONEY","crBOMBS","crARROWS","crMAGIC","crKEYS",

--- a/src/zc_list_data.cpp
+++ b/src/zc_list_data.cpp
@@ -547,52 +547,70 @@ GUI::ListData GUI::ZCListData::bottletype()
 	return ls;
 }
 
-GUI::ListData GUI::ZCListData::lweaptypes()
+GUI::ListData GUI::ZCListData::lweaptypes(bool numbered)
 {
 	std::map<std::string, int32_t> vals;
-	
-	std::string none(moduledata.player_weapon_names[0]);
-	if(skipchar(moduledata.player_weapon_names[0][0]))
-		none = "(None)";
-	
+
 	GUI::ListData ls;
-	ls.add(none, 0);
-	for(int32_t i=1; i<41; ++i)
+	ls.add("(None)", 0);
+	for (int32_t q = 1; q < lwMax; ++q)
 	{
-		if(skipchar(moduledata.player_weapon_names[i][0]))
-			continue;
-		
-		std::string sname(moduledata.player_weapon_names[i]);
-		ls.add(sname, i);
+		if (!ZI.isUsableWeap(q))
+			continue; //Hidden
+		char const* module_str = ZI.getWeapName(q);
+		if (numbered)
+			ls.add(fmt::format("{} ({:03})", module_str, q), q);
+		else ls.add(module_str, q);
 	}
-	
+	for (int32_t q = wIce; q < wEnemyWeapons; ++q)
+	{
+		if (!ZI.isUsableWeap(q))
+			continue; //Hidden
+		char const* module_str = ZI.getWeapName(q);
+		if (numbered)
+			ls.add(fmt::format("{} ({:03})", module_str, q), q);
+		else ls.add(module_str, q);
+	}
+	ls.alphabetize();
+	//should these always be at the end?
+	for (int32_t q = wScript1; q < wScript1+10; ++q)
+	{
+		if (!ZI.isUsableWeap(q))
+			continue; //Hidden
+		char const* module_str = ZI.getWeapName(q);
+		if (numbered)
+			ls.add(fmt::format("{} ({:03})", module_str, q), q);
+		else ls.add(module_str, q);
+	}
 	return ls;
 }
 
-GUI::ListData GUI::ZCListData::eweaptypes()
+GUI::ListData GUI::ZCListData::eweaptypes(bool numbered)
 {
 	std::map<std::string, int32_t> vals;
 
-	std::string none(moduledata.enemy_weapon_names[0]);
-	if (skipchar(moduledata.enemy_weapon_names[0][0]))
-		none = "(None)";
-
 	GUI::ListData ls;
-	ls.add(none, 0);
-	for (int32_t i = 1; i < wMax-wEnemyWeapons; ++i)
+	ls.add("(None)", 0);
+	for (int32_t q = wEnemyWeapons+1; q < wMax; ++q)
 	{
-		if (skipchar(moduledata.enemy_weapon_names[i][0]))
-			continue;
-
-		std::string sname(moduledata.enemy_weapon_names[i]);
-		ls.add(sname, wEnemyWeapons+i);
+		if (!ZI.isUsableWeap(q))
+			continue; //Hidden
+		char const* module_str = ZI.getWeapName(q);
+		if (numbered)
+			ls.add(fmt::format("{} ({:03})", module_str, q), q);
+		else ls.add(module_str, q);
 	}
-	for (int32_t i = 0; i < 10; ++i)
+	ls.alphabetize();
+	//should these always be at the end?
+	for (int32_t q = wScript1; q < wScript1 + 10; ++q)
 	{
-		std::string sname(moduledata.enemy_scriptweaponweapon_names[i]);
-		ls.add(sname, 30+i);
+		if (!ZI.isUsableWeap(q))
+			continue; //Hidden
+		char const* module_str = ZI.getWeapName(q);
+		if (numbered)
+			ls.add(fmt::format("{} ({:03})", module_str, q), q);
+		else ls.add(module_str, q);
 	}
-
 	return ls;
 }
 

--- a/src/zc_list_data.h
+++ b/src/zc_list_data.h
@@ -21,8 +21,8 @@ namespace GUI::ZCListData
 	GUI::ListData miscsprites(bool skipNone = true, bool inclNegSpecialVals = false, bool numbered = true);
 	GUI::ListData bottletype();
 	GUI::ListData dmaps(bool numbered = false);
-	GUI::ListData lweaptypes();
-	GUI::ListData eweaptypes();
+	GUI::ListData lweaptypes(bool numbered = false);
+	GUI::ListData eweaptypes(bool numbered = false);
 	GUI::ListData weaptypes(bool numbered = false);
 	GUI::ListData sfxnames(bool numbered = false);
 	GUI::ListData midinames(bool numbered = false, bool incl_engine = false);

--- a/src/zinfo.cpp
+++ b/src/zinfo.cpp
@@ -236,19 +236,19 @@ const char map_flag_default_string[mfMAX][255] =
 };
 const char weap_name_default_string[wMax][255] =
 {
-	"(None)","-Sword","Sword Beam","Boomerang","Bomb Blast",
+	"(None)","Sword","Sword Beam","Boomerang","Bomb Blast",
 	"Super Bomb Blast","Bomb","Super Bomb","Arrow","Fire",
 	//10
 	"Whistle","Bait","-Melee Handle","Magic","-Catching",
-	"Wind","Reflected Magic","Reflected Fireball","Reflected Rock","-Hammer",
+	"Wind","Reflected Magic","Reflected Fireball","Reflected Rock","Hammer",
 	//20
-	"-Hookshot","-Hookshot Handle","-Hookshot Chain","Sparkle","Fire Sparkle",
-	"-Smack","-Phantom","-Byrna","Reflected Beam","-Stomp",
+	"Hookshot","-Hookshot Handle","-Hookshot Chain","Sparkle","Fire Sparkle",
+	"-Smack","-Phantom","Byrna Beam","Reflected Beam","Stomp Boots",
 	//30
 	"-lwMax","Custom Weapon 1","Custom Weapon 2","Custom Weapon 3","Custom Weapon 4",
 	"Custom Weapon 5","Custom Weapon 6","Custom Weapon 7","Custom Weapon 8","Custom Weapon 9",
 	//40
-	"Custom Weapon 10","Ice","-Flame","-Sound","Thrown",
+	"Custom Weapon 10","-Ice","-Flame","-Sound","Thrown",
 	"-Pot","-Lit","-Med1","-Med2","-Med3",
 	//50
 	"-Sword180","-SwordLA","-Bug Net","Reflected Arrow","Reflected Fire",
@@ -267,13 +267,13 @@ const char weap_name_default_string[wMax][255] =
 	"","","","","","","","","","",
 	//120
 	"","","","","",
-	"","","","-wEnemyWeapons","E Fireball",
+	"","","","-wEnemyWeapons","Fireball",
 	//130
-	"E Arrow","E Boomerang","E Sword","E Rock","E Magic",
-	"E Bomb Blast","E Super Bomb Blast","E Bomb","E Super Bomb","E Fire Trail",
+	"Arrow","Boomerang","Sword","Rock","Magic",
+	"Bomb Blast","Super Bomb Blast","Bomb","Super Bomb","Fire Trail",
 	//140
-	"E Fire","E Wind","E Fire 2","-E Fire Trail 2","-E Ice",
-	"-E Fireball 2"
+	"Fire","Wind","Fire 2","-Fire Trail 2","-Ice",
+	"Fireball (Rising)"
 	//wMax
 };
 

--- a/src/zinfo.h
+++ b/src/zinfo.h
@@ -76,9 +76,6 @@ struct zcmodule
 	char walkmisc7_names[e7tEATHURT+1][255];
 	char walkmisc9_names[e9tARMOS+1][255];
 	char guy_type_names[gDUMMY1][255];
-	char enemy_weapon_names[wMax-wEnemyWeapons][255];
-	char enemy_scriptweaponweapon_names[10][255];
-	char player_weapon_names[wRefFire2+1][255];
 	
 	char base_NSF_file[1024];
 	char copyright_strings[3][2048];

--- a/src/zq/zq_custom.cpp
+++ b/src/zq/zq_custom.cpp
@@ -1669,77 +1669,6 @@ const char *itemsetlist(int32_t index, int32_t *list_size)
 list_data_struct biew[MAXWPNS];
 int32_t biew_cnt=-1;
 
-char temp_custom_ew_strings[10][40];
-
-static int32_t enemy_weapon_types[]=
-{
-	128, ewFireball,ewArrow,ewBrang,ewSword,
-	ewRock,ewMagic,ewBomb,ewSBomb,
-	//137
-	ewLitBomb,ewLitSBomb,ewFireTrail,ewFlame,
-	ewWind,ewFlame2,ewFlame2Trail,
-	//145
-	ewIce,ewFireball2
-	
-};
-
-static int32_t enemy_script_weapon_types[]=
-{
-	wScript1, wScript2, wScript3, wScript4,
-	//35
-	wScript5, wScript6, wScript7, wScript8,
-	//39
-	wScript9, wScript10
-	
-};
-
-void build_biew_list()
-{
-	biew_cnt=0;
-
-	memset(temp_custom_ew_strings, 0, sizeof(temp_custom_ew_strings));
-	
-	for(int32_t i=0; i<wMax-wEnemyWeapons; i++)
-	{
-		//if(eweapon_string[i][0]!='-')
-		if(moduledata.enemy_weapon_names[i][0]!='-')
-		{
-			//biew[biew_cnt].s = (char *)eweapon_string[i];
-			biew[biew_cnt].s = (char *)moduledata.enemy_weapon_names[i];
-			biew[biew_cnt].i = enemy_weapon_types[i];
-			++biew_cnt;
-		}
-	}
-	for(int32_t i = 0; i < 10; i++)
-	{
-		biew[biew_cnt].s = (char *)moduledata.enemy_scriptweaponweapon_names[i];
-	biew[biew_cnt].i = enemy_script_weapon_types[i];
-	++biew_cnt;
-	}
-	al_trace("biew_cnt is: %d\n", biew_cnt);
-	for ( int32_t i = 0; i < biew_cnt; i++ )
-	{
-	al_trace("biew[%d] id is (%d) and string is (%s)\n", i, biew[i].i, biew[i].s);
-		
-	}
-	
-}
-
-const char *eweaponlist(int32_t index, int32_t *list_size)
-{
-	if(biew_cnt==-1)
-		build_biew_list();
-		
-	if(index>=0)
-	{
-		bound(index,0,biew_cnt-1);
-		return biew[index].s;
-	}
-	
-	*list_size=biew_cnt;
-	return NULL;
-}
-
 const char *npcscriptdroplist(int32_t index, int32_t *list_size)
 {
 	if(index<0)
@@ -1755,24 +1684,6 @@ ListData npcscript_list(npcscriptdroplist, &font);
 static ListData itemset_list(itemsetlist, &font);
 static ListData eneanim_list(eneanimlist, &font);
 static ListData enetype_list(enetypelist, &font);
-static ListData eweapon_list(eweaponlist, &font);
-
-
-const char *eweaponscriptdroplist(int32_t index, int32_t *list_size)
-{
-	if(index<0)
-	{
-		*list_size = bieweapons_cnt;
-		return NULL;
-	}
-	
-	return bieweapons[index].first.c_str();
-}
-
-
-//droplist like the dialog proc, naming scheme for this stuff is awful...
-ListData eweaponscript_list(eweaponscriptdroplist, &a4fonts[font_pfont]);
-
 
 static ListData sfx__list(sfxlist, &font);
 

--- a/src/zq/zq_custom.h
+++ b/src/zq/zq_custom.h
@@ -9,7 +9,6 @@ int32_t d_cstile_proc(int32_t msg,DIALOG *d,int32_t c);
 int32_t jwin_as_droplist_proc(int32_t msg,DIALOG *d,int32_t c);
 void build_bief_list();
 void build_biea_list();
-void build_biew_list();
 
 struct list_data_struct
 {


### PR DESCRIPTION
zcgui listdata lweapons, eweapons, and weapons no longer use zcmodule. they have been removed from their as well.

![image](https://github.com/user-attachments/assets/8fd92a6e-dc1e-4e21-9730-c4b8e747f0d8)
![image](https://github.com/user-attachments/assets/11666492-fdc8-4480-ac61-fdf09872dc1a)
