### PR TITLE
feat: subscreen minimap compass can point to boss instead of McGuffin

### DIFF
--- a/resources/include/bindings/subscreendata.zh
+++ b/resources/include/bindings/subscreendata.zh
@@ -207,11 +207,12 @@ enum // Flags for SUBWIDG_MMAPTITLE
 	SUBW_MMAPTITLE_FLAG_ONELINE,
 	SUBW_MMAPTITLE_NUMFLAGS
 };
-enum // Flags for SUBWIDG_MMAP
+enum // Flags for [SUBWIDG_MMAP]
 {
-	SUBW_MMAP_FLAG_SHOWMAP,
-	SUBW_MMAP_FLAG_SHOWPLAYER,
-	SUBW_MMAP_FLAG_SHOWCOMPASS,
+	SUBW_MMAP_FLAG_SHOWMAP, // If the map itself is drawn
+	SUBW_MMAP_FLAG_SHOWPLAYER, // If the player marker is drawn
+	SUBW_MMAP_FLAG_SHOWCOMPASS, // If the compass marker is drawn
+	SUBW_MMAP_FLAG_COMPASSONBOSS, // If the compass marker blinks for the boss being alive, rather than the McGuffin being uncollected.
 	SUBW_MMAP_NUMFLAGS
 };
 enum // Flags for SUBWIDG_LMAP

--- a/src/dialog/subscr_props.cpp
+++ b/src/dialog/subscr_props.cpp
@@ -493,9 +493,9 @@ std::shared_ptr<GUI::Widget> SubscrPropDialog::view()
 			{
 				SW_MMap* w = dynamic_cast<SW_MMap*>(local_subref);
 				col_grid = Column(
-					MISC_COLOR_SEL(w->c_plr, "Hero Color", 1),
-					MISC_COLOR_SEL(w->c_cmp_blink, "Compass Blink Color", 2),
-					MISC_COLOR_SEL(w->c_cmp_off, "Compass Const Color", 3));
+					MISC_COLOR_SEL_EX(w->c_plr, "Hero Color", 1, info = "The color of the 'you are here' position"),
+					MISC_COLOR_SEL_EX(w->c_cmp_blink, "Compass Blink Color", 2, info = "The color the compass marker blinks to, when active"),
+					MISC_COLOR_SEL_EX(w->c_cmp_off, "Compass Const Color", 3, info = "The color the compass marker stays when inactive, and blinks from while active"));
 				break;
 			}
 			case widgMMAPTITLE:
@@ -1117,10 +1117,16 @@ std::shared_ptr<GUI::Widget> SubscrPropDialog::view()
 			{
 				SW_MMap* w = dynamic_cast<SW_MMap*>(local_subref);
 				mergetype = mtFORCE_TAB;
-				attrib_grid = Column(
+				attrib_grid = Rows<2>(
 					CBOX(w->flags, SUBSCR_MMAP_SHOWMAP, "Show Map", 1),
+					INFOBTN("Show the map itself. If unchecked, only the markers for 'Show Hero' and 'Show Compass' will be drawn."),
 					CBOX(w->flags, SUBSCR_MMAP_SHOWPLR, "Show Hero", 1),
-					CBOX(w->flags, SUBSCR_MMAP_SHOWCMP, "Show Compass", 1)
+					INFOBTN("Show the hero's current position on the map."),
+					CBOX(w->flags, SUBSCR_MMAP_SHOWCMP, "Show Compass", 1),
+					INFOBTN("Show the compass marker, which points to the player's destination. Will blink between two colors until"
+						" the McGuffin is collected, or until the boss is dead if 'Compass Points To Boss' is checked."),
+					CBOX(w->flags, SUBSCR_MMAP_CMPONBOSS, "Compass Points To Boss", 1),
+					INFOBTN("The compass stops blinking when the boss is dead, instead of when the McGuffin is collected.")
 				);
 				break;
 			}

--- a/src/new_subscr.cpp
+++ b/src/new_subscr.cpp
@@ -2825,6 +2825,7 @@ void SW_MMap::draw(BITMAP* dest, int32_t xofs, int32_t yofs, SubscrPage& page) c
 	auto const& thedmap = DMaps[get_sub_dmap()];
 	bool showplr = (flags&SUBSCR_MMAP_SHOWPLR) && !(TheMaps[(thedmap.map*MAPSCRS)+get_homescr()].flags7&fNOHEROMARK);
 	bool showcmp = (flags&SUBSCR_MMAP_SHOWCMP) && !(thedmap.flags&dmfNOCOMPASS);
+	bool cmp_on_boss = (flags&SUBSCR_MMAP_CMPONBOSS);
 	zcolors const& c = QMisc.colors;
 	int32_t type = (thedmap.type&dmfTYPE);
 	
@@ -2903,7 +2904,7 @@ void SW_MMap::draw(BITMAP* dest, int32_t xofs, int32_t yofs, SubscrPage& page) c
 			{
 				int32_t c2 = c_cmp_off.get_color();
 				
-				if(!has_item(itype_triforcepiece, -1) && (frame&16))
+				if(!(game->lvlitems[get_dlevel()]&(cmp_on_boss ? liBOSS : liTRIFORCE)) && (frame&16))
 					c2 = c_cmp_blink.get_color();
 					
 				int32_t cx = ((thedmap.compass&15)<<3)+tx+10;

--- a/src/new_subscr.h
+++ b/src/new_subscr.h
@@ -660,7 +660,8 @@ private:
 #define SUBSCR_MMAP_SHOWMAP           SUBSCRFLAG_SPEC_01
 #define SUBSCR_MMAP_SHOWPLR           SUBSCRFLAG_SPEC_02
 #define SUBSCR_MMAP_SHOWCMP           SUBSCRFLAG_SPEC_03
-#define SUBSCR_NUMFLAG_MMAP           3
+#define SUBSCR_MMAP_CMPONBOSS         SUBSCRFLAG_SPEC_04
+#define SUBSCR_NUMFLAG_MMAP           4
 struct SW_MMap : public SubscrWidget
 {
 	SubscrColorInfo c_plr, c_cmp_blink, c_cmp_off;


### PR DESCRIPTION
The compass marker will stop blinking when the boss is marked dead, rather than when the McGuffin is marked collected. This allows for dungeons without a McGuffin to appropriately stop the compass marker from blinking.