### PR TITLE
fix(zc)!: perm bunny status trigger not working

### DIFF
--- a/src/zc/combos.cpp
+++ b/src/zc/combos.cpp
@@ -2322,7 +2322,9 @@ void handle_trigger_results(const combined_handle_t& handle, combo_trigger const
 				Hero.setShieldClk(trig.trig_shieldjinxtime);
 			if (trig.trig_stuntime > -2)
 				Hero.setStunClock(trig.trig_stuntime);
-			if (trig.trig_bunnytime > -2)
+			if (trig.trig_bunnytime == -1)
+				Hero.setBunnyClock(-2); // '-1' is normally used for the dmap bunny effect
+			else if (trig.trig_bunnytime > -2)
 				Hero.setBunnyClock(trig.trig_bunnytime);
 		}
 		


### PR DESCRIPTION
'-1' bunny timer is the dmap bunny value, so the dmap was curing it.