### PR TITLE
refactor(zq): rename boomerang range attribute to duration

### DIFF
--- a/src/dialog/itemeditor.cpp
+++ b/src/dialog/itemeditor.cpp
@@ -811,7 +811,7 @@ void loadinfo(ItemNameInfo * inf, itemdata const& ref)
 		case itype_brang: //!TODO Help Text
 		{
 			inf->power = "Damage:";
-			inf->misc[0] = "Range (0 = Infinite):";
+			_SET(misc[0], "Duration:", "The amount of frames the boomerang flys before returning.\n0 = Infinite");
 			inf->misc[2] = "Block Flags:";
 			inf->misc[3] = "Reflect Flags:";
 			inf->flag[0] = "Corrected Animation";


### PR DESCRIPTION
also added tool tip
![Screenshot 2024-12-13 104429](https://github.com/user-attachments/assets/396d07fc-02e9-4f51-b182-499c5bbe25a3)
![Screenshot 2024-12-13 104416](https://github.com/user-attachments/assets/1b74937d-6849-454a-a173-47dd69809d86)
