### PR TITLE
chore!: add cstdint include in src/parser/CommentUtils.h

### DIFF
--- a/src/parser/CommentUtils.h
+++ b/src/parser/CommentUtils.h
@@ -1,6 +1,7 @@
 #ifndef COMMENT_UTILS_H_
 #define COMMENT_UTILS_H_
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <utility>


### PR DESCRIPTION
Fails to compile with GCC without the `<cstdint>` include.