### PR TITLE
sprite coordinate shortcut functions

### DIFF
--- a/resources/include/bindings/sprite.zh
+++ b/resources/include/bindings/sprite.zh
@@ -101,6 +101,21 @@ class sprite {
 	//
 	// @zasm_var SPRITE_Z_OFFSET
 	internal int DrawZOffset;
+	
+	// The current X position plus draw offset
+	//
+	// @zasm
+	//   POP REFSPRITE
+	//   SETR D2 SPRITE_X
+	//   ADDR D2 SPRITE_X_OFFSET
+	internal int DrawX();
+	
+	// The current Y position plus draw offset (including the draw offset caused by Z/DrawZOffset/FakeZ/etc)
+	//
+	// @zasm
+	//   POP REFSPRITE
+	//   SETR D2 SPRITE_DRAW_Y
+	internal int DrawY();
 
 	// Rotation of the sprite draw, in degrees.
 	//
@@ -277,6 +292,22 @@ class sprite {
 	//
 	// @zasm_var SPRITE_HIT_OFFSET_Y
 	internal int HitYOffset;
+	
+	// The current X position plus hit offset
+	//
+	// @zasm
+	//   POP REFSPRITE
+	//   SETR D2 SPRITE_X
+	//   ADDR D2 SPRITE_HIT_OFFSET_X
+	internal int HitX();
+	
+	// The current Y position plus hit offset
+	//
+	// @zasm
+	//   POP REFSPRITE
+	//   SETR D2 SPRITE_Y
+	//   ADDR D2 SPRITE_HIT_OFFSET_Y
+	internal int HitY();
 
 	// The timer indicating how many more frames the sprite will fall. If 0, the
 	// sprite is not falling. Max value of 70, which is the value at the start

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -356,6 +356,16 @@ zfix sprite::total_z() const
 	return z+fakez;
 }
 
+zfix sprite::draw_y() const
+{
+	zfix drawy = y + yofs - (z + zofs + fakez);
+#ifdef IS_PLAYER
+	if (switch_hooked && Hero.switchhookstyle == swRISE)
+		drawy -= (8-(abs(Hero.switchhookclk-32)/4));
+#endif
+	return drawy;
+}
+
 zfix sprite::center_y() const
 {
 	return y + yofs + (tysz * 8);

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -167,6 +167,7 @@ public:
     int32_t real_z(zfix fz);
     int32_t fake_z(zfix fz);
 	zfix total_z() const;
+	zfix draw_y() const;
 	zfix center_y() const;
     virtual bool hit();
     virtual bool hit(sprite *s);

--- a/src/zasm/defines.h
+++ b/src/zasm/defines.h
@@ -3293,7 +3293,8 @@ enum ASM_DEFINE
 #define COMBOD_DIVE_UNDER_LEVEL        0x166F
 #define GAMELAYERZTHRESHOLDS           0x1670
 #define NPCFLAGS                       0x1671
-#define MESSAGEDATASEGMENTS             0x1672
+#define MESSAGEDATASEGMENTS            0x1672
+#define SPRITE_DRAW_Y                  0x1673
 // unused block (we can fill this out)
 #define SPRITE_SHADOW_XOFS      0x16E7
 // Note: define new variables in above unused block

--- a/src/zasm/table.cpp
+++ b/src/zasm/table.cpp
@@ -2697,6 +2697,7 @@ static constexpr script_variable variable_list[]=
 	{ "GAMELAYERZTHRESHOLDS", GAMELAYERZTHRESHOLDS, 0 },
 	{ "NPCFLAGS", NPCFLAGS, 0 },
 	{ "MESSAGEDATASEGMENTS", MESSAGEDATASEGMENTS, 0 },
+	{ "SPRITE_DRAW_Y", SPRITE_DRAW_Y, 0 },
 	{"", -1},
 };
 
@@ -4519,6 +4520,7 @@ std::optional<int> get_register_ref_dependency(int reg)
 		case SPRITE_Y_OFFSET:
 		case SPRITE_Z:
 		case SPRITE_Z_OFFSET:
+		case SPRITE_DRAW_Y:
 			return REFSPRITE;
 
 		case SPRITEDATACSETS:

--- a/src/zc/scripting/context_strings.cpp
+++ b/src/zc/scripting/context_strings.cpp
@@ -1099,6 +1099,7 @@ const char* scripting_get_zasm_register_context_string(int reg)
 		case SPRITE_DIR: return "sprite::Dir";
 		case SPRITE_DRAW_STYLE: return "sprite::DrawStyle";
 		case SPRITE_X_OFFSET: return "sprite::DrawXOffset";
+		case SPRITE_DRAW_Y: return "sprite::DrawY()";
 		case SPRITE_Y_OFFSET: return "sprite::DrawYOffset";
 		case SPRITE_Z_OFFSET: return "sprite::DrawZOffset";
 		case SPRITE_DROWN_CMB: return "sprite::DrownCombo";
@@ -1995,6 +1996,7 @@ const char* scripting_get_zasm_command_context_string(ASM_DEFINE command)
 		case SAVEDPORTALREMOVE: return "savedportal::Remove()";
 		case SPRINTFVARG: return "sprintf()";
 		case SPRINTFA: return "sprintfa()";
+		case ADDR: return "sprite::DrawX()";
 		case OBJ_OWN_BITMAP: return "sprite::Own()";
 		case OBJ_OWN_PALDATA: return "sprite::Own()";
 		case OBJ_OWN_FILE: return "sprite::Own()";

--- a/src/zc/scripting/types/sprite.cpp
+++ b/src/zc/scripting/types/sprite.cpp
@@ -111,6 +111,12 @@ std::optional<int32_t> sprite_get_register(int32_t reg)
 				return s->zofs * 10000;
 			return 0;
 		}
+		case SPRITE_DRAW_Y:
+		{
+			if (auto s = get_sprite(GET_REF(spriteref)))
+				return (s->draw_y() - (get_qr(qr_OLD_DRAWOFFSET) ? playing_field_offset : original_playing_field_offset)).getZLong();
+			return 0;
+		}
 		case SPRITE_ROTATION:
 		{
 			if (get_qr(qr_OLDSPRITEDRAWS))


### PR DESCRIPTION
@connorjclark so, wanted to add some shortcuts here. Originally they were just gonna be std_zh and zscript functions, but I realized that internal would be more optimal, even without needing to create new registers for each of them (since a zasm function using existing commands could be very efficient, for most of these - except the DrawY because it has a lot more to account for). But, there's a couple issues-

1. I would've liked these to be `const int` vars, rather than getter functions- but as far as I can tell variables don't support `@zasm`, only `@zasm_var`. To be fair, a NON const variable, `@zasm` doesn't make sense- maybe something like an `@zasm_getter`/`@zasm_setter` that could be used for custom zasm on a variable would be worthwhile? EDIT: My string class branch has these tags.
2. I noticed that the `context_strings.cpp` had `case ADDR: return "sprite::DrawX()";` added... which, I feel like won't hurt anything but obviously doesn't actually make *sense*.

Any input would be much appreciated.