### PR TITLE
fix(zq): some textfields being hard to type in due to default digit count

### DIFF
--- a/src/gui/text_field.cpp
+++ b/src/gui/text_field.cpp
@@ -496,7 +496,7 @@ void TextField::check_len(size_t min)
 	size_t s = std::max(min, maxLength);
 	if(ubound > lbound)
 	{
-		s = std::max(count_digits(lbound), count_digits(ubound));
+		s = std::max(count_digits(lbound), count_digits(ubound)) + 1;
 	}
 	_updateBuf(s);
 }


### PR DESCRIPTION
some textfields would limit the characters based on the max value; but these would require you to backspace out a "0" before allowing you to type the full value, which is clunky. Now these fields will have an additional character space to account for a leading 0.