### PR TITLE
fix(zc)!: triggers / shooters / etc not functioning on certain layers

### DIFF
--- a/src/zc/guys.cpp
+++ b/src/zc/guys.cpp
@@ -18564,7 +18564,11 @@ void screen_ffc_modify_preroutine(const ffc_handle_t& ffc_handle)
 // Everything that must be done after we change a screen's combo to another combo. -L
 void screen_combo_modify_postroutine(const rpos_handle_t& rpos_handle)
 {
-	rpos_handle.scr->valid |= mVALID;
+	if (!(rpos_handle.scr->valid & mVALID))
+	{
+		rpos_handle.scr->valid |= mVALID;
+		mark_current_region_handles_dirty(); // a new layer becoming valid needs to reload the region handles
+	}
 	activate_fireball_statue(rpos_handle);
 
 	if(rpos_handle.ctype()==cSPINTILE1)

--- a/src/zc/maps.cpp
+++ b/src/zc/maps.cpp
@@ -277,14 +277,16 @@ static void prepare_current_region_handles()
 
 std::tuple<const rpos_handle_t*, int> get_current_region_handles()
 {
-	DCHECK(!current_region_rpos_handles_dirty);
+	if (current_region_rpos_handles_dirty)
+		prepare_current_region_handles();
 	return {current_region_rpos_handles, current_region_screen_count};
 }
 
 std::tuple<const rpos_handle_t*, int> get_current_region_handles(mapscr* scr)
 {
-	DCHECK(!current_region_rpos_handles_dirty);
-	if (scr == special_warp_return_scr || current_region_rpos_handles_dirty)
+	if (current_region_rpos_handles_dirty)
+		prepare_current_region_handles();
+	if (scr == special_warp_return_scr)
 		return {nullptr, 0};
 
 	if (cur_screen >= 0x80)


### PR DESCRIPTION
layers that were not set up in zq, but interacted with via scripts, were being ignored when updating timers / shooters.