### PR TITLE
fix(zscript): `lweapon->isValid()` now accurate for lifted weapons

### DIFF
--- a/src/zc/ffscript.cpp
+++ b/src/zc/ffscript.cpp
@@ -25363,7 +25363,11 @@ void do_isvalidlwpn()
 			set_register(sarg1, 10000);
 			return;
 		}
-		
+	if(Hero.lift_wpn && Hero.lift_wpn->getUID() == WID)
+	{
+		set_register(sarg1, 10000);
+		return;
+	}
 	set_register(sarg1, 0);
 }
 
@@ -25377,7 +25381,12 @@ void do_isvalidewpn()
 			set_register(sarg1, 10000);
 			return;
 		}
-		
+	// unsure how an ewpn would be lifted, but, checking just to be safe
+	if(Hero.lift_wpn && Hero.lift_wpn->getUID() == WID)
+	{
+		set_register(sarg1, 10000);
+		return;
+	}
 	set_register(sarg1, 0);
 }
 


### PR DESCRIPTION
Fixes [this report](https://discord.com/channels/876899628556091432/1340896636217331773)

Did not test the fix, but it seems exceedingly simple.