### PR TITLE
fix(zc): hookshot wedging the player into walls sometimes.

### DIFF
--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -8843,6 +8843,7 @@ heroanimate_skip_liftwpn:;
 	
 	if(hookshot_frozen || switch_hooked)
 	{
+		bool snap_player = hs_fix && replay_version_check(46);
 		if(hookshot_used || switch_hooked)
 		{
 			if (IsSideSwim()) {action=sideswimfreeze; FFCore.setHeroAction(sideswimfreeze);} 
@@ -9312,7 +9313,7 @@ heroanimate_skip_liftwpn:;
 			reset_hookshot();
 		}
 		
-		if(hs_fix)
+		if(snap_player)
 		{
 			if(dir==up || dir==down)
 			{

--- a/src/zc/replay.cpp
+++ b/src/zc/replay.cpp
@@ -34,7 +34,7 @@ struct ReplayStep;
 
 static const int ASSERT_SNAPSHOT_BUFFER = 10;
 static const int ASSERT_FAILED_EXIT_CODE = 120;
-static const int VERSION = 45;
+static const int VERSION = 46;
 
 static const std::string ANNOTATION_MARKER = "«";
 static const char TypeMeta = 'M';


### PR DESCRIPTION
This bug has apparently been present since 2.50.2, and already HAD a fix implemented, the fix was just very slightly broken.