### PR TITLE
fix(zc): Custom Bush/Slash combo sprites not spawning centered on the combo

### DIFF
--- a/src/zc/combos.cpp
+++ b/src/zc/combos.cpp
@@ -457,7 +457,7 @@ void trigger_cswitch_block_ffc(int32_t pos)
 
 
 
-void spawn_decoration_xy(newcombo const& cmb, zfix x, zfix y)
+void spawn_decoration_xy(newcombo const& cmb, zfix x, zfix y, zfix cx, zfix cy)
 {
 	int16_t decotype = (cmb.usrflags & cflag1) ? ((cmb.usrflags & cflag10) ? (cmb.attribytes[0]) : (-1)) : (0);
 	if(decotype > 3) decotype = 0;
@@ -469,7 +469,7 @@ void spawn_decoration_xy(newcombo const& cmb, zfix x, zfix y)
 	{
 		case -2: break; //nothing
 		case -1:
-			decorations.add(new comboSprite(x, y, dCOMBOSPRITE, 0, cmb.attribytes[0]));
+			decorations.add(new comboSprite(cx-8, cy-8, dCOMBOSPRITE, 0, cmb.attribytes[0]));
 			break;
 		case 1: decorations.add(new dBushLeaves(x, y, dBUSHLEAVES, 0, 0)); break;
 		case 2: decorations.add(new dFlowerClippings(x, y, dFLOWERCLIPPINGS, 0, 0)); break;
@@ -479,7 +479,7 @@ void spawn_decoration_xy(newcombo const& cmb, zfix x, zfix y)
 void spawn_decoration(newcombo const& cmb, int32_t pos)
 {
 	if(unsigned(pos) > 175) return;
-	spawn_decoration_xy(cmb, COMBOX(pos), COMBOY(pos));
+	spawn_decoration_xy(cmb, COMBOX(pos), COMBOY(pos), COMBOX(pos)+8, COMBOY(pos)+8);
 }
 
 void trigger_cuttable(int32_t lyr, int32_t pos)
@@ -703,7 +703,7 @@ void trigger_cuttable_ffc(int32_t pos)
 			sfx(QMisc.miscsfx[sfxBUSHGRASS],int32_t(x));
 		}
 	}
-	spawn_decoration_xy(cmb, x, y);
+	spawn_decoration_xy(cmb, x, y, ffc.x+(ffc.hit_width / 2), ffc.y+(ffc.hit_height / 2));
 }
 
 bool trigger_step(int32_t lyr, int32_t pos)

--- a/src/zc/combos.h
+++ b/src/zc/combos.h
@@ -31,7 +31,7 @@ void do_generic_combo2(int32_t bx, int32_t by, int32_t cid, int32_t flag, int32_
 void do_generic_combo_ffc2(int32_t pos, int32_t cid, int32_t ft);
 
 void spawn_decoration(newcombo const& cmb, int32_t pos);
-void spawn_decoration_xy(newcombo const& cmb, zfix x, zfix y);
+void spawn_decoration_xy(newcombo const& cmb, zfix x, zfix y, zfix cx, zfix cy);
 
 bool can_locked_combo(newcombo const& cmb);
 bool try_locked_combo(newcombo const& cmb);

--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -3980,7 +3980,7 @@ void HeroClass::check_slash_block_layer(int32_t bx, int32_t by, int32_t layer)
 		}
 	}
 	
-	spawn_decoration_xy(combobuf[cid], fx, fy);
+	spawn_decoration_xy(combobuf[cid], fx, fy, bx+8, by+8);
 }
 
 void HeroClass::check_slash_block(int32_t bx, int32_t by)
@@ -4221,7 +4221,7 @@ void HeroClass::check_slash_block(int32_t bx, int32_t by)
 			}
 		}
 		
-		spawn_decoration_xy(cmb, fx, fy);
+		spawn_decoration_xy(cmb, fx, fy, bx+8, by+8);
 	}
 	
 	if(!ignoreffc)
@@ -4286,8 +4286,8 @@ void HeroClass::check_slash_block(int32_t bx, int32_t by)
 				else sfx(QMisc.miscsfx[sfxBUSHGRASS],int32_t(bx));
 			}
 		}
-		
-		spawn_decoration_xy(cmb_ff, fx, fy);
+		ffcdata& ffc = s->getFFC(current_ffcombo);
+		spawn_decoration_xy(cmb_ff, fx, fy, ffc.x+(ffc.hit_width / 2), ffc.y+(ffc.hit_height / 2));
 	}
 }
 


### PR DESCRIPTION
Likely need to update some replays still; but only things using a custom `comboSprite` are expected to change, standard bush clippings and such should remain as usual.