### PR TITLE
feat: combo flag "Step 'in front' in sideview"

### DIFF
--- a/src/dialog/comboeditor.cpp
+++ b/src/dialog/comboeditor.cpp
@@ -3146,7 +3146,9 @@ std::shared_ptr<GUI::Widget> ComboEditorDialog::view()
 									CMB_GEN_FLAG(2,"Allow walk-on-top","The Player can walk along the top of this combo's solid parts"
 										" if they are on it, or above the combo's 'Z Height'."),
 									CMB_GEN_FLAG(3,"Walk-on-top -8px DrawYOffset","While the Player is walking on top of this combo,"
-										" they will be visually offset up by 8 pixels.")
+										" they will be visually offset up by 8 pixels."),
+									CMB_GEN_FLAG(4,"Step 'in front' in sideview","The effects of 'landing'/'standing'/'walking' on this"
+										" combo will occur when landing 'in front' of the combo in sideview, rather than 'on top' of the combo.")
 								)
 							),
 							Frame(title = "Hero Speed Mod",

--- a/src/zc/hero.h
+++ b/src/zc/hero.h
@@ -426,6 +426,7 @@ public:
 	bool mirrorBonk();
 	void doMirror(int32_t mirrorid);
 	void handle_passive_buttons();
+	void for_each_rpos_stood_on(std::function<void(const rpos_handle_t&)> proc);
 	void land_on_ground();
 	bool do_jump(int32_t jumpid, bool passive);
 	void drop_liftwpn();


### PR DESCRIPTION
Allows 'walking'/'standing'/'landing on' effects to occur when *behind* the player instead of *under* the player in sideview. Useful for, ex., a stream of running water (as background combos behind you) having walking/landing sfx for splashes.