### PR TITLE
fix(zc): 'slashable' combos (tall grass, etc) wrongly 'cutting' via triggers tab

### DIFF
--- a/src/core/qst_combos.cpp
+++ b/src/core/qst_combos.cpp
@@ -52,7 +52,7 @@ int32_t init_combo_classes()
     return 0;
 }
 
-int32_t readcombos_old(word section_version, PACKFILE *f, zquestheader *, word version, word build, word start_combo, word max_combos)
+int32_t readcombos_old(word section_version, PACKFILE *f, zquestheader *Header, word version, word build, word start_combo, word max_combos)
 {
 	bool should_skip = legacy_skip_flags && get_bit(legacy_skip_flags, skip_combos);
 	byte tempbyte;
@@ -474,6 +474,11 @@ int32_t readcombos_old(word section_version, PACKFILE *f, zquestheader *, word v
 			temp_combo.triggers.clear();
 		
 		update_combo(temp_combo, section_version);
+		if(section_version < 67 && !(Header && Header->version_major == 2 && Header->version_minor == 55 && Header->version_patch >= 14))
+		{
+			if(isCuttableType(temp_combo.type) && !temp_combo.triggers.empty())
+				temp_combo.triggers.front().trigger_flags.set(TRIGFLAG_CMBTYPEFX, true);
+		}
 		
 		if(i>=start_combo && !should_skip)
 		{
@@ -877,8 +882,37 @@ int32_t readcombo_triggers_loop(PACKFILE* f, word s_version, combo_trigger& temp
 
 } // end namespace
 
-int32_t readcombo_loop(PACKFILE* f, word s_version, newcombo& temp_combo)
+bool isCuttableType(int32_t type)
 {
+	switch(type)
+	{
+		case cSLASH:
+		case cSLASHITEM:
+		case cBUSH:
+		case cFLOWERS:
+		case cTALLGRASS:
+		case cTALLGRASSNEXT:
+		case cSLASHNEXT:
+		case cSLASHNEXTITEM:
+		case cBUSHNEXT:
+		
+		case cSLASHTOUCHY:
+		case cSLASHITEMTOUCHY:
+		case cBUSHTOUCHY:
+		case cFLOWERSTOUCHY:
+		case cTALLGRASSTOUCHY:
+		case cSLASHNEXTTOUCHY:
+		case cSLASHNEXTITEMTOUCHY:
+		case cBUSHNEXTTOUCHY:
+			return true;
+	}
+	
+	return false;
+}
+
+int32_t readcombo_loop(PACKFILE* f, word s_version, newcombo& temp_combo, zquestheader *Header)
+{
+	//WARNING: `Header` can be `nullptr` here from import/export code
 	byte tempbyte;
 	word tempword;
 	word combo_has_flags;
@@ -1286,6 +1320,11 @@ int32_t readcombo_loop(PACKFILE* f, word s_version, newcombo& temp_combo)
 		}
 	}
 	update_combo(temp_combo, s_version);
+	if(s_version < 67 && !(Header && Header->version_major == 2 && Header->version_minor == 55 && Header->version_patch >= 14))
+	{
+		if(isCuttableType(temp_combo.type) && !temp_combo.triggers.empty())
+			temp_combo.triggers.front().trigger_flags.set(TRIGFLAG_CMBTYPEFX, true);
+	}
 	return 0;
 }
 
@@ -1335,7 +1374,7 @@ int32_t readcombos(PACKFILE *f, zquestheader *Header, word version, word build, 
 		}
 		for(int32_t i=0; i<combos_used; i++)
 		{
-			auto ret = readcombo_loop(f,section_version,temp_combo);
+			auto ret = readcombo_loop(f,section_version,temp_combo,Header);
 			if(ret) return ret;
 			if(i>=start_combo)
 			{

--- a/src/core/zdefs.h
+++ b/src/core/zdefs.h
@@ -140,7 +140,7 @@ enum {ENC_METHOD_192B104=0, ENC_METHOD_192B105, ENC_METHOD_192B185, ENC_METHOD_2
 #define V_STRINGS         12
 #define V_MISC            21
 #define V_TILES            3 //2 is a int32_t, max 214500 tiles (ZScript upper limit)
-#define V_COMBOS          66
+#define V_COMBOS          67
 #define V_CSETS            6 //palette data
 #define V_MAPS            39
 #define V_DMAPS           26

--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -4736,7 +4736,7 @@ void HeroClass::check_slash_block2(int32_t bx, int32_t by, weapon *w)
 	    {
 		dontignore = 1;
 	    }
-	if(w->useweapon != wSword && !dontignore) return;
+	if(w->useweapon != wSword) return;
 
     auto rpos_handle = get_rpos_handle_for_world_xy(bx, by, 0);
     int32_t i = rpos_handle.pos;
@@ -4748,7 +4748,7 @@ void HeroClass::check_slash_block2(int32_t bx, int32_t by, weapon *w)
     
     if(get_bit(w->wscreengrid, i) != 0)
     {
-        ignorescreen = true; dontignore = 0;
+        ignorescreen = true;
     }
     
     auto current_ffc_handle = getFFCAt(fx,fy);
@@ -4783,7 +4783,7 @@ void HeroClass::check_slash_block2(int32_t bx, int32_t by, weapon *w)
 		}
 		else skipsecrets = 1; 
     }
-    if((!skipsecrets || !get_qr(qr_BUGGY_BUGGY_SLASH_TRIGGERS)) && (!ignorescreen || dontignore))
+    if((!skipsecrets || !get_qr(qr_BUGGY_BUGGY_SLASH_TRIGGERS)) && !ignorescreen)
     {
         if((flag >= 16)&&(flag <= 31)&&!skipsecrets)
         { 
@@ -4843,7 +4843,7 @@ void HeroClass::check_slash_block2(int32_t bx, int32_t by, weapon *w)
             }
         }
     }
-    else if(skipsecrets && (!ignorescreen || dontignore))
+    else if(skipsecrets && !ignorescreen)
     {
 	    if(isCuttableNextType(type))
 		{
@@ -4879,7 +4879,7 @@ void HeroClass::check_slash_block2(int32_t bx, int32_t by, weapon *w)
         }
     }
     
-    if(!ignorescreen || dontignore)
+    if(!ignorescreen)
     {
         if(!isTouchyType(type) && !get_qr(qr_CONT_SWORD_TRIGGERS)) set_bit(w->wscreengrid,i,1);
         

--- a/src/zc/maps.cpp
+++ b/src/zc/maps.cpp
@@ -8275,34 +8275,6 @@ bool isTouchyType(int32_t type)
     return false;
 }
 
-bool isCuttableType(int32_t type)
-{
-	switch(type)
-	{
-		case cSLASH:
-		case cSLASHITEM:
-		case cBUSH:
-		case cFLOWERS:
-		case cTALLGRASS:
-		case cTALLGRASSNEXT:
-		case cSLASHNEXT:
-		case cSLASHNEXTITEM:
-		case cBUSHNEXT:
-		
-		case cSLASHTOUCHY:
-		case cSLASHITEMTOUCHY:
-		case cBUSHTOUCHY:
-		case cFLOWERSTOUCHY:
-		case cTALLGRASSTOUCHY:
-		case cSLASHNEXTTOUCHY:
-		case cSLASHNEXTITEMTOUCHY:
-		case cBUSHNEXTTOUCHY:
-			return true;
-	}
-	
-	return false;
-}
-
 bool isCuttableItemType(int32_t type)
 {
     switch(type)

--- a/src/zq/zq_tiles.cpp
+++ b/src/zq/zq_tiles.cpp
@@ -12395,7 +12395,7 @@ void center_zq_tiles_dialogs()
 
 //.ZCOMBO
 
-int32_t readcombo_loop(PACKFILE* f, word section_version, newcombo& temp_combo);
+int32_t readcombo_loop(PACKFILE* f, word section_version, newcombo& temp_combo, zquestheader *Header);
 int32_t writecombo_loop(PACKFILE *f, newcombo const& tmp_cmb);
 
 int32_t readcombofile_old(PACKFILE *f, int32_t skip, byte nooverwrite, int32_t zversion,
@@ -12758,7 +12758,7 @@ int32_t readcombofile(PACKFILE *f, int32_t skip, byte nooverwrite, int32_t start
 	size_t end = index+count;
 	for ( size_t q = index; q < end; q++ )
 	{
-		auto ret = readcombo_loop(f,section_version,temp_combo);
+		auto ret = readcombo_loop(f,section_version,temp_combo,nullptr);
 		if(ret) return 0;
 		
 		if ( !(skip && q-1 < skip) )

--- a/tests/replays/ss_jenny/ss_jenny.zplay
+++ b/tests/replays/ss_jenny/ss_jenny.zplay
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d710dbe45f0b78b799dabb14d5bbef6ead643b9a4e7e74202284f2434a8ac9b6
-size 3131595
+oid sha256:377e020a84737c7083f5ff676fe08ccd6a89648bb506fa9f936b353e3038cbd0
+size 3131618


### PR DESCRIPTION
Due to some old half-finished code, slashables were responding to all weapons set in their combo triggers tab, even with `->ComboType Effects` not checked. This behavior has been fixed, now requiring `->ComboType Effects` to trigger.