### PR TITLE
fix(zscript): printf/sprintf '%f' improperly ending in `.` instead of  `.0` for integers

### DIFF
--- a/src/zc/scripting/string_utils.cpp
+++ b/src/zc/scripting/string_utils.cpp
@@ -76,7 +76,7 @@ const char* zs_formatter(const char* format, int32_t arg, int32_t mindig, dword 
 					argbuf[ind++] = '.';
 					for(int div = 1000; div > 0; div /= 10)
 						argbuf[ind++] = '0' + (arg/div)%10;
-					for(--ind; argbuf[ind]=='0' && argbuf[ind-1]!='-'; --ind)
+					for(--ind; argbuf[ind]=='0' && argbuf[ind-1]!='.'; --ind)
 					{
 						argbuf[ind] = 0;
 					}


### PR DESCRIPTION
@connorjclark unsure what we want to do re: compat for this, this has been broken since < 2.55.0

[relevant discussion](https://discord.com/channels/129399825342005250/598566179862478868/1444452828545286346)