### PR TITLE
fix(zq)!: map viewer error popups being invisible

### DIFF
--- a/src/zq/render_map_view.cpp
+++ b/src/zq/render_map_view.cpp
@@ -142,7 +142,14 @@ void mapview_open(int flags, int sw, int sh, int bw, int bh)
 	rti_map_view->sh = sh;
 	rti_map_view->set_size(bw, bh);
 	rti_map_view->dirty = true;
-	get_root_rti()->add_child(rti_map_view);
+	
+	// Add to the back of the dialogs. This allows popups intended to show over the map to still be visible (such as the image failing to save)
+	// Adding directly to `rti_dialogs` causes `screen` to end up `nullptr` and crashes, so add to the last child of dialogs instead.
+	// Reload the tints first to ensure the last child is not `rti_tint`, otherwise the entire map vanishes on using the KEY_SPACE shortcut.
+	// `popup_zq_dialog_start()` should have been used before calling `mapview_open`, and `popup_zq_dialog_end()` should be called after `mapview_close()`.
+	reload_dialog_tint();
+	ASSERT(rti_dialogs.has_children());
+	rti_dialogs.get_children().back()->add_child(rti_map_view);
 	render_zq();
 }
 

--- a/src/zq/zquest.cpp
+++ b/src/zq/zquest.cpp
@@ -4452,8 +4452,10 @@ int32_t saveMapAsImage(ALLEGRO_BITMAP* bitmap)
     }
     while(num<99999 && exists(buf));
     
-	if (!al_save_bitmap(buf, bitmap))
-		InfoDialog("Error", "Failed to save map image").show();
+	if (num >= 99999)
+		InfoDialog("Error", "Failed to save map image! Max map images (99999) already exist!").show();
+	else if (!al_save_bitmap(buf, bitmap))
+		InfoDialog("Error", fmt::format("Failed to save map image\n'{}'.", buf)).show();
     
     return D_O_K;
 }
@@ -4475,8 +4477,8 @@ int32_t launchPicViewer(BITMAP **pictoview, PALETTE pal, int32_t& px2, int32_t& 
 	if((!*pictoview || isviewingmap) && (isviewingmap ? load_the_map(skipmenu) : load_the_pic(pictoview,pal)))
 	{
 		zc_set_palette(RAMpal);
-		popup_zqdialog_end();
 		mapview_close();
+		popup_zqdialog_end();
 		return D_O_K;
 	}
 
@@ -4498,8 +4500,8 @@ int32_t launchPicViewer(BITMAP **pictoview, PALETTE pal, int32_t& px2, int32_t& 
 	if(!buf)
 	{
 		jwin_alert("Error","Error creating temp bitmap",NULL,NULL,"OK",NULL,13,27,get_zc_font(font_lfont));
-		popup_zqdialog_end();
 		mapview_close();
+		popup_zqdialog_end();
 		return D_O_K;
 	}
 
@@ -4539,6 +4541,8 @@ int32_t launchPicViewer(BITMAP **pictoview, PALETTE pal, int32_t& px2, int32_t& 
 	
 	do
 	{
+		HANDLE_CLOSE_ZQDLG();
+		if(exiting_program) break;
 		int w, h;
 		if (isviewingmap)
 		{
@@ -4780,7 +4784,6 @@ int32_t launchPicViewer(BITMAP **pictoview, PALETTE pal, int32_t& px2, int32_t& 
 				
 			case KEY_SPACE:
 				mapview_close();
-				// TODO: why is `load_the_map` rendering a black dialog?
 				if(isviewingmap ? load_the_map(skipmenu) : load_the_pic(pictoview,pal)==2)
 				{
 					done = true;
@@ -4805,11 +4808,11 @@ int32_t launchPicViewer(BITMAP **pictoview, PALETTE pal, int32_t& px2, int32_t& 
 	gui_fg_color = oldfgcolor;
 	gui_bg_color = oldbgcolor;
 	
-	popup_zqdialog_end();
 	position_mouse_z(0);
 	viewer_overlay_rti.remove();
 	set_center_root_rti(true);
 	mapview_close();
+	popup_zqdialog_end();
 	return D_O_K;
 }
 
@@ -4860,7 +4863,7 @@ int32_t load_the_map(bool skipmenu)
 	{
 		large_dialog(loadmap_dlg);
 
-		if (do_zqdialog(loadmap_dlg, 11) != 11)
+		if (do_zqdialog(loadmap_dlg, 11, true) != 11)
 		{
 			return 1;
 		}


### PR DESCRIPTION
Also adds some more detail to the errors
Also allows closing the program while the map viewer is open