### PR TITLE
fix(zc)!: bombs falling into pits not near them when exploding

### DIFF
--- a/src/zc/guys.cpp
+++ b/src/zc/guys.cpp
@@ -8445,6 +8445,16 @@ eTektite::eTektite(zfix X,zfix Y,int32_t Id,int32_t Clk) : enemy(X,Y,Id,Clk)
 	if (SIZEflags != 0) init_size_flags();;
 }
 
+static bool tek_combo_check(zfix tx, zfix ty)
+{
+	// tektites treat the world edge as a no-go zone if the combo next to the edge is a no-go zone
+	// otherwise, they'll do a separate bounce from the edge, which leads to a slightly different trajectory.
+	tx = vbound(tx, 0, world_w-1);
+	ty = vbound(ty, 0, world_h-1);
+	return COMBOTYPE(tx, ty) == cNOJUMPZONE || COMBOTYPE(tx, ty) == cNOENEMY ||
+		ispitfall(tx, ty) || MAPFLAG(tx, ty) == mfNOENEMY ||
+		MAPCOMBOFLAG(tx, ty) == mfNOENEMY;
+}
 bool eTektite::animate(int32_t index)
 {
 	if(switch_hooked) return enemy::animate(index);
@@ -8496,99 +8506,11 @@ bool eTektite::animate(int32_t index)
 		case 2:                                                 // in flight
 			move(step);
 			
-			if(step>0)                                            //going down
-			{
-				if(COMBOTYPE(x+8,y+16)==cNOJUMPZONE)
-				{
-					step=0-step;
-				}
-				else if(COMBOTYPE(x+8,y+16)==cNOENEMY)
-				{
-					step=0-step;
-				}
-				else if(ispitfall(x+8,y+16))
-				{
-					step=0-step;
-				}
-				else if(MAPFLAG(x+8,y+16)==mfNOENEMY)
-				{
-					step=0-step;
-				}
-				else if(MAPCOMBOFLAG(x+8,y+16)==mfNOENEMY)
-				{
-					step=0-step;
-				}
-			}
-			else if(step<0)
-			{
-				if(COMBOTYPE(x+8,y)==cNOJUMPZONE)
-				{
-					step=0-step;
-				}
-				else if(COMBOTYPE(x+8,y)==cNOENEMY)
-				{
-					step=0-step;
-				}
-				else if(ispitfall(x+8,y))
-				{
-					step=0-step;
-				}
-				else if(MAPFLAG(x+8,y)==mfNOENEMY)
-				{
-					step=0-step;
-				}
-				else if(MAPCOMBOFLAG(x+8,y)==mfNOENEMY)
-				{
-					step=0-step;
-				}
-			}
+			if (tek_combo_check(x + 8, y + (step > 0 ? 16 : 0)))
+				step = 0 - step;
 			
-			if(clk3==left)
-			{
-				if(COMBOTYPE(x,y+8)==cNOJUMPZONE)
-				{
-					clk3^=1;
-				}
-				else if(COMBOTYPE(x,y+8)==cNOENEMY)
-				{
-					clk3^=1;
-				}
-				else if(ispitfall(x,y+8))
-				{
-					clk3^=1;
-				}
-				else if(MAPFLAG(x,y+8)==mfNOENEMY)
-				{
-					clk3^=1;
-				}
-				else if(MAPCOMBOFLAG(x,y+8)==mfNOENEMY)
-				{
-					clk3^=1;
-				}
-			}
-			else
-			{
-				if(COMBOTYPE(x+16,y+8)==cNOJUMPZONE)
-				{
-					clk3^=1;
-				}
-				else if(COMBOTYPE(x+16,y+8)==cNOENEMY)
-				{
-					clk3^=1;
-				}
-				else if(ispitfall(x+16,y+8))
-				{
-					clk3^=1;
-				}
-				else if(MAPFLAG(x+16,y+8)==mfNOENEMY)
-				{
-					clk3^=1;
-				}
-				else if(MAPCOMBOFLAG(x+16,y+8)==mfNOENEMY)
-				{
-					clk3^=1;
-				}
-			}
+			if (tek_combo_check(x + (clk3 == left ? 0 : 16), y + 8))
+				clk3 ^= 1;
 			
 			--c;
 			

--- a/src/zc/maps.cpp
+++ b/src/zc/maps.cpp
@@ -865,8 +865,8 @@ bool canPermSecret(int32_t dmap, int32_t screen)
 
 int32_t MAPCOMBO(int32_t x, int32_t y)
 {
-	x = vbound(x, 0, world_w-1);
-	y = vbound(y, 0, world_h-1);
+	if (!is_in_world_bounds(x, y))
+		return 0;
 	int pos = COMBOPOS(x%256, y%176);
 	mapscr* scr = get_scr_for_world_xy(x, y);
 	return scr->data[pos];


### PR DESCRIPTION
this was caused the the bomb having a large hit offset when exploding, and a check was bounding the coordinates back into the valid screen area, causing the bomb to fall into pits along the right edge of the screen.