### PR TITLE
build!: remove invalid escape sequence in generate_version_header.py

### DIFF
--- a/scripts/generate_version_header.py
+++ b/scripts/generate_version_header.py
@@ -15,7 +15,7 @@ args = parser.parse_args()
 if args.version:
     version = args.version
 else:
-    command = 'git describe --tags --abbrev=0 --match "*\.*\.*"'
+    command = 'git describe --tags --abbrev=0 --match "*.*.*"'
     try:
         version = subprocess.check_output(command, shell=True, encoding='utf-8').strip()
     except:


### PR DESCRIPTION
Avoids this output during build:
```
/path/to/ZQuestClassic/scripts/generate_version_header.py:18: SyntaxWarning: invalid escape sequence '\.'
  command = 'git describe --tags --abbrev=0 --match "*\.*\.*"'
```

With fix, no output.
In both case, the generated file is correct.