### PR TITLE
fix(zc): stop softlocking when using hookshot into slope

### DIFF
--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -10120,6 +10120,7 @@ heroanimate_skip_liftwpn:;
 			
 			if (dx || dy) 
 			{
+				reset_hookshot();
 				int32_t pushret = push_move(dx,dy);
 				onplatform = (on_sideview_solid_oldpos(this, false, 1) && !Up());
 				if (s.slope() != slopeid && slopeid) staircheck = true;


### PR DESCRIPTION
replay verison check / qr + backport? Or just backport?