### PR TITLE
fix(zscript)!: @deprecated comment tag properly works on non-internal functions

### DIFF
--- a/resources/include/std_zh/std_functions.zh
+++ b/resources/include/std_zh/std_functions.zh
@@ -3386,7 +3386,7 @@ void ClearFFC(int ffc_id)
 }
 
 // Returns true if an npc's Misc. flag is set.
-// @deprecated
+// @deprecated Use [npc::Flags] instead
 bool GetNPCMiscFlag(npc e, int flag)
 {
 	#option WARN_DEPRECATED off

--- a/resources/include/std_zh/string/string_functions.zh
+++ b/resources/include/std_zh/string/string_functions.zh
@@ -1030,6 +1030,7 @@ namespace std
 		void printf(char32[] formatstr,int a0=0,int a1=0,int a2=0,int a3=0,int a4=0,int a5=0,int a6=0,int a7=0,
 								  int a8=0,int a9=0,int aa=0,int ab=0,int ac=0,int ad=0,int ae=0,int af=0)
 		{
+			#option WARN_DEPRECATED off
 			char32 buffer[0x200]; //Max Trace length is 512
 			sprintf(buffer,formatstr,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,aa,ab,ac,ad,ae,af);
 			TraceS(buffer);

--- a/src/parser/RegistrationVisitor.cpp
+++ b/src/parser/RegistrationVisitor.cpp
@@ -519,20 +519,21 @@ void RegistrationVisitor::caseClass(ASTClass& host, void* param)
 
 	for (auto fn_decl : host.functions)
 	{
+		scope->initFunctionBinding(fn_decl->func, this);
+		
 		if (!fn_decl->getFlag(FUNCFLAG_INTERNAL))
 			continue;
 
-		scope->initFunctionBinding(fn_decl->func, this);
 		if (user_class.internalRefVarString.empty())
 			fn_decl->func->setIntFlag(IFUNCFLAG_SKIPPOINTER);
 	}
 
 	for (auto fn_decl : host.constructors)
 	{
+		scope->initFunctionBinding(fn_decl->func, this);
+		
 		if (!fn_decl->getFlag(FUNCFLAG_INTERNAL))
 			continue;
-
-		scope->initFunctionBinding(fn_decl->func, this);
 
 		if (fn_decl->func->getFlag(FUNCFLAG_NIL))
 		{

--- a/src/parser/Scope.cpp
+++ b/src/parser/Scope.cpp
@@ -44,6 +44,15 @@ void Scope::invalidateStackSize()
 void Scope::initFunctionBinding(Function* fn, CompileErrorHandler* handler)
 {
 	auto parsed_comment = fn->getNode()->getParsedComment();
+	if (auto depr_message = parsed_comment.get_tag("deprecated"))
+	{
+		fn->setFlag(FUNCFLAG_DEPRECATED);
+		fn->setInfo(*depr_message);
+	}
+	
+	if (!fn->getFlag(FUNCFLAG_INTERNAL))
+		return;
+	
 	if (parsed_comment.contains_tag("delete"))
 	{
 		fn->setFlag(FUNCFLAG_NIL);
@@ -73,11 +82,7 @@ void Scope::initFunctionBinding(Function* fn, CompileErrorHandler* handler)
 
 	if (parsed_comment.contains_tag("exit"))
 		fn->setFlag(FUNCFLAG_EXITS|FUNCFLAG_NEVER_RETURN);
-	if (auto depr_message = parsed_comment.get_tag("deprecated"))
-	{
-		fn->setFlag(FUNCFLAG_DEPRECATED);
-		fn->setInfo(*depr_message);
-	}
+	
 	if (parsed_comment.contains_tag("reassign_ptr"))
 		fn->setIntFlag(IFUNCFLAG_REASSIGNPTR);
 
@@ -1652,8 +1657,7 @@ Function* BasicScope::addFunction(
 	{
 		fun->numOptionalParams = node->optparams.size();
 	}
-	if (flags&FUNCFLAG_INTERNAL)
-		initFunctionBinding(fun, handler);
+	initFunctionBinding(fun, handler);
 
 	functionsByName_[name].push_back(fun);
 	functionsBySignature_[signature] = fun;

--- a/tests/scripts/newbie_boss/_testing/NewbieBoss_expected.txt
+++ b/tests/scripts/newbie_boss/_testing/NewbieBoss_expected.txt
@@ -606,6 +606,24 @@ NewbieBoss.z Line 3237 @ Columns 3-18 - Warning S094: Function 'Game::PlaySound(
 
 
 INFO: Use [Audio->PlaySound] instead!
+NewbieBoss.z Line 3073 @ Columns 6-16 - Warning S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.
+
+3071    }
+3072    void EZB_DoLaser(int layer, int x, int y, int width, int angle, int damage, int laserColors, int forceColor, int state, int frame, int maxFrames){
+3073        if(ScreenFlag(1, 4)&&layer==2) //Layer -2
+               ^~~~~~~~~~
+
+
+INFO: Use [Screen->Flag] instead!
+NewbieBoss.z Line 3075 @ Columns 11-21 - Warning S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.
+
+3073    if(ScreenFlag(1, 4)&&layer==2) //Layer -2
+3074        layer = 1;
+3075    else if(ScreenFlag(1, 5)&&layer==3) //Layer -3
+                ^~~~~~~~~~
+
+
+INFO: Use [Screen->Flag] instead!
 NewbieBoss.z Line 3080 @ Columns 47-61 - Warning S108: Arrays should be explicitly typed - change `int` to `int[]`
 
 3078    if(state==0){
@@ -678,6 +696,24 @@ NewbieBoss.z Line 3116 @ Columns 50-64 - Warning S108: Arrays should be explicit
                                                          ^~~~~~~~~~~~~~
 
 
+NewbieBoss.z Line 3052 @ Columns 6-16 - Warning S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.
+
+3050    }
+3051    void EZB_DrawLaser(int layer, int x, int y, int width, int angle, int color){
+3052        if(ScreenFlag(1, 4)&&layer==2) //Layer -2
+               ^~~~~~~~~~
+
+
+INFO: Use [Screen->Flag] instead!
+NewbieBoss.z Line 3054 @ Columns 11-21 - Warning S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.
+
+3052    if(ScreenFlag(1, 4)&&layer==2) //Layer -2
+3053        layer = 1;
+3054    else if(ScreenFlag(1, 5)&&layer==3) //Layer -3
+                ^~~~~~~~~~
+
+
+INFO: Use [Screen->Flag] instead!
 NewbieBoss.z Line 2758 @ Columns 15-31 - Warning S108: Arrays should be explicitly typed - change `int` to `int[]`
 
 2756    int h = Ghost_TileHeight;
@@ -686,6 +722,15 @@ NewbieBoss.z Line 2758 @ Columns 15-31 - Warning S108: Arrays should be explicit
                     ^~~~~~~~~~~~~~~~
 
 
+NewbieBoss.z Line 2765 @ Columns 6-16 - Warning S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.
+
+2763    
+2764    int layer = 2;
+2765    if(ScreenFlag(1, 4)) //Layer -2
+           ^~~~~~~~~~
+
+
+INFO: Use [Screen->Flag] instead!
 NewbieBoss.z Line 2924 @ Columns 15-31 - Warning S108: Arrays should be explicitly typed - change `int` to `int[]`
 
 2922    }
@@ -1367,6 +1412,24 @@ NewbieBoss.z Line 3539 @ Columns 3-21 - Warning S108: Arrays should be explicitl
         ^~~~~~~~~~~~~~~~~~
 
 
+NewbieBoss.z Line 3176 @ Columns 6-16 - Warning S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.
+
+3174    }
+3175    void EZB_Shockwave(int layer, int x, int y, int rad1, int rad2, int rings, int damage, int color1, int color2, int color3){
+3176        if(ScreenFlag(1, 4)&&layer==2) //Layer -2
+               ^~~~~~~~~~
+
+
+INFO: Use [Screen->Flag] instead!
+NewbieBoss.z Line 3178 @ Columns 11-21 - Warning S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.
+
+3176    if(ScreenFlag(1, 4)&&layer==2) //Layer -2
+3177        layer = 1;
+3178    else if(ScreenFlag(1, 5)&&layer==3) //Layer -3
+                ^~~~~~~~~~
+
+
+INFO: Use [Screen->Flag] instead!
 NewbieBoss.z Line 2774 @ Columns 14-29 - Warning S108: Arrays should be explicitly typed - change `int` to `int[]`
 
 2772    }
@@ -3771,6 +3834,34 @@ stdout:
     {
       "range": {
         "start": {
+          "line": 3072,
+          "character": 5
+        },
+        "end": {
+          "line": 3072,
+          "character": 15
+        }
+      },
+      "severity": 2,
+      "message": "S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.\nUse [Screen->Flag] instead!"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 3074,
+          "character": 10
+        },
+        "end": {
+          "line": 3074,
+          "character": 20
+        }
+      },
+      "severity": 2,
+      "message": "S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.\nUse [Screen->Flag] instead!"
+    },
+    {
+      "range": {
+        "start": {
           "line": 3079,
           "character": 46
         },
@@ -3897,6 +3988,34 @@ stdout:
     {
       "range": {
         "start": {
+          "line": 3051,
+          "character": 5
+        },
+        "end": {
+          "line": 3051,
+          "character": 15
+        }
+      },
+      "severity": 2,
+      "message": "S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.\nUse [Screen->Flag] instead!"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 3053,
+          "character": 10
+        },
+        "end": {
+          "line": 3053,
+          "character": 20
+        }
+      },
+      "severity": 2,
+      "message": "S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.\nUse [Screen->Flag] instead!"
+    },
+    {
+      "range": {
+        "start": {
           "line": 2757,
           "character": 14
         },
@@ -3907,6 +4026,20 @@ stdout:
       },
       "severity": 2,
       "message": "S108: Arrays should be explicitly typed - change `int` to `int[]`"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 2764,
+          "character": 5
+        },
+        "end": {
+          "line": 2764,
+          "character": 15
+        }
+      },
+      "severity": 2,
+      "message": "S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.\nUse [Screen->Flag] instead!"
     },
     {
       "range": {
@@ -5097,6 +5230,34 @@ stdout:
       },
       "severity": 2,
       "message": "S108: Arrays should be explicitly typed - change `int` to `int[]`"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 3175,
+          "character": 5
+        },
+        "end": {
+          "line": 3175,
+          "character": 15
+        }
+      },
+      "severity": 2,
+      "message": "S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.\nUse [Screen->Flag] instead!"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 3177,
+          "character": 10
+        },
+        "end": {
+          "line": 3177,
+          "character": 20
+        }
+      },
+      "severity": 2,
+      "message": "S094: Function 'ScreenFlag(int, int)' is deprecated, and should not be used.\nUse [Screen->Flag] instead!"
     },
     {
       "range": {


### PR DESCRIPTION
Used to mark some old std_functions as deprecated