### PR TITLE
fix(zc): lifted weapon not disappearing on death

### DIFF
--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -9525,6 +9525,11 @@ heroanimate_skip_liftwpn:;
 					FFCore.deallocateAllScriptOwned(ScriptType::Global, GLOBAL_SCRIPT_GAME);
 					FFCore.deallocateAllScriptOwned(ScriptType::Hero, SCRIPT_HERO_ACTIVE);
 					ALLOFF(true,true);
+					if(lift_wpn)
+					{
+						delete lift_wpn;
+						lift_wpn = nullptr;
+					}
 					GameFlags |= GAMEFLAG_NO_F6;
 					if(!debug_enabled)
 					{


### PR DESCRIPTION
Should fix [this report](https://discord.com/channels/876899628556091432/1264018139570769970)

Didn't actually test, the fix seemed simple. Will possibly need replay updates.