### PR TITLE
Enable building without GTK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,11 @@ if(NOT allegro5_POPULATED)
 	# We don't support FLAC.
 	option(WANT_FLAC "" OFF)
 	option(WANT_VIDEO "" OFF)
+
+	if(NOT USE_NFD)
+	  set(WANT_NATIVE_DIALOG OFF CACHE BOOL "" FORCE)
+	  set(ALLEGRO_SDL ON CACHE BOOL "" FORCE)
+	endif()
   add_subdirectory(${allegro5_SOURCE_DIR} ${allegro5_BINARY_DIR} EXCLUDE_FROM_ALL)
   # Allegro 5 CMakeLists sets CMAKE_CONFIGURATION_TYPES in a way that doesn't work for us,
   # so set it back to our value.
@@ -365,7 +370,7 @@ target_include_directories(allegro_with_legacy INTERFACE ${allegro5_SOURCE_DIR}/
 target_include_directories(allegro_with_legacy INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/third_party/allegro_legacy/include ${CMAKE_CURRENT_BINARY_DIR}/third_party/allegro_legacy/include)
 target_link_libraries(allegro_with_legacy INTERFACE allegro-legacy allegro_primitives allegro_font allegro_image allegro_audio allegro_acodec allegro_main)
 
-if (NOT EMSCRIPTEN)
+if (USE_NFD AND NOT EMSCRIPTEN)
 	target_link_libraries(allegro_with_legacy INTERFACE allegro_dialog)
 endif()
 
@@ -643,6 +648,9 @@ endif()
 if (USE_NFD)
 	target_link_libraries(zcbase PUBLIC nfd)
 	target_compile_definitions(zcbase PUBLIC HAS_NFD)
+else()
+	find_package(SDL2 REQUIRED)
+	target_link_libraries(zcbase PUBLIC SDL2::SDL2)
 endif()
 
 # std::execution supplementation.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,6 +751,10 @@ add_library(zconsolelogger STATIC src/zconsole/ConsoleLogger.cpp)
 target_link_libraries(zconsolelogger PUBLIC allegro_with_legacy zcbase)
 target_include_directories(zconsolelogger PUBLIC src)
 
+if(USE_NFD)
+	target_compile_definitions(zconsolelogger PUBLIC HAS_NFD)
+endif()
+
 target_link_libraries(zcbase PUBLIC zconsolelogger)
 
 #############################################################

--- a/src/base/zsys.cpp
+++ b/src/base/zsys.cpp
@@ -226,7 +226,7 @@ char datapwd[8]   = "longtan";
 #if defined(ALLEGRO_MAXOSX)
     printf("%s",buf);
 #endif
-#ifndef __EMSCRIPTEN__
+#ifdef HAS_NFD
     if (!zscript_coloured_console.valid() && !is_headless())
     {
         al_show_native_message_box(all_get_display(), "ZQuest Classic: I AM ERROR", "", buf, NULL, ALLEGRO_MESSAGEBOX_ERROR);

--- a/src/zconsole/ConsoleLogger.cpp
+++ b/src/zconsole/ConsoleLogger.cpp
@@ -526,7 +526,7 @@ int32_t CConsoleLogger::Create(const char	*lpszWindowTitle/*=NULL*/,
 							const char	*logger_name/*=NULL*/,
 							const char	*helper_executable/*=NULL*/)
 {
-#ifdef __EMSCRIPTEN__
+#ifndef HAS_NFD
 	return 0;
 #else
 	if (m_textlog) {
@@ -540,7 +540,7 @@ int32_t CConsoleLogger::Create(const char	*lpszWindowTitle/*=NULL*/,
 
 void CConsoleLogger::kill()
 {
-#ifndef __EMSCRIPTEN__
+#ifdef HAS_NFD
 	if (m_textlog) {
 		al_close_native_text_log(m_textlog);
 		m_textlog = NULL;
@@ -563,7 +563,7 @@ int32_t CConsoleLogger::Close(void)
 //////////////////////////////////////////////////////////////////////////
 inline int32_t CConsoleLogger::print(const char *lpszText,int32_t iSize/*=-1*/)
 {
-#ifdef __EMSCRIPTEN__
+#ifndef HAS_NFD
 	::printf("%s", lpszText);
 #else
 	al_append_native_text_log(m_textlog, "%s", lpszText);
@@ -573,7 +573,7 @@ inline int32_t CConsoleLogger::print(const char *lpszText,int32_t iSize/*=-1*/)
 
 bool CConsoleLogger::valid()
 {
-#ifdef __EMSCRIPTEN__
+#ifndef HAS_NFD
 	return 1;
 #else
 	return m_textlog != NULL;
@@ -595,7 +595,7 @@ int32_t CConsoleLogger::printf(const char *format,...)
 	
 	va_end(argList);
 	
-#ifdef __EMSCRIPTEN__
+#ifndef HAS_NFD
 	::printf("%s", tmp);
 #else
 	al_append_native_text_log(m_textlog, "%s", tmp);
@@ -702,7 +702,7 @@ int32_t CConsoleLoggerEx::cprintf(int32_t attributes,const char *format,...)
 	
 	va_end(argList);
 
-#ifdef __EMSCRIPTEN__
+#ifndef HAS_NFD
 	::printf("%s", tmp);
 #else
 	al_append_native_text_log(m_textlog, "%s", tmp);
@@ -713,7 +713,7 @@ int32_t CConsoleLoggerEx::safeprint(int32_t attributes,const char *str)
 {
 	int32_t sz = strlen(str);
 
-#ifdef __EMSCRIPTEN__
+#ifndef HAS_NFD
 	::printf("%s", str);
 #else
 	al_append_native_text_log(m_textlog, "%s", str);
@@ -736,7 +736,7 @@ int32_t CConsoleLoggerEx::cprintf(const char *format,...)
 	
 	va_end(argList);
 	
-#ifdef __EMSCRIPTEN__
+#ifndef HAS_NFD
 	::printf("%s", tmp);
 #else
 	al_append_native_text_log(m_textlog, "%s", tmp);
@@ -747,7 +747,7 @@ int32_t CConsoleLoggerEx::safeprint(const char *str)
 {
 	int32_t sz = strlen(str);
 
-#ifdef __EMSCRIPTEN__
+#ifndef HAS_NFD
 	::printf("%s", str);
 #else
 	al_append_native_text_log(m_textlog, "%s", str);


### PR DESCRIPTION
Hi,

I reached out earlier this week to see if it was possible to build the `zplayer` without GTK dependencies. I didn't give much context at the time, but my interest is in seeing if I can get the player to work on handheld Linux ARM devices and one of the runtimes supported by the [PortMaster](https://portmaster.games/) project. Coincidentally it looks like that community had [looked into the feasibility](https://suggestions.portmaster.games/suggestion-details?id=b06f2329b04040c995f24b06a01bf4f4) of porting ZQuest Classic before. I'm new to this, but it looks like the [Westonpack runtime](https://github.com/binarycounter/Westonpack/wiki) + Box64 is what I would use, and the PostMaster community generally describes GTK as incompatible. So my goal here was to see if I could build the project without GTK-dependent stuff like NFD, which seemed to be possible given the cool work done here in creating a browser runtime.

Massive thanks for disabling NFD inclusion in the `CMakeLists.txt `and `src/files.cpp`! This was tremendously helpful in showing me how I might do this for the rest of the project. I continued to make progress here by doing the same in `src/base/zsys.cpp` and the `zconsole`. I also built upon a previous issue that I saw referenced in the `CMakeLists.txt` (https://github.com/liballeg/allegro5/issues/1335) that would build Allegro without need of GTK3: Disabling NFD and (not sure if necessary but) enabling the SDL2 experimental backend.

Ultimately with a lot of troubleshooting I was able to produce something that builds and runs within an amd64 Docker container.
<details>

<summary>Dockerfile and run script</summary>

```dockerfile
FROM ubuntu:24.04

# Update package list and install dependencies
RUN apt update -y \
    && apt install -y \
        # Build tools
        build-essential \
        gcc-multilib \
        g++-multilib \
        cmake \
        clang \
        ninja-build \
        git \
        flex using\
        bison \
        pkg-config \
        zlib1g-dev \
        uuid-dev \
        elfutils \
        libcurl4-openssl-dev \
        # Graphical libraries
        libsdl2-dev \
        libsdl2-mixer-dev \
        libpng-dev \
        libjpeg-dev \
        libx11-dev \
        libglu1-mesa-dev \
        freeglut3-dev \
        mesa-common-dev \
        libopengl0 \
        libglu1 \
        libxcursor1 \
        # Audio libraries
        libasound2-dev \
        libdumb1-dev \
        libogg-dev \
        libvorbis-dev

# Copy project files into the container
COPY . /opt/zquestclassic

# Set working directory
WORKDIR /opt/zquestclassic

# Configure and build the project
RUN CC=clang-18 CXX=clang++-18 cmake \
    -G 'Ninja Multi-Config' \
    -B build \
    -DWANT_NFD=FALSE \
    -S .

RUN cmake --build build --config Debug -t zplayer -j 8

WORKDIR /opt/zquestclassic/build/Debug
CMD ["./zplayer"]
```
```sh
#!/bin/bash
# Run container on Fedora 42 KDE

set -e

docker run -it --rm \
  -e DISPLAY=$DISPLAY \
  -e PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native \
  -v /tmp/.X11-unix:/tmp/.X11-unix \
  -v ${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native \
  -v $HOME/.config/pulse/cookie:/root/.config/pulse/cookie \
  -v $PWD/quests:/opt/zquestclassic/build/Debug/quests \
  --device /dev/dri \
  --group-add video \
  zquestclassic
```
</details>

This is my first project working with graphics/audio dependencies, so I'm still working on my understanding of these things. Please let me know whether I'm going about this the wrong way!

I'll see if I can get the build outputs to work on my ARM handheld.

Thanks,
James