### PR TITLE
feat: expand max Sprite Data (256 -> 8192)

### DIFF
--- a/modules/zelda/ZeldaSprite.txt
+++ b/modules/zelda/ZeldaSprite.txt
@@ -11,6 +11,7 @@ src/zc/combos.cpp
 src/zc/hero.cpp
 src/particles.cpp
 src/items.cpp
+src/sprite_data.cpp
 src/solidobject.cpp
 src/tiles.cpp
 src/zc/maps.cpp

--- a/modules/zquest/ZQuestMisc.txt
+++ b/modules/zquest/ZQuestMisc.txt
@@ -5,6 +5,7 @@ set(ZQUEST_MISC_SOURCES
 # Add or remove files here
 ################################
 src/items.cpp
+src/sprite_data.cpp
 src/zq/questReport.cpp
 src/zq/ffasm.cpp
 src/zq/zquest.cpp

--- a/src/base/general.h
+++ b/src/base/general.h
@@ -190,7 +190,7 @@ double wrap_float(double x,double low,double high);
 #define OLDMAXLEVELS               256
 #define OLDMAXDMAPS                256
 #define MAXITEMS                   1024
-#define MAXWPNS                    256
+#define MAXSPRITES                 8192
 #define OLDBETAMAXGUYS             256 //max 2.5 guys through beta 20
 #define MAXGUYS                    512
 #define MAXITEMDROPSETS            256

--- a/src/core/combo.h
+++ b/src/core/combo.h
@@ -153,7 +153,7 @@ struct newcombo
 	byte liftgfx;
 	word liftcmb, liftundercmb;
 	byte liftcs, liftundercs;
-	byte liftsprite;
+	word liftsprite;
 	byte liftdmg;
 	int16_t liftbreaksprite = -1;
 	byte liftbreaksfx;
@@ -173,7 +173,7 @@ struct newcombo
 	byte speed_div = 1;
 	zfix speed_add;
 	word sfx_appear, sfx_disappear, sfx_loop, sfx_walking, sfx_standing, sfx_tap, sfx_landing, sfx_falling, sfx_drowning, sfx_lava_drowning;
-	byte spr_appear, spr_disappear, spr_walking, spr_standing, spr_falling, spr_drowning, spr_lava_drowning;
+	word spr_appear, spr_disappear, spr_walking, spr_standing, spr_falling, spr_drowning, spr_lava_drowning;
 	
 	vector<combo_trigger> triggers;
 	byte only_gentrig;

--- a/src/core/cpos_info.cpp
+++ b/src/core/cpos_info.cpp
@@ -37,7 +37,7 @@ void cpos_info::updateData(int32_t newdata)
 {
 	if(data != newdata)
 	{
-		byte csfx = sfx_onchange, cspr = spr_onchange;
+		word csfx = sfx_onchange, cspr = spr_onchange;
 		if (appeared)
 		{
 			newcombo const& cmb = combobuf[data];

--- a/src/core/cpos_info.h
+++ b/src/core/cpos_info.h
@@ -25,7 +25,7 @@ struct cpos_info
 	byte pushes[4];
 	bool crumbling, appeared;
 	
-	byte sfx_onchange, spr_onchange;
+	word sfx_onchange, spr_onchange;
 	
 	bounded_vec<byte,cpos_trig_info> trig_data = {255};
 	

--- a/src/core/misctypes.h
+++ b/src/core/misctypes.h
@@ -192,7 +192,7 @@ struct miscQdata
 	// This has been deprecated, but kept around to keep a funny quest working (alarm clocks).
 	int32_t questmisc[32]; //Misc init values for the user. Used by scripts.
 	int32_t zscript_last_compiled_version;
-	byte sprites[sprMAX];
+	word sprites[sprMAX];
 	
 	bottletype bottle_types[NUM_BOTTLE_TYPES];
 	bottleshoptype bottle_shop_types[NUM_BOTTLE_SHOPS];

--- a/src/core/qst.cpp
+++ b/src/core/qst.cpp
@@ -82,7 +82,6 @@ extern int32_t                 hero_animation_speed; //lower is faster animation
 extern byte                *colordata;
 extern tiledata            *newtilebuf;
 extern byte                *trashbuf;
-extern wpndata             *wpnsbuf;
 extern comboclass          *combo_class_buf;
 extern guydata             *guysbuf;
 extern ZCHEATS             zcheats;
@@ -1028,9 +1027,6 @@ bool reset_wpns(bool validate, zquestheader *Header)
     if (get_app_id() == App::zquest)
         ret = init_section(Header, ID_WEAPONS, NULL, NULL, validate, "modules/classic/default.qst");
     
-    for(int32_t i=0; i<MAXWPNS; i++)
-        reset_weaponname(i);
-        
     return ret;
 }
 
@@ -1053,6 +1049,8 @@ bool reset_mapstyles(bool validate, miscQdata *Misc)
 
 int32_t read_weap_data(weapon_data& data, PACKFILE* f)
 {
+	byte tempbyte;
+	
 	word v_weapon_data;
 	if(!p_igetw(&v_weapon_data,f))
 		return qe_invalid;
@@ -1068,7 +1066,13 @@ int32_t read_weap_data(weapon_data& data, PACKFILE* f)
 	
 	for (int32_t q = 0; q < WPNSPR_MAX; ++q)
 	{
-		if (!p_getc(&(data.burnsprs[q]), f))
+		if (v_weapon_data < 1)
+		{
+			if (!p_getc(&tempbyte, f))
+				return qe_invalid;
+			data.burnsprs[q] = tempbyte;
+		}
+		else if (!p_igetw(&(data.burnsprs[q]), f))
 			return qe_invalid;
 		if (!p_getc(&(data.light_rads[q]), f))
 			return qe_invalid;
@@ -1188,11 +1192,7 @@ int32_t get_qst_buffers()
         return 0;
     
 	itemsbuf.clear();
-    
-    if((wpnsbuf=(wpndata*)malloc(sizeof(wpndata)*MAXWPNS))==NULL)
-        return 0;
-        
-    memset(wpnsbuf,0,sizeof(wpndata)*MAXWPNS);
+	sprite_data_buf.clear();
     
     if((guysbuf=(guydata*)malloc(sizeof(guydata)*MAXGUYS))==NULL)
         return 0;
@@ -1251,8 +1251,7 @@ void del_qst_buffers()
     if(trashbuf) free(trashbuf);
     
     itemsbuf.clear();
-    
-    if(wpnsbuf) free(wpnsbuf);
+	sprite_data_buf.clear();
     
     if(guysbuf) free(guysbuf);
     
@@ -5943,7 +5942,15 @@ int32_t readmisc(PACKFILE *f, zquestheader *Header, miscQdata *Misc)
 	
 	FFCore.quest_format[vLastCompile] = temp_misc.zscript_last_compiled_version;
 	
-	if(s_version >= 12)
+	if(s_version >= 21)
+	{
+		for(int32_t q = 0; q < sprMAX; ++q)
+		{
+			if(!p_igetw(&temp_misc.sprites[q],f))
+				return qe_invalid;
+		}
+	}
+	else if(s_version >= 12)
 	{
 		byte spr;
 		for(int32_t q = 0; q < sprMAX; ++q)
@@ -6187,7 +6194,6 @@ int32_t readmisc(PACKFILE *f, zquestheader *Header, miscQdata *Misc)
 }
 
 extern const char *old_item_string[iLast];
-extern char *weapon_string[MAXWPNS];
 extern const char *old_weapon_string[wLast];
 
 void update_old_item(word s_version, word index, word version)
@@ -6282,8 +6288,8 @@ void update_old_item(word s_version, word index, word version)
 				case iBombs:
 					tempitem.level=i_bomb;
 					tempitem.power=4;
-					tempitem.wpn=wBOMB;
-					tempitem.wpn2=wBOOM;
+					tempitem.wpn_sprites[0]=wBOMB;
+					tempitem.wpn_sprites[1]=wBOOM;
 					tempitem.misc1 = 50;
 					
 					if(get_bit(deprecated_rules,qr_SLOWBOMBFUSES_DEP)) tempitem.misc1 = 200;
@@ -6293,8 +6299,8 @@ void update_old_item(word s_version, word index, word version)
 				case iSBomb:
 					tempitem.level=i_sbomb;
 					tempitem.power=16;
-					tempitem.wpn=wSBOMB;
-					tempitem.wpn2=wSBOOM;
+					tempitem.wpn_sprites[0]=wSBOMB;
+					tempitem.wpn_sprites[1]=wSBOOM;
 					tempitem.misc1 = 50;
 					
 					if(get_bit(deprecated_rules,qr_SLOWBOMBFUSES_DEP)) tempitem.misc1 = 400;
@@ -6303,40 +6309,40 @@ void update_old_item(word s_version, word index, word version)
 					
 				case iBook:
 					if(get_bit(deprecated_rules, qr_FIREMAGICSPRITE_DEP))
-						tempitem.wpn = wFIREMAGIC;
+						tempitem.wpn_sprites[0] = wFIREMAGIC;
 						
 					break;
 					
 				case iSArrow:
-					tempitem.wpn2 = get_bit(deprecated_rules,27) ? wSSPARKLE : 0; //qr_SASPARKLES
+					tempitem.wpn_sprites[1] = get_bit(deprecated_rules,27) ? wSSPARKLE : 0; //qr_SASPARKLES
 					tempitem.power=4;
 					tempitem.flags|=item_gamedata;
-					tempitem.wpn=wSARROW;
+					tempitem.wpn_sprites[0]=wSARROW;
 					break;
 					
 				case iGArrow:
-					tempitem.wpn2 = get_bit(deprecated_rules,28) ? wGSPARKLE : 0; //qr_GASPARKLES
+					tempitem.wpn_sprites[1] = get_bit(deprecated_rules,28) ? wGSPARKLE : 0; //qr_GASPARKLES
 					tempitem.power=8;
 					tempitem.flags|=(item_gamedata|item_flag1);
-					tempitem.wpn=wGARROW;
+					tempitem.wpn_sprites[0]=wGARROW;
 					break;
 					
 				case iBrang:
 					tempitem.power=0;
-					tempitem.wpn=wBRANG;
+					tempitem.wpn_sprites[0]=wBRANG;
 					tempitem.misc1=36;
 					break;
 					
 				case iMBrang:
-					tempitem.wpn2 = get_bit(deprecated_rules,29) ? wMSPARKLE : 0; //qr_MBSPARKLES
+					tempitem.wpn_sprites[1] = get_bit(deprecated_rules,29) ? wMSPARKLE : 0; //qr_MBSPARKLES
 					tempitem.power=0;
-					tempitem.wpn=wMBRANG;
+					tempitem.wpn_sprites[0]=wMBRANG;
 					break;
 					
 				case iFBrang:
-					tempitem.wpn3 = get_bit(deprecated_rules,30) ? wFSPARKLE : 0; //qr_FBSPARKLES
+					tempitem.wpn_sprites[2] = get_bit(deprecated_rules,30) ? wFSPARKLE : 0; //qr_FBSPARKLES
 					tempitem.power=2;
-					tempitem.wpn=wFBRANG;
+					tempitem.wpn_sprites[0]=wFBRANG;
 					break;
 					
 				case iBoots:
@@ -6347,64 +6353,64 @@ void update_old_item(word s_version, word index, word version)
 				case iWand:
 					tempitem.cost_amount[0] = get_bit(deprecated_rules,qr_MAGICWAND_DEP) ? 8 : 0;
 					tempitem.power=2;
-					tempitem.wpn=wWAND;
-					tempitem.wpn3=wMAGIC;
+					tempitem.wpn_sprites[0]=wWAND;
+					tempitem.wpn_sprites[2]=wMAGIC;
 					break;
 					
 				case iBCandle:
 					tempitem.cost_amount[0] = get_bit(deprecated_rules,qr_MAGICCANDLE_DEP) ? 4 : 0;
 					tempitem.power=1;
 					tempitem.flags|=(item_gamedata|item_flag1);
-					tempitem.wpn3=wFIRE;
+					tempitem.wpn_sprites[2]=wFIRE;
 					break;
 					
 				case iRCandle:
 					tempitem.cost_amount[0] = get_bit(deprecated_rules,qr_MAGICCANDLE_DEP) ? 4 : 0;
 					tempitem.power=1;
-					tempitem.wpn3=wFIRE;
+					tempitem.wpn_sprites[2]=wFIRE;
 					break;
 					
 				case iSword:
 					tempitem.power=1;
 					tempitem.flags|= item_flag4 |item_flag2;
-					tempitem.wpn=tempitem.wpn3=wSWORD;
-					tempitem.wpn2=wSWORDSLASH;
+					tempitem.wpn_sprites[0]=tempitem.wpn_sprites[2]=wSWORD;
+					tempitem.wpn_sprites[1]=wSWORDSLASH;
 					break;
 					
 				case iWSword:
 					tempitem.power=2;
 					tempitem.flags|= item_flag4 |item_flag2;
-					tempitem.wpn=tempitem.wpn3=wWSWORD;
-					tempitem.wpn2=wWSWORDSLASH;
+					tempitem.wpn_sprites[0]=tempitem.wpn_sprites[2]=wWSWORD;
+					tempitem.wpn_sprites[1]=wWSWORDSLASH;
 					break;
 					
 				case iMSword:
 					tempitem.power=4;
 					tempitem.flags|= item_flag4 |item_flag2;
-					tempitem.wpn=tempitem.wpn3=wMSWORD;
-					tempitem.wpn2=wMSWORDSLASH;
+					tempitem.wpn_sprites[0]=tempitem.wpn_sprites[2]=wMSWORD;
+					tempitem.wpn_sprites[1]=wMSWORDSLASH;
 					break;
 					
 				case iXSword:
 					tempitem.power=8;
 					tempitem.flags|= item_flag4 |item_flag2;
-					tempitem.wpn=tempitem.wpn3=wXSWORD;
-					tempitem.wpn2=wXSWORDSLASH;
+					tempitem.wpn_sprites[0]=tempitem.wpn_sprites[2]=wXSWORD;
+					tempitem.wpn_sprites[1]=wXSWORDSLASH;
 					break;
 					
 				case iDivineProtection:
 					tempitem.flags |= get_bit(deprecated_rules,qr_FLICKERINGDIVINEPROTECTIONROCKET_DEP) ? item_flag1 : item_none;
 					tempitem.flags |= get_bit(deprecated_rules,qr_TRANSLUCENTDIVINEPROTECTIONROCKET_DEP) ? item_flag2 : item_none;
-					tempitem.wpn=wDIVINEPROTECTION1A;
-					tempitem.wpn2=wDIVINEPROTECTION1B;
-					tempitem.wpn3=wDIVINEPROTECTIONS1A;
-					tempitem.wpn4=wDIVINEPROTECTIONS1B;
-					tempitem.wpn6=wDIVINEPROTECTION2A;
-					tempitem.wpn7=wDIVINEPROTECTION2B;
-					tempitem.wpn8=wDIVINEPROTECTIONS2A;
-					tempitem.wpn9=wDIVINEPROTECTIONS2B;
-					tempitem.wpn5 = iwDivineProtectionShieldFront;
-					tempitem.wpn10 = iwDivineProtectionShieldBack;
+					tempitem.wpn_sprites[0]=wDIVINEPROTECTION1A;
+					tempitem.wpn_sprites[1]=wDIVINEPROTECTION1B;
+					tempitem.wpn_sprites[2]=wDIVINEPROTECTIONS1A;
+					tempitem.wpn_sprites[3]=wDIVINEPROTECTIONS1B;
+					tempitem.wpn_sprites[5]=wDIVINEPROTECTION2A;
+					tempitem.wpn_sprites[6]=wDIVINEPROTECTION2B;
+					tempitem.wpn_sprites[7]=wDIVINEPROTECTIONS2A;
+					tempitem.wpn_sprites[8]=wDIVINEPROTECTIONS2B;
+					tempitem.wpn_sprites[4] = iwDivineProtectionShieldFront;
+					tempitem.wpn_sprites[9] = iwDivineProtectionShieldBack;
 					tempitem.misc1=512;
 					tempitem.cost_amount[0]=64;
 					break;
@@ -6417,20 +6423,20 @@ void update_old_item(word s_version, word index, word version)
 					
 				case iArrow:
 					tempitem.power=2;
-					tempitem.wpn=wARROW;
+					tempitem.wpn_sprites[0]=wARROW;
 					break;
 					
 				case iHoverBoots:
 					tempitem.misc1=45;
-					tempitem.wpn=iwHover;
+					tempitem.wpn_sprites[0]=iwHover;
 					break;
 					
 				case iDivineFire:
 					tempitem.power=8;
-					tempitem.wpn=wDIVINEFIRE1A;
-					tempitem.wpn2=wDIVINEFIRE1B;
-					tempitem.wpn3=wDIVINEFIRES1A;
-					tempitem.wpn4=wDIVINEFIRES1B;
+					tempitem.wpn_sprites[0]=wDIVINEFIRE1A;
+					tempitem.wpn_sprites[1]=wDIVINEFIRE1B;
+					tempitem.wpn_sprites[2]=wDIVINEFIRES1A;
+					tempitem.wpn_sprites[3]=wDIVINEFIRES1B;
 					tempitem.misc1 = 32;
 					tempitem.misc2 = 200;
 					tempitem.cost_amount[0]=32;
@@ -6443,10 +6449,10 @@ void update_old_item(word s_version, word index, word version)
 				case iHookshot:
 					tempitem.power=0;
 					tempitem.flags&=~item_flag1;
-					tempitem.wpn=wHSHEAD;
-					tempitem.wpn2=wHSCHAIN_H;
-					tempitem.wpn4=wHSHANDLE;
-					tempitem.wpn3=wHSCHAIN_V;
+					tempitem.wpn_sprites[0]=wHSHEAD;
+					tempitem.wpn_sprites[1]=wHSCHAIN_H;
+					tempitem.wpn_sprites[3]=wHSHANDLE;
+					tempitem.wpn_sprites[2]=wHSCHAIN_V;
 					tempitem.misc1=50;
 					tempitem.misc2=100;
 					break;
@@ -6454,25 +6460,25 @@ void update_old_item(word s_version, word index, word version)
 				case iLongshot:
 					tempitem.power=0;
 					tempitem.flags&=~item_flag1;
-					tempitem.wpn=wLSHEAD;
-					tempitem.wpn2=wLSCHAIN_H;
-					tempitem.wpn4=wLSHANDLE;
-					tempitem.wpn3=wLSCHAIN_V;
+					tempitem.wpn_sprites[0]=wLSHEAD;
+					tempitem.wpn_sprites[1]=wLSCHAIN_H;
+					tempitem.wpn_sprites[3]=wLSHANDLE;
+					tempitem.wpn_sprites[2]=wLSCHAIN_V;
 					tempitem.misc1=99;
 					tempitem.misc2=100;
 					break;
 					
 				case iHammer:
 					tempitem.power=4;
-					tempitem.wpn=wHAMMER;
-					tempitem.wpn2=iwHammerSmack;
+					tempitem.wpn_sprites[0]=wHAMMER;
+					tempitem.wpn_sprites[1]=iwHammerSmack;
 					break;
 					
 				case iCByrna:
 					tempitem.power=1;
-					tempitem.wpn=wCBYRNA;
-					tempitem.wpn2=wCBYRNASLASH;
-					tempitem.wpn3=wCBYRNAORB;
+					tempitem.wpn_sprites[0]=wCBYRNA;
+					tempitem.wpn_sprites[1]=wCBYRNASLASH;
+					tempitem.wpn_sprites[2]=wCBYRNAORB;
 					tempitem.misc1=4;
 					tempitem.misc2=16;
 					tempitem.misc3=1;
@@ -6480,7 +6486,7 @@ void update_old_item(word s_version, word index, word version)
 					break;
 					
 				case iWhistle:
-					tempitem.wpn=wWIND;
+					tempitem.wpn_sprites[0]=wWIND;
 					tempitem.misc1=3;
 					tempitem.flags|=item_flag1;
 					break;
@@ -6764,9 +6770,9 @@ void update_old_item(word s_version, word index, word version)
 		
 		if(s_version < 17) // November 2007
 		{
-			if(tempitem.type == itype_candle && !tempitem.wpn3)
+			if(tempitem.type == itype_candle && !tempitem.wpn_sprites[2])
 			{
-				tempitem.wpn3 = wFIRE;
+				tempitem.wpn_sprites[2] = wFIRE;
 			}
 			else if(tempitem.type == itype_arrow && tempitem.power>4)
 			{
@@ -6803,12 +6809,12 @@ void update_old_item(word s_version, word index, word version)
 		{
 			if(tempitem.type == itype_divineprotection)
 			{
-				tempitem.wpn6=wDIVINEPROTECTION2A;
-				tempitem.wpn7=wDIVINEPROTECTION2B;
-				tempitem.wpn8=wDIVINEPROTECTIONS2A;
-				tempitem.wpn9=wDIVINEPROTECTIONS2B;
-				tempitem.wpn5 = iwDivineProtectionShieldFront;
-				tempitem.wpn10 = iwDivineProtectionShieldBack;
+				tempitem.wpn_sprites[5]=wDIVINEPROTECTION2A;
+				tempitem.wpn_sprites[6]=wDIVINEPROTECTION2B;
+				tempitem.wpn_sprites[7]=wDIVINEPROTECTIONS2A;
+				tempitem.wpn_sprites[8]=wDIVINEPROTECTIONS2B;
+				tempitem.wpn_sprites[4] = iwDivineProtectionShieldFront;
+				tempitem.wpn_sprites[9] = iwDivineProtectionShieldBack;
 			}
 		}
 		
@@ -6839,9 +6845,9 @@ void update_old_item(word s_version, word index, word version)
 		if(s_version < 23)    // March 2011
 		{
 			if(tempitem.type == itype_divinefire)
-				tempitem.wpn5 = wFIRE;
+				tempitem.wpn_sprites[4] = wFIRE;
 			else if(tempitem.type == itype_book)
-				tempitem.wpn2 = wFIRE;
+				tempitem.wpn_sprites[1] = wFIRE;
 		}
 		
 		// Version 25: Bomb bags were acting as though "super bombs also" was checked
@@ -6871,13 +6877,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 3; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_brang:
@@ -6890,13 +6891,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 3; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_arrow:
@@ -6911,13 +6907,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 3; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_candle:
@@ -6933,13 +6924,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 3; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_whistle:
@@ -6953,15 +6939,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 1; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_bait:
@@ -6976,15 +6955,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 1; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_letter:
@@ -7000,16 +6972,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_potion:
@@ -7023,16 +6987,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_wand:
@@ -7048,13 +7004,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 3; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_ring:
@@ -7069,16 +7020,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_wallet:
@@ -7092,16 +7035,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_amulet:
@@ -7117,16 +7052,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_shield:
@@ -7140,16 +7067,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_bow:
@@ -7165,16 +7084,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_raft:
@@ -7190,16 +7101,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_ladder:
@@ -7215,16 +7118,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_book:
@@ -7240,14 +7135,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 2; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_magickey:
@@ -7263,16 +7152,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_bracelet:
@@ -7288,16 +7169,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_flippers:
@@ -7313,16 +7186,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_boots:
@@ -7338,16 +7203,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_hookshot:
@@ -7359,12 +7216,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 4; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_lens:
@@ -7379,16 +7232,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_hammer:
@@ -7404,14 +7249,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 2; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_divinefire:
@@ -7425,11 +7264,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 5; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_divineescape:
@@ -7444,16 +7280,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_divineprotection:
@@ -7480,14 +7308,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 2; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_sbomb:
@@ -7500,14 +7322,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 2; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_clock:
@@ -7522,16 +7338,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_key:
@@ -7547,16 +7355,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_magiccontainer:
@@ -7572,16 +7372,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_triforcepiece:
@@ -7595,16 +7387,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_map:	case itype_compass:	case itype_bosskey:
@@ -7620,16 +7404,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_quiver:
@@ -7643,16 +7419,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_lkey:
@@ -7668,16 +7436,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_cbyrna:
@@ -7690,11 +7450,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 5; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_rupee: case itype_arrowammo:
@@ -7710,16 +7467,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_fairy:
@@ -7732,16 +7481,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_magic: case itype_heart: case itype_heartcontainer: case itype_heartpiece: case itype_killem: case itype_bombammo:
@@ -7757,16 +7498,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_bombbag:
@@ -7780,16 +7513,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_rocs:
@@ -7805,16 +7530,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_hoverboots:
@@ -7829,15 +7546,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 1; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_spinscroll:
@@ -7852,16 +7562,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_crossscroll:
@@ -7877,16 +7579,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_quakescroll:
@@ -7900,16 +7594,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_whispring:
@@ -7924,16 +7610,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_chargering:
@@ -7947,16 +7625,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_perilscroll:
@@ -7971,16 +7641,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_wealthmedal:
@@ -7995,16 +7657,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_heartring:
@@ -8018,16 +7672,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_magicring:
@@ -8041,16 +7687,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_spinscroll2:
@@ -8065,16 +7703,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_quakescroll2:
@@ -8088,16 +7718,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_agony:
@@ -8112,16 +7734,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_stompboots:
@@ -8137,16 +7751,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_whimsicalring:
@@ -8161,16 +7767,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_perilring:
@@ -8185,16 +7783,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 				case itype_custom1: case itype_custom2: case itype_custom3: case itype_custom4: case itype_custom5:
@@ -8214,16 +7804,8 @@ void update_old_item(word s_version, word index, word version)
 					tempitem.misc8 = 0;
 					tempitem.misc9 = 0;
 					tempitem.misc10 = 0;
-					tempitem.wpn = 0;
-					tempitem.wpn2 = 0;
-					tempitem.wpn3 = 0;
-					tempitem.wpn4 = 0;
-					tempitem.wpn5 = 0;
-					tempitem.wpn6 = 0;
-					tempitem.wpn7 = 0;
-					tempitem.wpn8 = 0;
-					tempitem.wpn9 = 0;
-					tempitem.wpn10 = 0;
+					for(int q = 0; q < 10; ++q)
+						tempitem.wpn_sprites[q] = 0;
 					break;
 				}
 			}
@@ -8642,7 +8224,7 @@ int32_t read_single_item_old(PACKFILE *f, word s_version, word index, word versi
 			
 			tempitem.count=-1;
 			tempitem.flags=item_none;
-			tempitem.wpn=tempitem.wpn2=tempitem.wpn3=tempitem.wpn3=tempitem.pickup_hearts=
+			tempitem.wpn_sprites[0]=tempitem.wpn_sprites[1]=tempitem.wpn_sprites[2]=tempitem.wpn_sprites[2]=tempitem.pickup_hearts=
 											tempitem.misc1=tempitem.misc2=tempitem.usesound=0;
 			tempitem.type=0xFF;
 			tempitem.playsound=WAV_SCALE;
@@ -8820,57 +8402,12 @@ int32_t read_single_item_old(PACKFILE *f, word s_version, word index, word versi
 		{
 			if(s_version>5)
 			{
-				if(!p_getc(&tempitem.wpn,f))
+				int count = s_version >= 15 ? 10 : 4;
+				for (int q = 0; q < count; ++q)
 				{
-					return qe_invalid;
-				}
-				
-				if(!p_getc(&tempitem.wpn2,f))
-				{
-					return qe_invalid;
-				}
-				
-				if(!p_getc(&tempitem.wpn3,f))
-				{
-					return qe_invalid;
-				}
-				
-				if(!p_getc(&tempitem.wpn4,f))
-				{
-					return qe_invalid;
-				}
-				
-				if(s_version>=15)
-				{
-					if(!p_getc(&tempitem.wpn5,f))
-					{
+					if(!p_getc(&tempbyte,f))
 						return qe_invalid;
-					}
-					
-					if(!p_getc(&tempitem.wpn6,f))
-					{
-						return qe_invalid;
-					}
-					
-					if(!p_getc(&tempitem.wpn7,f))
-					{
-						return qe_invalid;
-					}
-					
-					if(!p_getc(&tempitem.wpn8,f))
-					{
-						return qe_invalid;
-					}
-					
-					if(!p_getc(&tempitem.wpn9,f))
-					{
-						return qe_invalid;
-					}
-					
-					if(!p_getc(&tempitem.wpn10,f))
-					{
-						return qe_invalid;
-					}
+					tempitem.wpn_sprites[q] = tempbyte;
 				}
 				
 				if(!p_getc(&tempitem.pickup_hearts,f))
@@ -9287,7 +8824,7 @@ int32_t read_single_item_old(PACKFILE *f, word s_version, word index, word versi
 		tempitem.count=-1;
 		tempitem.type=itype_misc;
 		tempitem.flags=item_none;
-		tempitem.wpn=tempitem.wpn2=tempitem.wpn3=tempitem.wpn3=tempitem.pickup_hearts=tempitem.misc1=tempitem.misc2=tempitem.usesound=0;
+		tempitem.wpn_sprites[0]=tempitem.wpn_sprites[1]=tempitem.wpn_sprites[2]=tempitem.pickup_hearts=tempitem.misc1=tempitem.misc2=tempitem.usesound=0;
 		tempitem.playsound=WAV_SCALE;
 		reset_itembuf(&tempitem,index);
 	}
@@ -9296,8 +8833,9 @@ int32_t read_single_item_old(PACKFILE *f, word s_version, word index, word versi
 	{
 		for(int q = 0; q < WPNSPR_MAX; ++q)
 		{
-			if(!p_getc(&tempitem.weap_data.burnsprs[q],f))
+			if(!p_getc(&tempbyte,f))
 				return qe_invalid;
+			tempitem.weap_data.burnsprs[q] = tempbyte;
 			if(s_version >= 59)
 				if(!p_getc(&tempitem.weap_data.light_rads[q],f))
 					return qe_invalid;
@@ -9410,6 +8948,7 @@ int32_t read_single_item(PACKFILE *f, word s_version, word index, word version, 
 		return read_single_item_old(f, s_version, index, version, build);
 	static itemdata _nil_item;
 	
+	byte tempbyte;
 	bool should_skip = legacy_skip_flags && get_bit(legacy_skip_flags, skip_items);
 	itemdata& item_ref = should_skip ? _nil_item : itemsbuf[index];
 	item_ref = itemdata();
@@ -9476,35 +9015,21 @@ int32_t read_single_item(PACKFILE *f, word s_version, word index, word version, 
 		if(!p_igetl(&item_ref.initiald[q], f))
 			return qe_invalid;
 	
-	if(!p_getc(&item_ref.wpn,f))
-		return qe_invalid;
-	
-	if(!p_getc(&item_ref.wpn2,f))
-		return qe_invalid;
-	
-	if(!p_getc(&item_ref.wpn3,f))
-		return qe_invalid;
-	
-	if(!p_getc(&item_ref.wpn4,f))
-		return qe_invalid;
-	
-	if(!p_getc(&item_ref.wpn5,f))
-		return qe_invalid;
-	
-	if(!p_getc(&item_ref.wpn6,f))
-		return qe_invalid;
-	
-	if(!p_getc(&item_ref.wpn7,f))
-		return qe_invalid;
-	
-	if(!p_getc(&item_ref.wpn8,f))
-		return qe_invalid;
-	
-	if(!p_getc(&item_ref.wpn9,f))
-		return qe_invalid;
-	
-	if(!p_getc(&item_ref.wpn10,f))
-		return qe_invalid;
+	if (s_version < 68)
+	{
+		for (int q = 0; q < 10; ++q)
+		{
+			if(!p_getc(&tempbyte,f))
+				return qe_invalid;
+			item_ref.wpn_sprites[q] = tempbyte;
+		}
+	}
+	else
+	{
+		for (int q = 0; q < 10; ++q)
+			if(!p_igetw(&item_ref.wpn_sprites[q],f))
+				return qe_invalid;
+	}
 	
 	if(!p_getc(&item_ref.pickup_hearts,f))
 		return qe_invalid;
@@ -9802,14 +9327,70 @@ void reset_itemname(int32_t id)
 		itemsbuf[id].name = fmt::format("zz{:03}", id);
 }
 
+int32_t read_single_spritedata(PACKFILE *f, zquestheader *Header, word s_version, word index)
+{
+	static sprite_data _nil_sprite;
+	
+	bool should_skip = legacy_skip_flags && get_bit(legacy_skip_flags, skip_weapons);
+	sprite_data& sprite_ref = should_skip ? _nil_sprite : sprite_data_buf[index];
+	string oldname = sprite_ref.name;
+	sprite_ref = sprite_data();
+	
+	byte tempbyte;
+	word tempword;
+	if (s_version >= 9)
+	{
+		if (!p_getcstr(&sprite_ref.name, f))
+			return qe_invalid;
+	}
+	else sprite_ref.name = oldname;
+	
+	if (s_version < 8)
+	{
+		if (!p_igetw(&tempword, f))
+			return qe_invalid;
+		if (s_version < 7)
+			sprite_ref.tile = tempword;
+	}
+
+	if(!p_getc(&sprite_ref.misc,f))
+		return qe_invalid;
+	
+	if(!p_getc(&sprite_ref.csets,f))
+		return qe_invalid;
+	
+	if(!p_getc(&sprite_ref.frames,f))
+		return qe_invalid;
+	
+	if(!p_getc(&sprite_ref.speed,f))
+		return qe_invalid;
+	
+	if(!p_getc(&sprite_ref.type,f))
+		return qe_invalid;
+
+	if ( s_version >= 7 )
+	{
+		if(!p_igetw(&sprite_ref.script,f))
+			return qe_invalid;
+		if(!p_igetl(&sprite_ref.tile,f))
+			return qe_invalid;
+	}
+	
+	if(Header->zelda_version < 0x193)
+		if(!p_getc(&tempbyte,f))
+			return qe_invalid;
+	
+	if(s_version < 6)
+		SETFLAG(sprite_ref.misc, WF_BEHIND, index == ewFIRETRAIL);
+	return 0;
+}
 int32_t readweapons(PACKFILE *f, zquestheader *Header)
 {
 	bool should_skip = legacy_skip_flags && get_bit(legacy_skip_flags, skip_weapons);
 
-    word weapons_to_read=MAXWPNS;
+    word weapons_to_read=256;
     int32_t dummy;
     byte padding;
-    wpndata tempweapon;
     word s_version=0;
     
     
@@ -9855,122 +9436,57 @@ int32_t readweapons(PACKFILE *f, zquestheader *Header)
             return qe_invalid;
         }
 
-        if (weapons_to_read > MAXWPNS)
+        if (weapons_to_read > MAXSPRITES)
         {
             return qe_invalid;
         }
     }
     
-    if(s_version>2)
+	if (!should_skip)
+	{
+		sprite_data_buf.clear();
+		sprite_data_buf.reserve(weapons_to_read);
+	}
+	if (s_version <= 2)
+	{
+		if (!should_skip)
+			for(int32_t i=0; i<256; i++)
+				reset_weaponname(i);
+	}
+    else if(s_version < 9)
     {
         for(int32_t i=0; i<weapons_to_read; i++)
         {
-            char tempname[64];
+            char tempname[65] = {0};
             
             if(!pfread(tempname, 64, f))
             {
                 return qe_invalid;
             }
             
-			weapon_string[i][0] = '\0';
-			strncat(weapon_string[i], tempname, 64 - 1);
+			if (!should_skip)
+				sprite_data_buf[i].name = tempname;
         }
         
-        if(s_version<4)
-        {
-			strcpy(weapon_string[iwHover],old_weapon_string[iwHover]);
-			strcpy(weapon_string[wFIREMAGIC],old_weapon_string[wFIREMAGIC]);
+		if (!should_skip)
+		{
+			if(s_version<4)
+			{
+				sprite_data_buf[iwHover].name = old_weapon_string[iwHover];
+				sprite_data_buf[wFIREMAGIC].name = old_weapon_string[wFIREMAGIC];
+			}
+			
+			if(s_version<5)
+			{
+				sprite_data_buf[iwQuarterHearts].name = old_weapon_string[iwQuarterHearts];
+			}
         }
-        
-        if(s_version<5)
-        {
-            strcpy(weapon_string[iwQuarterHearts],old_weapon_string[iwQuarterHearts]);
-        }
-        
-        /*
-            if (s_version<6)
-            {
-              strcpy(weapon_string[iwSideRaft],old_weapon_string[iwSideRaft]);
-              strcpy(weapon_string[iwSideLadder],old_weapon_string[iwSideLadder]);
-            }
-        */
-    }
-    else if (!should_skip)
-    {
-		for(int32_t i=0; i<MAXWPNS; i++)
-			reset_weaponname(i);
     }
     
 	for(int32_t i=0; i<weapons_to_read; i++)
 	{
-		word oldtile = 0;
-		if (s_version < 8)
-		{
-			if (!p_igetw(&oldtile, f))
-				return qe_invalid;
-		}
-
-		if(!p_getc(&tempweapon.misc,f))
-		{
-			return qe_invalid;
-		}
-        
-		if(!p_getc(&tempweapon.csets,f))
-		{
-			return qe_invalid;
-		}
-        
-		if(!p_getc(&tempweapon.frames,f))
-		{
-			return qe_invalid;
-		}
-        
-		if(!p_getc(&tempweapon.speed,f))
-		{
-			return qe_invalid;
-		}
-        
-		if(!p_getc(&tempweapon.type,f))
-		{
-			return qe_invalid;
-		}
-	
-		if ( s_version >= 7 )
-		{
-			if(!p_igetw(&tempweapon.script,f))
-			{
-				return qe_invalid;
-			}
-			if(!p_igetl(&tempweapon.tile,f))
-			{
-				return qe_invalid;
-			}	    
-		}
-		if ( s_version < 7 ) 
-		{
-			tempweapon.tile = oldtile;
-		}
-        
-		if(Header->zelda_version < 0x193)
-		{
-			if(!p_getc(&padding,f))
-			{
-				return qe_invalid;
-			}
-		}
-        
-		if(s_version < 6)
-		{
-			if(i==ewFIRETRAIL)
-			{
-				tempweapon.misc |= WF_BEHIND;
-			}
-			else
-				tempweapon.misc &= ~WF_BEHIND;
-		}
-        
-		if (!should_skip)
-			memcpy(&wpnsbuf[i], &tempweapon, sizeof(tempweapon));
+		if (auto ret = read_single_spritedata(f, Header, s_version, i))
+			return ret;
 	}
 
 	if (should_skip)
@@ -9978,21 +9494,21 @@ int32_t readweapons(PACKFILE *f, zquestheader *Header)
     
 	if(s_version<2)
 	{
-		wpnsbuf[wSBOOM]=wpnsbuf[wBOOM];
+		sprite_data_buf[wSBOOM] = sprite_data_buf.get(wBOOM);
 	}
 	
 	if(s_version<5)
 	{
-		wpnsbuf[iwQuarterHearts].tile=1;
-		wpnsbuf[iwQuarterHearts].csets=1;
+		sprite_data_buf[iwQuarterHearts].tile = 1;
+		sprite_data_buf[iwQuarterHearts].csets = 1;
 	}
 	
 	if(Header->zelda_version < 0x176)
 	{
 		auto& spawn_item = itemsbuf[iMisc1];
 		auto& death_item = itemsbuf[iMisc2];
-		wpnsbuf[iwSpawn].load_item(spawn_item);
-		wpnsbuf[iwDeath].load_item(death_item);
+		sprite_data_buf[iwSpawn].load_item(spawn_item);
+		sprite_data_buf[iwDeath].load_item(death_item);
 		spawn_item.clear();
 		death_item.clear();
 	}
@@ -10000,16 +9516,18 @@ int32_t readweapons(PACKFILE *f, zquestheader *Header)
 	if((Header->zelda_version < 0x192)||
 			((Header->zelda_version == 0x192)&&(Header->build<129)))
 	{
-		wpnsbuf[wHSCHAIN_V] = wpnsbuf[wHSCHAIN_H];
+		sprite_data_buf[wHSCHAIN_V] = sprite_data_buf.get(wHSCHAIN_H);
 	}
 	
 	if((Header->zelda_version < 0x210))
 	{
-		wpnsbuf[wLSHEAD] = wpnsbuf[wHSHEAD];
-		wpnsbuf[wLSCHAIN_H] = wpnsbuf[wHSCHAIN_H];
-		wpnsbuf[wLSHANDLE] = wpnsbuf[wHSHANDLE];
-		wpnsbuf[wLSCHAIN_V] = wpnsbuf[wHSCHAIN_V];
+		sprite_data_buf[wLSHEAD] = sprite_data_buf.get(wHSHEAD);
+		sprite_data_buf[wLSCHAIN_H] = sprite_data_buf.get(wHSCHAIN_H);
+		sprite_data_buf[wLSHANDLE] = sprite_data_buf.get(wHSHANDLE);
+		sprite_data_buf[wLSCHAIN_V] = sprite_data_buf.get(wHSCHAIN_V);
 	}
+	
+	sprite_data_buf.normalize();
     
     return 0;
 }
@@ -10261,12 +9779,9 @@ void init_guys(int32_t guyversion)
 
 void reset_weaponname(int32_t i)
 {
-    if(i<wLast)
-    {
-        strcpy(weapon_string[i],old_weapon_string[i]);
-    }
-    else
-        sprintf(weapon_string[i],"zz%03d",i);
+	sprite_data_buf[i].name = i < wLast
+		? old_weapon_string[i]
+		: fmt::format("zz{:03}", i);
 }
 
 void init_item_drop_sets()
@@ -13860,6 +13375,7 @@ int32_t readguys(PACKFILE *f, zquestheader *Header)
 
     dword dummy;
 	byte tempbyte;
+	word tempword;
     word guy_cversion;
     word guyversion=0;
     
@@ -15342,20 +14858,26 @@ int32_t readguys(PACKFILE *f, zquestheader *Header)
 					tempguy.flags |= guy_fade_instant;
 				}
 			}
-			if (guyversion > 44)
+			if (guyversion > 55)
 			{
-				if(!p_getc(&(tempguy.spr_shadow),f))
-				{
+				if(!p_igetw(&(tempguy.spr_shadow),f))
 					return qe_invalid;
-				}
-				if(!p_getc(&(tempguy.spr_death),f))
-				{
+				if(!p_igetw(&(tempguy.spr_death),f))
 					return qe_invalid;
-				}
-				if(!p_getc(&(tempguy.spr_spawn),f))
-				{
+				if(!p_igetw(&(tempguy.spr_spawn),f))
 					return qe_invalid;
-				}
+			}
+			else if (guyversion > 44)
+			{
+				if(!p_getc(&tempbyte,f))
+					return qe_invalid;
+				tempguy.spr_shadow = tempbyte;
+				if(!p_getc(&tempbyte,f))
+					return qe_invalid;
+				tempguy.spr_death = tempbyte;
+				if(!p_getc(&tempbyte,f))
+					return qe_invalid;
+				tempguy.spr_spawn = tempbyte;
 			}
 			else
 			{
@@ -15442,10 +14964,11 @@ int32_t readguys(PACKFILE *f, zquestheader *Header)
 				tempguy.weap_data.step = zslongToFix(temp_step*100);
 				for (int32_t q = 0; q < WPNSPR_MAX; ++q)
 				{
-					if (!p_igetw(&(tempguy.weap_data.burnsprs[q]), f))
+					if (!p_igetw(&tempguy.weap_data.burnsprs[q], f))
 						return qe_invalid;
-					if (!p_igetw(&(tempguy.weap_data.light_rads[q]), f))
+					if (!p_igetw(&tempword, f))
 						return qe_invalid;
+					tempguy.weap_data.light_rads[q] = (byte)tempword;
 				}
 			}
 			if (guyversion < 53)
@@ -18828,8 +18351,17 @@ int32_t readcombo_loop(PACKFILE* f, word s_version, newcombo& temp_combo)
 				return qe_invalid;
 			if(!p_getc(&temp_combo.liftgfx,f))
 				return qe_invalid;
-			if(!p_getc(&temp_combo.liftsprite,f))
-				return qe_invalid;
+			if (s_version < 66)
+			{
+				if(!p_getc(&tempbyte,f))
+					return qe_invalid;
+				temp_combo.liftsprite = tempbyte;
+			}
+			else
+			{
+				if(!p_igetw(&temp_combo.liftsprite,f))
+					return qe_invalid;
+			}
 			if (s_version < 64)
 			{
 				if(!p_getc(&tempbyte,f))
@@ -18943,14 +18475,32 @@ int32_t readcombo_loop(PACKFILE* f, word s_version, newcombo& temp_combo)
 					if(!p_igetw(&temp_combo.sfx_standing,f))
 						return qe_invalid;
 				}
-				if(!p_getc(&temp_combo.spr_appear,f))
-					return qe_invalid;
-				if(!p_getc(&temp_combo.spr_disappear,f))
-					return qe_invalid;
-				if(!p_getc(&temp_combo.spr_walking,f))
-					return qe_invalid;
-				if(!p_getc(&temp_combo.spr_standing,f))
-					return qe_invalid;
+				if (s_version < 66)
+				{
+					if(!p_getc(&tempbyte,f))
+						return qe_invalid;
+					temp_combo.spr_appear = tempbyte;
+					if(!p_getc(&tempbyte,f))
+						return qe_invalid;
+					temp_combo.spr_disappear = tempbyte;
+					if(!p_getc(&tempbyte,f))
+						return qe_invalid;
+					temp_combo.spr_walking = tempbyte;
+					if(!p_getc(&tempbyte,f))
+						return qe_invalid;
+					temp_combo.spr_standing = tempbyte;
+				}
+				else
+				{
+					if(!p_igetw(&temp_combo.spr_appear,f))
+						return qe_invalid;
+					if(!p_igetw(&temp_combo.spr_disappear,f))
+						return qe_invalid;
+					if(!p_igetw(&temp_combo.spr_walking,f))
+						return qe_invalid;
+					if(!p_igetw(&temp_combo.spr_standing,f))
+						return qe_invalid;
+				}
 			}
 			if (s_version < 64)
 			{
@@ -18976,12 +18526,27 @@ int32_t readcombo_loop(PACKFILE* f, word s_version, newcombo& temp_combo)
 			}
 			if(s_version >= 50)
 			{
-				if(!p_getc(&temp_combo.spr_falling,f))
-					return qe_invalid;
-				if(!p_getc(&temp_combo.spr_drowning,f))
-					return qe_invalid;
-				if(!p_getc(&temp_combo.spr_lava_drowning,f))
-					return qe_invalid;
+				if (s_version < 66)
+				{
+					if(!p_getc(&tempbyte,f))
+						return qe_invalid;
+					temp_combo.spr_falling = tempbyte;
+					if(!p_getc(&tempbyte,f))
+						return qe_invalid;
+					temp_combo.spr_drowning = tempbyte;
+					if(!p_getc(&tempbyte,f))
+						return qe_invalid;
+					temp_combo.spr_lava_drowning = tempbyte;
+				}
+				else
+				{
+					if(!p_igetw(&temp_combo.spr_falling,f))
+						return qe_invalid;
+					if(!p_igetw(&temp_combo.spr_drowning,f))
+						return qe_invalid;
+					if(!p_igetw(&temp_combo.spr_lava_drowning,f))
+						return qe_invalid;
+				}
 				
 				if (s_version < 64)
 				{
@@ -19872,7 +19437,7 @@ int32_t readtiles(PACKFILE *f, tiledata *buf, zquestheader *Header, word version
 		if(get_qr(qr_BSZELDA))   //
 		{
 			byte tempbyte;
-			int32_t floattile=wpnsbuf[iwSwim].tile;
+			int32_t floattile = sprite_data_buf.get(iwSwim).tile;
 			
 			for(int32_t i=0; i<tilesize(tf4Bit); i++)  //BSZelda tiles are out of order //does this include swim tiles?
 			{

--- a/src/core/qst.h
+++ b/src/core/qst.h
@@ -198,6 +198,7 @@ int32_t readmisc(PACKFILE *f, zquestheader *Header, miscQdata *Misc);
 void update_old_item(word s_version, word index, word version);
 int32_t read_single_item(PACKFILE *f, word s_version, word index, word version, word build);
 int32_t readitems(PACKFILE *f, word version, word build);
+int32_t read_single_spritedata(PACKFILE *f, zquestheader *Header, word s_version, word index);
 int32_t readweapons(PACKFILE *f, zquestheader *Header);
 int32_t readguys(PACKFILE *f, zquestheader *Header);
 int32_t readmapscreen(PACKFILE *f, zquestheader *Header, mapscr *temp_mapscr, word version, int scrind = -1, bool keep_music = false);

--- a/src/core/weapon_data.h
+++ b/src/core/weapon_data.h
@@ -25,7 +25,7 @@ struct weapon_data
 	
 	weapon_flags wflags = WFLAG_NONE;
 	
-	byte burnsprs[WPNSPR_MAX];
+	word burnsprs[WPNSPR_MAX];
 	byte light_rads[WPNSPR_MAX];
 	byte glow_shape;
 	

--- a/src/core/zdefs.cpp
+++ b/src/core/zdefs.cpp
@@ -1676,13 +1676,3 @@ void zctune::reset()
 	*this = zctune();
 }
 
-void wpndata::load_item(itemdata const& itm)
-{
-	tile = itm.tile;
-	misc = itm.misc_flags;
-	csets = itm.csets;
-	frames = itm.frames;
-	speed = itm.speed;
-	type = itm.delay;
-}
-

--- a/src/core/zdefs.h
+++ b/src/core/zdefs.h
@@ -138,20 +138,20 @@ enum {ENC_METHOD_192B104=0, ENC_METHOD_192B105, ENC_METHOD_192B185, ENC_METHOD_2
 #define V_HEADER           9
 #define V_RULES           17
 #define V_STRINGS         12
-#define V_MISC            20
+#define V_MISC            21
 #define V_TILES            3 //2 is a int32_t, max 214500 tiles (ZScript upper limit)
-#define V_COMBOS          65
+#define V_COMBOS          66
 #define V_CSETS            6 //palette data
 #define V_MAPS            39
 #define V_DMAPS           26
 #define V_DOORS            1
-#define V_ITEMS           67
-#define V_WEAPONS          8
+#define V_ITEMS           68
+#define V_WEAPONS          9
 #define V_COLORS           4 //Misc Colours
 #define V_ICONS            10 //Game Icons
 #define V_GRAPHICSPACK     1
 #define V_INITDATA        47
-#define V_GUYS            55
+#define V_GUYS            56
 #define V_MIDIS            5
 #define V_CHEATS           1
 #define V_SAVEGAME        49
@@ -167,7 +167,7 @@ enum {ENC_METHOD_192B104=0, ENC_METHOD_192B105, ENC_METHOD_192B185, ENC_METHOD_2
 
 // not 'real' sections, just separate version numbers
 #define V_COMPATRULE       102
-#define V_WEAP_DATA        0
+#define V_WEAP_DATA        1
 
 //= V_SHOPS is under V_MISC
 
@@ -1103,28 +1103,6 @@ enum
 	wmovepatternPATTERN_B, wmovepatternPATTERN_C, wmovepatternPATTERN_D, wmovepatternPATTERN_E, wmovepatternPATTERN_F
 };
 
-struct itemdata;
-struct wpndata
-{
-	int32_t tile;
-	byte misc;                                                // 000bvhff (vh:flipping, f:flash (1:NES, 2:BSZ))
-	byte csets;                                               // ffffcccc (f:flash cset, c:cset)
-	byte frames;                                              // animation frame count
-	byte speed;                                               // animation speed
-	byte type;                                                // used by certain weapons
-	word script;
-	
-	byte flip() const
-	{
-		return (misc >> 2) & 0b11;
-	}
-	byte cs() const
-	{
-		return csets & 0xF;
-	}
-	void load_item(itemdata const& itm);
-};
-
 #define WF_AUTOFLASH  0x01
 #define WF_2PFLASH    0x02
 #define WF_HFLIP      0x04
@@ -1203,7 +1181,7 @@ struct guydata
     
     char initD_label[8][65];
     
-	byte spr_shadow, spr_death, spr_spawn;
+	word spr_shadow, spr_death, spr_spawn;
 	word specialsfx;
 	
 	weapon_data weap_data;

--- a/src/dialog/info_lister.cpp
+++ b/src/dialog/info_lister.cpp
@@ -24,8 +24,6 @@
 #include <sstream>
 #include "advanced_music.h"
 
-extern char *weapon_string[];
-
 static string get_info(bool sel, bool advpaste, bool saveload = true, bool copypaste = true)
 {
 	std::ostringstream oss;
@@ -275,7 +273,7 @@ void ItemListerDialog::preinit()
 		if (itemsbuf.capacity() < MAXITEMS)
 		{
 			frozen_end = 1;
-			lister.add(fmt::format("<New Item> ({:03})", itemsbuf.capacity()), itemsbuf.capacity());
+			lister.add(fmt::format("<New Item> ({:04})", itemsbuf.capacity()), itemsbuf.capacity());
 		}
 		resort();
 		if(selected_val < 0)
@@ -422,7 +420,7 @@ bool ItemListerDialog::clear_nondelete()
 		fmt::format("Clear Item #{}, '{}'?\nThis will reset it to blank.", selected_val, itm.name)))
 		return false;
 	itm.clear();
-	itm.name = fmt::format("zz{:03}", selected_val);
+	itm.name = fmt::format("zz{:04}", selected_val);
 	refresh_dlg();
 	return true;
 }
@@ -545,43 +543,82 @@ SpriteListerDialog::SpriteListerDialog(int spriteid, bool selecting):
 }
 void SpriteListerDialog::preinit()
 {
+	sprite_data_buf.normalize();
 	lister = GUI::ZCListData::miscsprites(!selecting, false, true);
 	if(selecting)
 		frozen_start = 1; // lock '(None)'
 	else
 	{
 		resort();
+		if (sprite_data_buf.capacity() < MAXSPRITES)
+		{
+			frozen_end = 1;
+			lister.add(fmt::format("<New Sprite> ({:04})", sprite_data_buf.capacity()), sprite_data_buf.capacity());
+		}
 		if(selected_val < 0)
 			selected_val = lister.getValue(0);
 	}
-	selected_val = vbound(selected_val, (selecting?-1:0), MAXWPNS-1);
+	selected_val = vbound(selected_val, (selecting?-1:0), sprite_data_buf.capacity() + (selecting?-1:0));
 }
 void SpriteListerDialog::postinit()
 {
+	using namespace GUI::Builder;
+	using namespace GUI::Props;
+	using namespace GUI::Key;
 	size_t len = 16;
-	for(int q = 0; q < MAXWPNS; ++q)
+	for(int q = 0; q < sprite_data_buf.capacity(); ++q)
 	{
-		size_t tlen = text_length(GUI_DEF_FONT,weapon_string[q]);
+		size_t tlen = text_length(GUI_DEF_FONT,sprite_data_buf.get(q).name.c_str());
 		if(tlen > len)
 			len = tlen;
 	}
 	widgInfo->minWidth(Size::pixels(len+8));
 	widgList->minHeight(Size::pixels(320));
 	window->setHelp(get_info(selecting, true));
+	
+	btnrow2 = Column(
+		Columns<2>(
+			DummyWidget(),
+			del_btn = Button(text = "Delete",
+				fitParent = true,
+				onClick = message::CLEAR),
+			up_btn = Button(text = "Up",
+				fitParent = true,
+				onPressFunc = [&]()
+				{
+					zc_swap(sprite_data_buf[selected_val], sprite_data_buf[selected_val-1]);
+					--selected_val;
+					refresh_dlg();
+				}),
+			down_btn = Button(text = "Down",
+				fitParent = true,
+				onPressFunc = [&]()
+				{
+					zc_swap(sprite_data_buf[selected_val], sprite_data_buf[selected_val+1]);
+					++selected_val;
+					refresh_dlg();
+				})
+		),
+		Label(fitParent = true, maxwidth = 250_px,
+			text = "Sprites cannot be re-ordered while the list is alphabetized."
+			"\nWARNING: Re-ordering Sprites will NOT update anything that uses them."
+			"\nThis includes the re-ordering that happens when deleting Sprites."
+		)
+	);
 }
 static int copied_sprite_id = -1;
 void SpriteListerDialog::update(bool)
 {
-	std::string copied_name = "(None)\n";
-	if(unsigned(copied_sprite_id) < MAXWPNS)
-		copied_name = weapon_string[copied_sprite_id];
-	if(unsigned(selected_val) < MAXWPNS)
+	std::string copied_name = "(None)";
+	if(unsigned(copied_sprite_id) < sprite_data_buf.capacity())
+		copied_name = sprite_data_buf.get(copied_sprite_id).name;
+	if(unsigned(selected_val) < sprite_data_buf.capacity())
 	{
-		wpndata const& spr = wpnsbuf[selected_val];
+		sprite_data const& spr = sprite_data_buf.get(selected_val);
 		widgInfo->setText(fmt::format(
 			"{}\nCSet: {}\nFlip: {}\nFrames: {}\nSpeed: {}"
 			"\n\nCopied:\n{}",
-			weapon_string[selected_val], spr.cs(), spr.flip(), spr.frames, spr.speed,
+			spr.name, spr.cs(), spr.flip(), spr.frames, spr.speed,
 			copied_name));
 		widgPrev->setDisabled(false);
 		widgPrev->setTile(spr.tile);
@@ -614,13 +651,48 @@ void SpriteListerDialog::edit()
 }
 void SpriteListerDialog::rclick(int x, int y)
 {
+	bool oob = unsigned(selected_val) >= sprite_data_buf.capacity();
+	bool paste_oob = oob && (selected_val != sprite_data_buf.capacity());
+	bool copy_oob = unsigned(copied_sprite_id) >= sprite_data_buf.capacity();
 	NewMenu rcmenu {
-		{ "&Copy", [&](){copy();} },
-		{ "Paste", "&v", [&](){paste();}, 0, copied_sprite_id < 0 ? MFL_DIS : 0 },
-		{ "&Save", [&](){save();} },
-		{ "&Load", [&](){load();} },
+		{ "Clear", [&](){clear_nondelete();}, 0, oob ? MFL_DIS : 0 },
+		{ "&Copy", [&](){copy();}, 0, oob ? MFL_DIS : 0 },
+		{ "Paste", "&v", [&](){paste();}, 0, copy_oob || paste_oob ? MFL_DIS : 0 },
+		{ "Delete", [&](){clear();}, 0, oob ? MFL_DIS : 0 },
+		{ "&Save", [&](){save();}, 0, oob ? MFL_DIS : 0 },
+		{ "&Load", [&](){load();}, 0, paste_oob ? MFL_DIS : 0 },
 	};
 	rcmenu.pop(x, y);
+}
+bool SpriteListerDialog::clear_nondelete()
+{
+	if (unsigned(selected_val) >= sprite_data_buf.capacity())
+		return false;
+	auto name = sprite_data_buf.get(selected_val).name;
+	if (!alert_confirm(fmt::format("Clear Sprite {}", selected_val),
+		fmt::format("Clear Sprite #{}, '{}'?\nThis will reset it to blank.", selected_val, name)))
+		return false;
+	auto& spr = sprite_data_buf[selected_val];
+	spr.clear();
+	spr.name = fmt::format("zz{:04}", selected_val);
+	refresh_dlg();
+	return true;
+}
+bool SpriteListerDialog::clear()
+{
+	if (unsigned(selected_val) >= sprite_data_buf.capacity())
+		return false;
+	auto& spr = sprite_data_buf.get(selected_val);
+	if (!alert_confirm(fmt::format("Delete Sprite '{}'?", spr.name),
+		fmt::format("This will delete Sprite #{}, '{}'."
+		"\nThis will offset all entries after it; sprite IDs of various things may need to be updated.",
+		selected_val, spr.name)))
+		return false;
+	delete_quest_sprites(selected_val);
+	if (selected_val >= sprite_data_buf.capacity())
+		--selected_val;
+	refresh_dlg();
+	return true;
 }
 void SpriteListerDialog::copy()
 {
@@ -629,11 +701,13 @@ void SpriteListerDialog::copy()
 }
 bool SpriteListerDialog::paste()
 {
-	if(copied_sprite_id < 0 || selected_val < 0)
+	if (unsigned(copied_sprite_id) >= sprite_data_buf.capacity())
+		return false;
+	if (unsigned(selected_val) >= zc_min(MAXSPRITES, sprite_data_buf.capacity() + 1))
 		return false;
 	if(copied_sprite_id == selected_val)
 		return false;
-	wpnsbuf[selected_val] = wpnsbuf[copied_sprite_id];
+	sprite_data_buf[selected_val] = sprite_data_buf.get(copied_sprite_id);
 	refresh_dlg();
 	mark_save_dirty();
 	return true;
@@ -644,7 +718,7 @@ void SpriteListerDialog::save()
 {
 	if(selected_val < 0)
 		return;
-	if(!prompt_for_new_file_compat(fmt::format("Save Sprite '{}' #{} (.zwpnspr)",weapon_string[selected_val],selected_val).c_str(),"zwpnspr",NULL,datapath,false))
+	if(!prompt_for_new_file_compat(fmt::format("Save Sprite '{}' #{} (.zwpnspr)",sprite_data_buf.get(selected_val).name,selected_val).c_str(),"zwpnspr",NULL,datapath,false))
 		return;
 	
 	PACKFILE *f=zalleg_pack_fopen_password(temppath,F_WRITE,"");
@@ -660,12 +734,12 @@ bool SpriteListerDialog::load()
 {
 	if(selected_val < 0)
 		return false;
-	if(!prompt_for_existing_file_compat(fmt::format("Load Sprite (replacing '{}' #{}) (.zwpnspr)",weapon_string[selected_val],selected_val).c_str(),"zwpnspr",NULL,datapath,false))
+	if(!prompt_for_existing_file_compat(fmt::format("Load Sprite (replacing '{}' #{}) (.zwpnspr)",sprite_data_buf.get(selected_val).name,selected_val).c_str(),"zwpnspr",NULL,datapath,false))
 		return false;
 	
 	PACKFILE *f=zalleg_pack_fopen_password(temppath,F_READ,"");
 	if(!f) return false;
-	if (!readoneweapon(f,selected_val))
+	if (!readoneweapon(f, selected_val))
 	{
 		Z_error("Could not read from .zwpnspr packfile %s\n", temppath);
 		InfoDialog("ZWpnSpr Error", "Could not load the specified sprite.").show();
@@ -975,7 +1049,7 @@ void SFXListerDialog::preinit()
 		lister.removeInd(0); // remove '(None)'
 	if (quest_sounds.size() < MAX_SFX)
 	{
-		lister.add(fmt::format("<New SFX> ({:03})", quest_sounds.size() + 1), quest_sounds.size() + 1);
+		lister.add(fmt::format("<New SFX> ({:04})", quest_sounds.size() + 1), quest_sounds.size() + 1);
 		frozen_end = 1;
 	}
 	if(selected_val < 0)
@@ -1436,7 +1510,7 @@ void MusicListerDialog::preinit()
 		lister.removeInd(0); // remove '(None)'
 	if (quest_music.size() < MAX_QUEST_MUSIC)
 	{
-		lister.add(fmt::format("<New Music> ({:03})", quest_music.size() + 1), quest_music.size() + 1);
+		lister.add(fmt::format("<New Music> ({:05})", quest_music.size() + 1), quest_music.size() + 1);
 		frozen_end = 1;
 	}
 	resort();

--- a/src/dialog/info_lister.h
+++ b/src/dialog/info_lister.h
@@ -108,10 +108,15 @@ protected:
 	void update(bool startup = false) override;
 	void edit() override;
 	void rclick(int x, int y) override;
+	bool clear_nondelete();
+	bool clear() override;
 	void copy() override;
 	bool paste() override;
 	void save() override;
 	bool load() override;
+
+private:
+	std::shared_ptr<GUI::Button> up_btn, down_btn, del_btn;
 };
 
 class SubscrWidgListerDialog: public BasicListerDialog

--- a/src/dialog/itemeditor.cpp
+++ b/src/dialog/itemeditor.cpp
@@ -2084,16 +2084,16 @@ std::shared_ptr<GUI::Widget> ItemEditorDialog::view()
 					TabRef(name = "Sprites", TabPanel(
 						ptr = &itmtabs[4],
 						TabRef(name = "Basic", Columns<5>(
-							SPRITE_DROP(0,wpn),
-							SPRITE_DROP(1,wpn2),
-							SPRITE_DROP(2,wpn3),
-							SPRITE_DROP(3,wpn4),
-							SPRITE_DROP(4,wpn5),
-							SPRITE_DROP(5,wpn6),
-							SPRITE_DROP(6,wpn7),
-							SPRITE_DROP(7,wpn8),
-							SPRITE_DROP(8,wpn9),
-							SPRITE_DROP(9,wpn10)
+							SPRITE_DROP(0, wpn_sprites[0]),
+							SPRITE_DROP(1, wpn_sprites[1]),
+							SPRITE_DROP(2, wpn_sprites[2]),
+							SPRITE_DROP(3, wpn_sprites[3]),
+							SPRITE_DROP(4, wpn_sprites[4]),
+							SPRITE_DROP(5, wpn_sprites[5]),
+							SPRITE_DROP(6, wpn_sprites[6]),
+							SPRITE_DROP(7, wpn_sprites[7]),
+							SPRITE_DROP(8, wpn_sprites[8]),
+							SPRITE_DROP(9, wpn_sprites[9])
 						))
 					)),
 					TabRef(name = "Size", Row(

--- a/src/dialog/misc_sprs.cpp
+++ b/src/dialog/misc_sprs.cpp
@@ -15,13 +15,11 @@ static const GUI::ListData miscSprsList
 	{ "Switch Poof:", sprSWITCHPOOF, "Shown when 'switching' objects with the poof switch style." }
 };
 
-MiscSprsDialog::MiscSprsDialog(byte* vals, size_t vals_per_tab, std::function<void(int32_t*)> setVals):
+MiscSprsDialog::MiscSprsDialog(word* vals, size_t vals_per_tab, std::function<void(int32_t*)> setVals):
 	sprs_list(GUI::ZCListData::miscsprites()), setVals(setVals), vals_per_tab(vals_per_tab)
 {
 	for(auto q = 0; q < sprMAX; ++q)
-	{
 		local_sprs[q] = vals[q];
-	}
 }
 
 std::shared_ptr<GUI::Widget> MiscSprsDialog::view()

--- a/src/dialog/misc_sprs.h
+++ b/src/dialog/misc_sprs.h
@@ -13,7 +13,7 @@ class MiscSprsDialog: public GUI::Dialog<MiscSprsDialog>
 public:
 	enum class message { REFR_INFO, OK, CANCEL };
 
-	MiscSprsDialog(byte* vals, size_t vals_per_tab, std::function<void(int32_t*)> setVals);
+	MiscSprsDialog(word* vals, size_t vals_per_tab, std::function<void(int32_t*)> setVals);
 
 	std::shared_ptr<GUI::Widget> view() override;
 	bool handleMessage(const GUI::DialogMessage<message>& msg);

--- a/src/dialog/spritedata.cpp
+++ b/src/dialog/spritedata.cpp
@@ -5,20 +5,18 @@
 #include "zc_list_data.h"
 
 void mark_save_dirty();
-extern wpndata *wpnsbuf;
-extern char *weapon_string[];
 
 void call_sprite_dlg(int32_t index)
 {
-	if(unsigned(index) > 255) return;
+	if(unsigned(index) >= MAXSPRITES) return;
 	SpriteDataDialog(index).show();
 }
 
 SpriteDataDialog::SpriteDataDialog(int32_t index):
-	index(index), sourceSprite(wpnsbuf[index]),
-	tempSprite(wpnsbuf[index])
+	index(index), tempSprite(sprite_data_buf.get(index))
 {
-	sprintf(localName, "%s", weapon_string[index]);
+	if (index >= sprite_data_buf.capacity() && index < MAXSPRITES)
+		tempSprite.name = fmt::format("zz{:03}", index);
 }
 
 #define NUM_FIELD(member,_min,_max) \
@@ -59,12 +57,9 @@ std::shared_ptr<GUI::Widget> SpriteDataDialog::view()
 	using namespace GUI::Key;
 	using namespace GUI::Props;
 	
-	
-	char titlebuf[256];
-	sprintf(titlebuf, "Sprite %d: %s", index, localName);
 	window = Window(
 		use_vsync = true,
-		title = titlebuf,
+		title = fmt::format("Sprite {}: {}", index, tempSprite.name),
 		minwidth = 30_em,
 		info = "Sprite Data is used as misc animation data for other objects.",
 		onClose = message::CANCEL,
@@ -74,15 +69,11 @@ std::shared_ptr<GUI::Widget> SpriteDataDialog::view()
 				TextField(
 					maxwidth = 15_em,
 					maxLength = 64,
-					text = localName,
+					text = tempSprite.name,
 					onValChangedFunc = [&](GUI::TextField::type,std::string_view str,int32_t)
 					{
-						std::string name(str);
-						strncpy(localName, name.c_str(), 64);
-						localName[64] = 0;
-						char buf[256];
-						sprintf(buf, "Sprite %d: %s", index, localName);
-						window->setTitle(buf);
+						tempSprite.name = str;
+						window->setTitle(fmt::format("Sprite {}: {}", index, tempSprite.name));
 					}
 				)
 			),
@@ -210,8 +201,7 @@ bool SpriteDataDialog::handleMessage(const GUI::DialogMessage<message>& msg)
 	switch(msg.message)
 	{
 		case message::OK:
-			memcpy(&sourceSprite, &tempSprite, sizeof(tempSprite));
-			strcpy(weapon_string[index], localName);
+			sprite_data_buf[index] = tempSprite;
 			mark_save_dirty();
 			return true;
 

--- a/src/dialog/spritedata.h
+++ b/src/dialog/spritedata.h
@@ -10,6 +10,7 @@
 #include <zq/gui/seltile_swatch.h>
 #include <gui/window.h>
 #include <functional>
+#include "sprite_data.h"
 
 void call_sprite_dlg(int32_t index);
 
@@ -32,9 +33,7 @@ private:
 	std::shared_ptr<GUI::SelTileSwatch> tswatch;
 	std::shared_ptr<GUI::Checkbox> hflipcb, vflipcb;
 	int32_t index;
-	char localName[65];
-	wpndata& sourceSprite;
-	wpndata tempSprite;
+	sprite_data tempSprite;
 	void updateAnimation();
 };
 

--- a/src/dialog/subscr_props.cpp
+++ b/src/dialog/subscr_props.cpp
@@ -15,6 +15,7 @@
 #include "subscr_macros.h"
 #include "items.h"
 #include "zinfo.h"
+#include "sprite_data.h"
 
 extern script_data *genericscripts[NUMSCRIPTSGENERIC];
 extern ZCSubscreen subscr_edit;
@@ -1309,12 +1310,12 @@ std::shared_ptr<GUI::Widget> SubscrPropDialog::view()
 					switch(w->special_tile)
 					{
 						case ssmstSSVINETILE:
-							tl = wpnsbuf[iwSubscreenVine].tile;
+							tl = sprite_data_buf.get(iwSubscreenVine).tile;
 							tw = 3;
 							crn = w->crn;
 							break;
 						case ssmstMAGICMETER:
-							tl = wpnsbuf[iwMMeter].tile;
+							tl = sprite_data_buf.get(iwMMeter).tile;
 							tw = 9;
 							crn = w->crn;
 							break;
@@ -1377,13 +1378,13 @@ std::shared_ptr<GUI::Widget> SubscrPropDialog::view()
 								case 0:
 									tswatches[0]->setTileWid(3);
 									tswatches[0]->setMiniOnly(true);
-									newtile = wpnsbuf[iwSubscreenVine].tile;
+									newtile = sprite_data_buf.get(iwSubscreenVine).tile;
 									w->tile = newtile;
 									break;
 								case 1:
 									tswatches[0]->setTileWid(9);
 									tswatches[0]->setMiniOnly(true);
-									newtile = wpnsbuf[iwMMeter].tile;
+									newtile = sprite_data_buf.get(iwMMeter).tile;
 									w->tile = newtile;
 									break;
 							}

--- a/src/gui/jwin.cpp
+++ b/src/gui/jwin.cpp
@@ -6860,17 +6860,18 @@ int32_t jwin_abclist_proc(int32_t msg,DIALOG *d,int32_t c)
 				//Find a different indexing type in the strings?
 				if(!foundmatch)
 				{
-					char buf[16];
-					if(num < 0) sprintf(buf, "(%04d)", num);
-					else sprintf(buf, "(%03d)", num);
-					std::string cmp = buf;
 					for(int32_t listpos = 0; listpos < max; ++listpos)
 					{
 						std::string str((data->listFunc(listpos,&dummy)));
-						size_t trimpos = str.find_last_not_of("-(0123456789)");
-						if(trimpos != std::string::npos) ++trimpos;
-						str.erase(0, trimpos);
-						if(cmp == str)
+						if (auto trimpos = str.find_last_not_of("-(0123456789)"); trimpos != std::string::npos)
+							str.erase(0, trimpos + 1);
+						if (!(str.size() > 2 && str.front() == '(' && str.back() == ')'))
+							continue;
+						str = str.substr(1, str.size()-2); // trim ()
+						if (auto negpos = str.find_last_of("-"); negpos != string::npos && negpos > 0)
+							continue; // extraneous '-' not at the start of string
+						
+						if(atoi(str.c_str()) == num)
 						{
 							d->d1 = listpos;
 							d->d2 = zc_max(zc_min(listpos-(h>>1), max-h), 0);

--- a/src/gui/list_data.cpp
+++ b/src/gui/list_data.cpp
@@ -70,12 +70,10 @@ ListData ListData::numbers(bool none, int32_t start, uint32_t count, std::functi
 	return ls;
 }
 
-void ListData::add(set<string> names, map<string, int32_t> vals)
+void ListData::add(map<string, int32_t> const& vals)
 {
-	for(set<string>::iterator it = names.begin(); it != names.end(); ++it)
-	{
-		add(*it, vals[*it]);
-	}
+	for(auto& [name, val] : vals)
+		add(name, val);
 }
 
 ListData ListData::operator+(ListData const& other) const

--- a/src/gui/list_data.h
+++ b/src/gui/list_data.h
@@ -191,7 +191,7 @@ public:
 	void add(ListItem item) {listItems.push_back(item);}
 	void add(std::string name, int32_t val) {listItems.emplace_back(name, val);};
 	void add(std::string name, int32_t val, std::string desc) {listItems.emplace_back(name, val,desc);};
-	void add(std::set<std::string> names, std::map<std::string, int32_t> vals);
+	void add(std::map<std::string, int32_t> const& vals);
 	
 	ListData copy() const
 	{

--- a/src/hero_tiles.cpp
+++ b/src/hero_tiles.cpp
@@ -1,7 +1,7 @@
 #include "hero_tiles.h"
 #include "core/zdefs.h"
+#include "sprite_data.h"
 
-extern wpndata    *wpnsbuf;
 int32_t hero_animation_speed = 1;
 int32_t liftspeed = 4;
 
@@ -633,8 +633,8 @@ void herotile(int32_t *tile, int32_t *flip, int32_t state, int32_t dir, int32_t)
 
 void setupherotiles(int32_t style)
 {
-    old_floatspr = wpnsbuf[iwSwim].tile;
-    old_slashspr = wpnsbuf[iwHeroSlash].tile;
+    old_floatspr = sprite_data_buf.get(iwSwim).tile;
+    old_slashspr = sprite_data_buf.get(iwHeroSlash).tile;
     herospr = 4;
     
     switch(style)

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -62,7 +62,7 @@ bool item::animate(int32_t)
 			if(fallclk == PITFALL_FALL_FRAMES && fallCombo) sfx(combobuf[fallCombo].c_attributes[8].getTrunc(), pan(x));
 			if(!--fallclk) return true;
 			
-			wpndata& spr = wpnsbuf[QMisc.sprites[sprFALL]];
+			sprite_data const& spr = sprite_data_buf.get(QMisc.sprites[sprFALL]);
 			cs = spr.csets & 0xF;
 			int32_t fr = spr.frames ? spr.frames : 1;
 			int32_t spd = spr.speed ? spr.speed : 1;
@@ -79,7 +79,7 @@ bool item::animate(int32_t)
 			if(!--drownclk) return true;
 			
 			bool lava = (drownCombo && combobuf[drownCombo].usrflags&cflag1);
-			wpndata &spr = wpnsbuf[QMisc.sprites[lava ? sprLAVADROWN : sprDROWN]];
+			sprite_data const& spr = sprite_data_buf.get(QMisc.sprites[lava ? sprLAVADROWN : sprDROWN]);
 			cs = spr.csets & 0xF;
 			int32_t fr = spr.frames ? spr.frames : 1;
 			int32_t spd = spr.speed ? spr.speed : 1;
@@ -268,7 +268,7 @@ bool item::animate(int32_t)
 #endif
 	
 	if ((z > 0 || fakez > 0) && get_qr(qr_ITEMSHADOWS) && !get_qr(qr_CLASSIC_DRAWING_ORDER))
-		shadowtile = wpnsbuf[spr_shadow].tile+aframe;
+		shadowtile = sprite_data_buf.get(spr_shadow).tile+aframe;
 	if(fadeclk==0 && !subscreenItem)
 	{
 		return true;
@@ -288,7 +288,7 @@ void item::draw(BITMAP *dest)
 	
 	if ( (z > 0 || fakez > 0) && get_qr(qr_ITEMSHADOWS) && get_qr(qr_CLASSIC_DRAWING_ORDER))
 	{
-		shadowtile = wpnsbuf[spr_shadow].tile+aframe;
+		shadowtile = sprite_data_buf.get(spr_shadow).tile+aframe;
 		sprite::drawshadow(dest,get_qr(qr_TRANSSHADOWS) != 0);
 	}
 	bool ignore_flicker = fallclk || drownclk;
@@ -719,7 +719,7 @@ bool itembundle_safe(int32_t itmid, bool skipError)
 	return true;
 }
 
-struct LensHintItemData
+struct LensHintData
 {
 	int aclk;
 	int aframe;
@@ -727,13 +727,24 @@ struct LensHintItemData
 	{
 		return !(aclk || aframe);
 	}
-	bool operator==(LensHintItemData const& other) const = default;
+	bool operator==(LensHintData const& other) const = default;
+};
+struct LensOffsetData
+{
+	int dir, x, y;
+	bool empty() const
+	{
+		return !(dir || x || y);
+	}
+	bool operator==(LensOffsetData const& other) const = default;
 };
 
-bounded_map<int, LensHintItemData> lens_hint_item {MAXITEMS, {}};
-void draw_lens_hint_item(BITMAP *dest,int32_t x,int32_t y,int32_t item_id, int32_t flash)
+bounded_map<int, LensHintData> lens_hint_item {MAXITEMS, {}};
+bounded_map<int, LensHintData> lens_hint_sprite {MAXSPRITES, {}};
+bounded_map<int, LensOffsetData> lens_hint_weapon_offsets {wMax, {}};
+void draw_lens_hint_item(BITMAP *dest, int32_t x, int32_t y, int32_t item_id, int32_t flash)
 {
-	LensHintItemData data = lens_hint_item[item_id];
+	LensHintData data = lens_hint_item.get(item_id);
 	item temp((zfix)x,(zfix)y,(zfix)0,item_id,0,0,true);
 	temp.yofs=0;
 	temp.aclk = data.aclk;
@@ -769,9 +780,105 @@ void draw_lens_hint_item(BITMAP *dest,int32_t x,int32_t y,int32_t item_id, int32
 	else
 		lens_hint_item[item_id] = data;
 }
-void reset_lens_hint_items()
+void update_lens_hint_weapon(int weapon_id)
+{
+	// Some weapons when drawing their hint sprite would use additional data, but
+	// this data was indexed by weapon id rather than sprite id.
+	// I've split this data into a *separate* set of data which should only need
+	// to exist for the 3 hardcoded weapon types that use this.
+	switch (weapon_id) // filter out weapons that don't use this hardcode
+	{
+		case wMagic:
+		case ewMagic:
+		case ewFireball:
+			break;
+		default:
+			return;
+	}
+	auto& offset = lens_hint_weapon_offsets[weapon_id];
+	switch (weapon_id)
+	{
+		case wMagic:
+		{
+			--offset.y;
+			if(offset.y < -8)
+				offset.y = 8;
+			break;
+		}
+		case ewMagic:
+		{
+			if(offset.dir == up)
+				--offset.y;
+			else
+				++offset.y;
+			
+			if(offset.y > 8)
+				offset.dir = up;
+			
+			if(offset.y <= 0)
+				offset.dir = down;
+			break;
+		}
+		case ewFireball:
+		{
+			++offset.x;
+			
+			if(offset.x > 8)
+			{
+				offset.x = -8;
+				offset.y = 8;
+			}
+			
+			if(offset.x > 0)
+				++offset.y;
+			else
+				--offset.y;
+			break;
+		}
+	}
+}
+void draw_lens_hint_sprite(BITMAP *dest, int32_t x, int32_t y, int32_t sprite_id, int type, int dir, int parentid, bool peek, int weapon_id)
+{
+#ifdef IS_PLAYER
+	// In all honesty, these look buggy AF if more than one of the same
+	// is on-screen, because each one is one frame advanced in the animation
+	// from the previous. Should ideally overhaul these hints to update animation
+	// globally instead of during each draw, so the animations don't do this.
+	// Out of scope for current changes, so leaving for future fixing. -Em
+	LensHintData data = lens_hint_sprite.get(sprite_id);
+	if (weapon_id > -1)
+	{
+		auto const& offset = lens_hint_weapon_offsets.get(weapon_id);
+		if (weapon_id == ewMagic)
+			dir = offset.dir;
+		x += offset.x;
+		y += offset.y;
+	}
+	weapon temp((zfix)x,(zfix)y,(zfix)0,sprite_id,type,0,dir,-1,parentid,true);
+	temp.ignoreHero = true;
+	temp.fake_weapon = true;
+	temp.yofs = 0;
+	temp.clk2 = data.aclk;
+	temp.aframe = data.aframe;
+	temp.script = 0; // ensure no scripts
+	temp.animate(0);
+	temp.draw(dest);
+	
+	if (peek) return;
+	data.aclk = temp.clk2;
+	data.aframe = temp.aframe;
+	
+	if (data.empty())
+		lens_hint_sprite.erase(sprite_id);
+	else
+		lens_hint_sprite[sprite_id] = data;
+#endif
+}
+void reset_lens_hints()
 {
 	lens_hint_item.clear();
+	lens_hint_sprite.clear();
+	lens_hint_weapon_offsets.clear();
 }
 
 void dummyitem_animate(item* dummy, int32_t clk)
@@ -1050,8 +1157,6 @@ const char *old_weapon_string[wLast] =
 	"Fire Trail (Enemy)", "Fire 2 (Enemy)", "Fire 2 Trail (Enemy) <Unused>", "Ice Magic (Enemy) <Unused>", "MISC: Hover Boots Glow", "Magic (Fire)", "MISC: Quarter Hearts", "Cane of Byrna (Beam)" /*, "MISC: Sideview Ladder", "MISC: Sideview Raft"*/
 };
 
-char *weapon_string[MAXWPNS];
-
 ALLEGRO_COLOR item::hitboxColor(byte opacity) const
 {
 	return al_map_rgba(0,255,255,opacity);
@@ -1226,16 +1331,8 @@ void itemdata::advpaste(itemdata const& other, bitstring const& pasteflags)
 		ltm = other.ltm;
 	if(pasteflags.get(ITM_ADVP_SPRITES))
 	{
-		wpn = other.wpn;
-		wpn2 = other.wpn2;
-		wpn3 = other.wpn3;
-		wpn4 = other.wpn4;
-		wpn5 = other.wpn5;
-		wpn6 = other.wpn6;
-		wpn7 = other.wpn7;
-		wpn8 = other.wpn8;
-		wpn9 = other.wpn9;
-		wpn10 = other.wpn10;
+		for (int q = 0; q < 10; ++q)
+			wpn_sprites[q] = other.wpn_sprites[q];
 		CPYFLAG(weap_data.wflags, WFLAG_UPDATE_IGNITE_SPRITE, other.weap_data.wflags);
 		CPYFLAG(weap_data.flags, wdata_glow_rad, other.weap_data.flags);
 		for(int q = 0; q < WPNSPR_MAX; ++q)

--- a/src/items.h
+++ b/src/items.h
@@ -124,7 +124,9 @@ void putitem(BITMAP *dest,int32_t x,int32_t y,int32_t item_id);
 void putitem3(BITMAP *dest,int32_t x,int32_t y,int32_t item_id, int32_t clk);
 
 void draw_lens_hint_item(BITMAP *dest, int32_t x, int32_t y, int32_t item_id, int32_t flash);
-void reset_lens_hint_items();
+void update_lens_hint_weapon(int weapon_id);
+void draw_lens_hint_sprite(BITMAP *dest, int32_t x, int32_t y, int32_t sprite_id, int type, int dir, int parentid, bool peek = false, int weapon_id = -1);
+void reset_lens_hints();
 
 void dummyitem_animate(item* dummy, int32_t clk);
 
@@ -176,16 +178,7 @@ struct itemdata
     word playsound = WAV_SCALE;
     word collect_script;
     int32_t initiald[INITIAL_D];
-    byte wpn;
-    byte wpn2;
-    byte wpn3;
-    byte wpn4;
-    byte wpn5;
-    byte wpn6;
-    byte wpn7;
-    byte wpn8;
-    byte wpn9;
-    byte wpn10;
+	word wpn_sprites[10];
     byte pickup_hearts;
     int32_t misc1;
     int32_t misc2;

--- a/src/new_subscr.cpp
+++ b/src/new_subscr.cpp
@@ -978,7 +978,7 @@ int32_t SubscrColorInfo::get_cset(byte type, int16_t color)
 					break;
 					
 				case sscsSSVINECSET:
-					ret=wpnsbuf[iwSubscreenVine].csets&15;
+					ret=sprite_data_buf.get(iwSubscreenVine).csets&15;
 					break;
 					
 				default:
@@ -4490,9 +4490,9 @@ int32_t SW_MiniTile::get_tile() const
 		switch(special_tile)
 		{
 			case ssmstSSVINETILE:
-				return wpnsbuf[iwSubscreenVine].tile;
+				return sprite_data_buf.get(iwSubscreenVine).tile;
 			case ssmstMAGICMETER:
-				return wpnsbuf[iwMMeter].tile;
+				return sprite_data_buf.get(iwMMeter).tile;
 			default:
 				return (zc_oldrand()*100000)%32767;
 		}

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -1389,8 +1389,9 @@ void sprite::draw(BITMAP* dest)
 		isspawning = true;
 		if(e!=3) //if extend != 3 
 		{
-			int32_t t  = wpnsbuf[spr_spawn].tile;
-			int32_t cs2 = wpnsbuf[spr_spawn].csets&15;
+			auto const& spawnspr = sprite_data_buf.get(spr_spawn);
+			int32_t t  = spawnspr.tile;
+			int32_t cs2 = spawnspr.cs();
             
 			if(!get_qr(qr_HARDCODED_ENEMY_ANIMS))
 			{
@@ -1402,8 +1403,8 @@ void sprite::draw(BITMAP* dest)
 				if(clk==-1 && spr_spawn_anim_clk>-1)
 				{
 					--clk;
-					spr_spawn_anim_frm=(spr_spawn_anim_clk/zc_max(wpnsbuf[spr_spawn].speed,1));
-					if(++spr_spawn_anim_clk >= (zc_max(wpnsbuf[spr_spawn].speed,1) * zc_max(wpnsbuf[spr_spawn].frames,1)))
+					spr_spawn_anim_frm=(spr_spawn_anim_clk/zc_max(spawnspr.speed,1));
+					if(++spr_spawn_anim_clk >= spawnspr.total_duration())
 					{
 						spr_spawn_anim_clk=-1;
 						clk=-1;
@@ -1428,7 +1429,8 @@ void sprite::draw(BITMAP* dest)
 		}
 		else //extend == 3?
 		{
-			sprite w((zfix)sx,(zfix)sy,wpnsbuf[extend].tile,wpnsbuf[extend].csets&15,0,0,0);
+			auto const& extendspr = sprite_data_buf.get(extend);
+			sprite w((zfix)sx,(zfix)sy,extendspr.tile,extendspr.cs(),0,0,0);
 			w.xofs = xofs;
 			w.yofs = yofs;
 			w.zofs = zofs;
@@ -1796,8 +1798,9 @@ void sprite::drawzcboss(BITMAP* dest)
 	{
 		if(e!=3)
 		{
-			int32_t t  = wpnsbuf[spr_spawn].tile;
-			int32_t cs2 = wpnsbuf[spr_spawn].csets&15;
+			auto const& spawnspr = sprite_data_buf.get(spr_spawn);
+			int32_t t  = spawnspr.tile;
+			int32_t cs2 = spawnspr.cs();
             
 			if(!get_qr(qr_HARDCODED_ENEMY_ANIMS))
 			{
@@ -1809,8 +1812,8 @@ void sprite::drawzcboss(BITMAP* dest)
 				if(clk==-1 && spr_spawn_anim_clk>-1)
 				{
 					--clk;
-					spr_spawn_anim_frm=(spr_spawn_anim_clk/zc_max(wpnsbuf[spr_spawn].speed,1));
-					if(++spr_spawn_anim_clk >= (zc_max(wpnsbuf[spr_spawn].speed,1) * zc_max(wpnsbuf[spr_spawn].frames,1)))
+					spr_spawn_anim_frm=(spr_spawn_anim_clk/zc_max(spawnspr.speed,1));
+					if(++spr_spawn_anim_clk >= spawnspr.total_duration())
 					{
 						spr_spawn_anim_clk=-1;
 						clk=-1;
@@ -1835,7 +1838,8 @@ void sprite::drawzcboss(BITMAP* dest)
 		}
 		else
 		{
-			sprite w((zfix)sx,(zfix)sy,wpnsbuf[extend].tile,wpnsbuf[extend].csets&15,0,0,0);
+			auto const& extendspr = sprite_data_buf.get(extend);
+			sprite w((zfix)sx,(zfix)sy,extendspr.tile,extendspr.cs(),0,0,0);
 			w.xofs = xofs;
 			w.yofs = yofs;
 			w.zofs = zofs;
@@ -1953,8 +1957,9 @@ void sprite::drawcloaked(BITMAP* dest)
     }
     else
     {
-        int32_t t  = wpnsbuf[spr_spawn].tile;
-        int32_t cs2 = wpnsbuf[spr_spawn].csets&15;
+		auto const& spawnspr = sprite_data_buf.get(spr_spawn);
+        int32_t t  = spawnspr.tile;
+        int32_t cs2 = spawnspr.cs();
         
 		if(!get_qr(qr_HARDCODED_ENEMY_ANIMS))
 		{
@@ -1966,8 +1971,8 @@ void sprite::drawcloaked(BITMAP* dest)
 			if(clk==-1 && spr_spawn_anim_clk>-1)
 			{
 				--clk;
-				spr_spawn_anim_frm=(spr_spawn_anim_clk/zc_max(wpnsbuf[spr_spawn].speed,1));
-				if(++spr_spawn_anim_clk >= (zc_max(wpnsbuf[spr_spawn].speed,1) * zc_max(wpnsbuf[spr_spawn].frames,1)))
+				spr_spawn_anim_frm=(spr_spawn_anim_clk/zc_max(spawnspr.speed,1));
+				if(++spr_spawn_anim_clk >= spawnspr.total_duration())
 				{
 					spr_spawn_anim_clk=-1;
 					clk=-1;
@@ -2016,8 +2021,9 @@ void sprite::drawshadow(BITMAP* dest,bool translucent)
 	//int32_t sy1 = sx-56; //subscreen offset
 	//if ( ispitfall(x+xofs, y+yofs+16) || ispitfall(x+xofs+8, y+yofs+16) || ispitfall(x+xofs+15, y+yofs+16)  ) return;
 	//sWTF, why is this offset by half the screen. Can't do this right now. Sanity. -Z
-	int32_t shadowcs = wpnsbuf[spr_shadow].csets & 0xFFFF;
-	int32_t shadowflip = wpnsbuf[spr_shadow].misc & 0xFF;
+	auto const& shadowspr = sprite_data_buf.get(spr_shadow);
+	int32_t shadowcs = shadowspr.cs();
+	int32_t shadowflip = shadowspr.flip();
 	//if ( !ispitfall(sx,sy+4) && !ispitfall(sx+8,sy+4) )
 	{
 		if(clk>=0)
@@ -2797,9 +2803,9 @@ void movingblock::draw(BITMAP *dest)
 		newcombo const& cmb = combobuf[bcombo];
 		if(cmb.spr_falling)
 			sprid = cmb.spr_falling;
-		if(unsigned(sprid) < MAXWPNS)
+		if(unsigned(sprid) < MAXSPRITES)
 		{
-			wpndata& spr = wpnsbuf[sprid];
+			sprite_data const& spr = sprite_data_buf.get(sprid);
 			cs = spr.csets & 0xF;
 			int32_t fr = spr.frames ? spr.frames : 1;
 			int32_t spd = spr.speed ? spr.speed : 1;
@@ -2821,9 +2827,9 @@ void movingblock::draw(BITMAP *dest)
 		newcombo const& cmb = combobuf[bcombo];
 		if(int cspr = lava ? cmb.spr_lava_drowning : cmb.spr_drowning)
 			sprid = cspr;
-		if(unsigned(sprid) < MAXWPNS)
+		if(unsigned(sprid) < MAXSPRITES)
 		{
-			wpndata &spr = wpnsbuf[sprid];
+			sprite_data const& spr = sprite_data_buf.get(sprid);
 			cs = spr.csets & 0xF;
 			int32_t fr = spr.frames ? spr.frames : 1;
 			int32_t spd = spr.speed ? spr.speed : 1;
@@ -2871,7 +2877,7 @@ portal::portal(int32_t dm, int32_t scr, int32_t gfx, int32_t sfx, int32_t spr)
 }
 void portal::LOADGFX(int32_t spr)
 {
-	wpndata const& portalsprite = wpnsbuf[spr];
+	sprite_data const& portalsprite = sprite_data_buf.get(spr);
 	o_tile = portalsprite.tile;
 	aspd = portalsprite.speed ? portalsprite.speed : 1;
 	frames = portalsprite.frames ? portalsprite.frames : 1;

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -8,12 +8,12 @@
 #include <map>
 #include "solidobject.h"
 #include "core/cpos_info.h"
+#include "base/containers.h"
 
 struct itemdata;
 struct newcombo;
 using std::map;
 
-extern wpndata  *wpnsbuf;
 extern bool     freeze_guys;
 extern int32_t fadeclk;
 extern int32_t frame;
@@ -130,7 +130,7 @@ public:
 	bool hide_hitbox;
     bool behind;
 	
-	byte spr_shadow, spr_death, spr_spawn;
+	word spr_shadow, spr_death, spr_spawn;
 	int16_t spr_death_anim_clk, spr_spawn_anim_clk;
 	byte spr_death_anim_frm, spr_spawn_anim_frm;
 	

--- a/src/sprite_data.cpp
+++ b/src/sprite_data.cpp
@@ -1,0 +1,92 @@
+#include "sprite_data.h"
+#include "items.h"
+
+void mark_save_dirty();
+bounded_vec<word, sprite_data> sprite_data_buf = {MAXSPRITES};
+
+void sprite_data::load_item(itemdata const& itm)
+{
+	tile = itm.tile;
+	misc = itm.misc_flags;
+	csets = itm.csets;
+	frames = itm.frames;
+	speed = itm.speed;
+	type = itm.delay;
+}
+
+
+// For deleting / moving quest sprites, updating references to affected sprites
+static void update_quest_sprites(std::map<size_t, size_t> changes)
+{
+	// TODO: This will take a lot of work, and won't help any hardcoded sprite IDs.
+	// For now just going to warn that Sprites won't be updated;
+	// can come back to this later when more Sprite hardcodes have been removed.
+	// -Em
+	
+	for (auto it = changes.begin(); it != changes.end();) // trim non-changes
+	{
+		if (it->first == it->second)
+			it = changes.erase(it);
+		else ++it;
+	}
+	if (changes.empty())
+		return;
+	
+	mark_save_dirty();
+}
+void delete_quest_sprites(std::function<bool(sprite_data const&)> proc)
+{
+	size_t del_count = 0;
+	std::map<size_t, size_t> changes;
+	auto& cont = sprite_data_buf.mut_inner();
+	size_t sz = cont.size();
+	auto it = cont.begin();
+	for (size_t q = 0; q < sz; ++q)
+	{
+		if (proc(*it))
+		{
+			it = cont.erase(it);
+			changes[q] = -1;
+			++del_count;
+		}
+		else
+		{
+			++it;
+			if (del_count)
+				changes[q] = q - del_count;
+		}
+	}
+	update_quest_sprites(changes);
+}
+void delete_quest_sprites(size_t idx)
+{
+	if (unsigned(idx) >= sprite_data_buf.capacity()) return;
+	std::map<size_t, size_t> changes;
+	auto& cont = sprite_data_buf.mut_inner();
+	size_t sz = cont.size();
+	auto it = cont.begin();
+	for (size_t q = 0; q < sz; ++q)
+	{
+		if (q == idx)
+		{
+			it = cont.erase(it);
+			changes[q] = -1;
+		}
+		else
+		{
+			++it;
+			if (q > idx)
+				changes[q] = q - 1;
+		}
+	}
+	update_quest_sprites(changes);
+}
+void swap_quest_sprites(size_t idx1, size_t idx2)
+{
+	if (unsigned(idx1) >= MAXSPRITES ||
+		unsigned(idx2) >= MAXSPRITES ||
+		idx1 == idx2) return;
+	zc_swap_mv(sprite_data_buf[idx1], sprite_data_buf[idx2]);
+	update_quest_sprites({{idx1, idx2},{idx2, idx1}});
+}
+

--- a/src/sprite_data.h
+++ b/src/sprite_data.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "base/containers.h"
+
+struct itemdata;
+
+struct sprite_data
+{
+	std::string name;
+	int32_t tile;
+	byte misc;         // 000bvhff (vh:flipping, f:flash (1:NES, 2:BSZ))
+	byte csets;        // ffffcccc (f:flash cset, c:cset)
+	byte frames;       // animation frame count
+	byte speed;        // animation speed
+	byte type;         // used by certain weapons
+	word script;
+	
+	byte flip() const
+	{
+		return (misc >> 2) & 0b11;
+	}
+	byte cs() const
+	{
+		return csets & 0xF;
+	}
+	word total_duration(bool min1 = true) const
+	{
+		if (min1)
+			return zc_max(1, frames) * zc_max(1, speed);
+		return frames * speed;
+	}
+	void clear()
+	{
+		*this = sprite_data();
+	}
+	void load_item(itemdata const& itm);
+	bool operator==(sprite_data const& other) const = default;
+};
+
+extern bounded_vec<word, sprite_data> sprite_data_buf;
+
+void delete_quest_sprites(std::function<bool(itemdata const&)> proc);
+void delete_quest_sprites(size_t idx);
+void swap_quest_sprites(size_t idx1, size_t idx2);
+

--- a/src/subscr.cpp
+++ b/src/subscr.cpp
@@ -2559,7 +2559,7 @@ void lifemeter(BITMAP *dest,int32_t x,int32_t y,int32_t cs,bool bs_style)
 		y+=24;
 	}
 	int32_t tile = 0;
-	const int32_t basetile = wpnsbuf[iwQuarterHearts].tile;
+	const int32_t basetile = sprite_data_buf.get(iwQuarterHearts).tile;
 	const int32_t max_iter = (game != NULL ? zc_min(game->get_maxlife(),game->get_hp_per_heart()*24) : 1);
 	const int32_t inc = (game != NULL ? game->get_hp_per_heart() : 16);
 	
@@ -2677,8 +2677,9 @@ void magicmeter(BITMAP *dest,int32_t x,int32_t y)
     if(game->get_maxmagic()==0) return;
     
     int32_t tile;
-    int32_t mmtile=wpnsbuf[iwMMeter].tile;
-    int32_t mmcset=wpnsbuf[iwMMeter].csets&15;
+	auto const& mmspr = sprite_data_buf.get(iwMMeter);
+    int32_t mmtile = mmspr.tile;
+    int32_t mmcset = mmspr.csets&15;
     overtile8(dest,(mmtile*4)+2,x-8,y,mmcset,0);
     
     if(game->get_magicdrainrate()==1)
@@ -2930,7 +2931,7 @@ int32_t subscreen_cset(int32_t c1, int32_t c2)
             break;
             
         case sscsSSVINECSET:
-            ret=wpnsbuf[iwSubscreenVine].csets&15;
+            ret = sprite_data_buf.get(iwSubscreenVine).csets&15;
             break;
             
         default:

--- a/src/tiles.cpp
+++ b/src/tiles.cpp
@@ -14,7 +14,6 @@
 #include "zc/maps.h"
 #include "items.h"
 
-extern wpndata    *wpnsbuf;
 tiledata *newtilebuf, *grabtilebuf;
 int32_t animated_combo_table[MAXCOMBOS][2];                    //[0]=position in act2, [1]=original tile
 int32_t animated_combo_table4[MAXCOMBOS][2];                   //[0]=combo, [1]=clock

--- a/src/zc/decorations.cpp
+++ b/src/zc/decorations.cpp
@@ -6,6 +6,7 @@
 #include "zc/maps.h"
 #include "zalleg/zsys.h"
 #include "zc/hero.h"
+#include "sprite_data.h"
 
 decoration::decoration(zfix X,zfix Y,int32_t Id,int32_t Clk, int32_t wpnSpr) : sprite()
 {
@@ -17,7 +18,7 @@ decoration::decoration(zfix X,zfix Y,int32_t Id,int32_t Clk, int32_t wpnSpr) : s
 	misc = 0;
 	yofs = (get_qr(qr_OLD_DRAWOFFSET)?playing_field_offset:original_playing_field_offset);
 	if(get_qr(qr_DECO_2_YOFFSET)) yofs -= 2;
-	the_deco_sprite = vbound(wpnSpr,0,255);
+	the_deco_sprite = vbound(wpnSpr,0,MAXSPRITES-1);
 }
 
 decoration::~decoration() {}
@@ -33,7 +34,7 @@ dBushLeaves::dBushLeaves(zfix X,zfix Y,int32_t Id,int32_t Clk, int32_t wpnSpr) :
 	oy=Y;
 	id=Id;
 	clk=Clk;
-	the_deco_sprite = vbound(wpnSpr,0,255);
+	the_deco_sprite = vbound(wpnSpr,0,MAXSPRITES-1);
 	static bool initialized=false;
 	if(!initialized)
 	{
@@ -154,18 +155,9 @@ void dBushLeaves::draw(BITMAP *dest)
 		return;
 	}
 	int32_t t=0;
-	if ( the_deco_sprite )
-	{
-		t=wpnsbuf[the_deco_sprite].tile;
-		cs=wpnsbuf[the_deco_sprite].csets&15;
-		
-	}
-	else
-	{
-		t=wpnsbuf[iwBushLeaves].tile;
-		cs=wpnsbuf[iwBushLeaves].csets&15;
-		
-	}
+	auto const& wspr = sprite_data_buf.get(the_deco_sprite ? the_deco_sprite : iwBushLeaves);
+	t = wspr.tile;
+	cs = wspr.cs();
 	
 	for(int32_t i=0; i<4; ++i)
 	{
@@ -184,15 +176,16 @@ comboSprite::comboSprite(zfix X,zfix Y,int32_t Id,int32_t Clk, int32_t wpnSpr) :
 	id=Id;
 	clk=Clk;
 	
-	the_deco_sprite = vbound(wpnSpr,0,255);
-	tframes = wpnsbuf[the_deco_sprite].frames;
-	spd = wpnsbuf[the_deco_sprite].speed;
+	the_deco_sprite = vbound(wpnSpr,0,MAXSPRITES-1);
+	auto const& wspr = sprite_data_buf.get(the_deco_sprite);
+	tframes = wspr.frames;
+	spd = wspr.speed;
 }
 
 bool comboSprite::animate(int32_t)
 {
-	int32_t dur = zc_max(1,wpnsbuf[the_deco_sprite].frames) * zc_max(1,wpnsbuf[the_deco_sprite].speed);
-	return (clk++>=dur);
+	auto const& wspr = sprite_data_buf.get(the_deco_sprite);
+	return (clk++ >= wspr.total_duration());
 }
 
 void comboSprite::realdraw(BITMAP *dest, int32_t draw_what)
@@ -200,11 +193,11 @@ void comboSprite::realdraw(BITMAP *dest, int32_t draw_what)
 	if(misc!=draw_what || the_deco_sprite < 0)
 		return;
 	
-	int32_t fb=the_deco_sprite;
-	int32_t t=wpnsbuf[fb].tile;
-	int32_t fr=zc_max(1,wpnsbuf[fb].frames);
-	int32_t spd=zc_max(1,wpnsbuf[fb].speed);
-	cs=wpnsbuf[fb].csets&15;
+	auto const& wspr = sprite_data_buf.get(the_deco_sprite);
+	int32_t t = wspr.tile;
+	int32_t fr = zc_max(1,wspr.frames);
+	int32_t spd = zc_max(1,wspr.speed);
+	cs = wspr.csets&15;
 	flip=0;
 	
 	tile = t+(((clk-1)/spd)%fr);
@@ -228,7 +221,7 @@ dFlowerClippings::dFlowerClippings(zfix X,zfix Y,int32_t Id,int32_t Clk, int32_t
 	oy=Y;
 	id=Id;
 	clk=Clk;
-	the_deco_sprite = vbound(wpnSpr,0,255);
+	the_deco_sprite = vbound(wpnSpr,0,MAXSPRITES-1);
 	static bool initialized=false;
 	if(!initialized)
 	{
@@ -351,19 +344,9 @@ void dFlowerClippings::draw(BITMAP *dest)
 	
 	int32_t t=0;
 	
-	if ( the_deco_sprite )
-	{
-		t=wpnsbuf[the_deco_sprite].tile;
-		cs=wpnsbuf[the_deco_sprite].csets&15;
-		
-	}
-	else
-	{
-		t=wpnsbuf[iwFlowerClippings].tile;
-		cs=wpnsbuf[iwFlowerClippings].csets&15;
-		
-	}
-	
+	auto const& wspr = sprite_data_buf.get(the_deco_sprite ? the_deco_sprite : iwFlowerClippings);
+	t = wspr.tile;
+	cs = wspr.cs();
 	
 	for(int32_t i=0; i<4; ++i)
 	{
@@ -381,7 +364,7 @@ dGrassClippings::dGrassClippings(zfix X,zfix Y,int32_t Id,int32_t Clk, int32_t w
 	oy=Y;
 	id=Id;
 	clk=Clk;
-	the_deco_sprite = vbound(wpnSpr,0,255);
+	the_deco_sprite = vbound(wpnSpr,0,MAXSPRITES-1);
 	static bool initialized=false;
 	if(!initialized)
 	{
@@ -455,18 +438,9 @@ void dGrassClippings::draw(BITMAP *dest)
 	
 	int32_t t=0;
 	
-	if ( the_deco_sprite )
-	{
-		t=wpnsbuf[the_deco_sprite].tile;
-		cs=wpnsbuf[the_deco_sprite].csets&15;
-		
-	}
-	else
-	{
-		t=wpnsbuf[iwGrassClippings].tile;
-		cs=wpnsbuf[iwGrassClippings].csets&15;
-		
-	}
+	auto const& wspr = sprite_data_buf.get(the_deco_sprite ? the_deco_sprite : iwGrassClippings);
+	t = wspr.tile;
+	cs = wspr.cs();
 	
 	for(int32_t i=0; i<3; ++i)
 	{
@@ -484,7 +458,7 @@ dHammerSmack::dHammerSmack(zfix X,zfix Y,int32_t Id,int32_t Clk, int32_t wpnSpr)
 	oy=Y;
 	id=Id;
 	clk=Clk;
-	the_deco_sprite = vbound(wpnSpr,0,255);
+	the_deco_sprite = vbound(wpnSpr,0,MAXSPRITES-1);
 	static bool initialized=false;
 	if(!initialized)
 	{
@@ -517,7 +491,7 @@ dHammerSmack::dHammerSmack(zfix X,zfix Y,int32_t Id,int32_t Clk, int32_t wpnSpr)
 		ft[1][3][2]=1;
 	}
 	
-	wpnid = get_item_data(current_item_id(itype_hammer)).wpn2;
+	wpnid = get_item_data(current_item_id(itype_hammer)).wpn_sprites[1];
 }
 
 bool dHammerSmack::animate(int32_t)
@@ -533,8 +507,9 @@ void dHammerSmack::draw(BITMAP *dest)
 		return;
 	}
 	
-	int32_t t=wpnsbuf[wpnid].tile;
-	cs=wpnsbuf[wpnid].csets&15;
+	auto const& wspr = sprite_data_buf.get(wpnid);
+	int32_t t = wspr.tile;
+	cs = wspr.cs();
 	flip=0;
 	
 	for(int32_t i=0; i<2; ++i)
@@ -570,16 +545,9 @@ void dTallGrass::draw(BITMAP *dest)
 		return;
 		
 	int32_t t=0;
-	if ( the_deco_sprite )
-	{
-		t=wpnsbuf[the_deco_sprite].tile*4;
-		cs=wpnsbuf[the_deco_sprite].csets&15;
-	}
-	else
-	{
-		t=wpnsbuf[iwTallGrass].tile*4;
-		cs=wpnsbuf[iwTallGrass].csets&15;
-	}
+	auto const& wspr = sprite_data_buf.get(the_deco_sprite ? the_deco_sprite : iwTallGrass);
+	t = wspr.tile*4;
+	cs = wspr.cs();
 	
 	flip=0;
 	x=HeroX();
@@ -642,16 +610,9 @@ void dRipples::draw(BITMAP *dest)
 	
 	int32_t t=0;
 	
-	if ( the_deco_sprite )
-	{
-		t=wpnsbuf[the_deco_sprite].tile*4;
-		cs=wpnsbuf[the_deco_sprite].csets&15;
-	}
-	else
-	{
-		t=wpnsbuf[iwRipples].tile*4;
-		cs=wpnsbuf[iwRipples].csets&15;
-	}
+	auto const& wspr = sprite_data_buf.get(the_deco_sprite ? the_deco_sprite : iwRipples);
+	t = wspr.tile*4;
+	cs = wspr.cs();
 	
 	flip=0;
 	x=HeroX();
@@ -667,13 +628,14 @@ dHover::dHover(zfix X,zfix Y,int32_t Id,int32_t Clk, int32_t wpnSpr) : decoratio
 {
 	id=Id;
 	clk=Clk;
-	wpnid = get_item_data(current_item_id(itype_hoverboots)).wpn;
+	wpnid = get_item_data(current_item_id(itype_hoverboots)).wpn_sprites[0];
 }
 
 void dHover::draw(BITMAP *dest)
 {
-	int32_t t=wpnsbuf[wpnid].tile*4;
-	cs=wpnsbuf[wpnid].csets&15;
+	auto const& wspr = sprite_data_buf.get(wpnid);
+	int32_t t = wspr.tile*4;
+	cs = wspr.cs();
 	flip=0;
 	x=HeroX();
 	y=HeroY()+10-HeroZ()-HeroFakeZ();
@@ -710,15 +672,21 @@ void dDivineProtectionShield::realdraw(BITMAP *dest, int32_t draw_what)
 	}
 	
 	auto const& divine_prot = get_item_data(current_item_id(itype_divineprotection));
-	int32_t fb=(misc==0?
-	        (divine_prot.wpn5 ?
-	         divine_prot.wpn5 : (byte) iwDivineProtectionShieldFront) :
-	            (divine_prot.wpn10 ?
-	             divine_prot.wpn10 : (byte) iwDivineProtectionShieldBack));
-	int32_t t=wpnsbuf[fb].tile;
-	int32_t fr=wpnsbuf[fb].frames;
-	int32_t spd=wpnsbuf[fb].speed;
-	cs=wpnsbuf[fb].csets&15;
+	int32_t fb;
+	if (misc == 0)
+	{
+		if (auto v = divine_prot.wpn_sprites[4])
+			fb = v;
+		else fb = iwDivineProtectionShieldFront;
+	}
+	else if (auto v = divine_prot.wpn_sprites[9])
+		fb = v;
+	else fb = iwDivineProtectionShieldBack;
+	auto const& wspr = sprite_data_buf.get(fb);
+	int32_t t = wspr.tile;
+	int32_t fr = wspr.frames;
+	int32_t spd = wspr.speed;
+	cs = wspr.cs();
 	flip=0;
 	bool flickering = (divine_prot.flags & item_flag4) != 0;
 	bool translucent = (divine_prot.flags & item_flag3) != 0;
@@ -772,9 +740,8 @@ bool customWalkSprite::animate(int32_t)
 	else return true;
 	if(!(bits & 0b10))
 		return false;
-	auto const& wspr = wpnsbuf[the_deco_sprite];
-	int32_t dur = zc_max(1,wspr.frames) * zc_max(1,wspr.speed);
-	clk = (clk+1)%dur;
+	auto const& wspr = sprite_data_buf.get(the_deco_sprite);
+	clk = (clk+1) % wspr.total_duration();
 	return false;
 }
 
@@ -784,7 +751,7 @@ void customWalkSprite::realdraw(BITMAP *dest, int32_t draw_what)
 		return;
 	bits |= 0b10;
 	
-	auto const& wspr = wpnsbuf[the_deco_sprite];
+	auto const& wspr = sprite_data_buf.get(the_deco_sprite);
 	int32_t t=wspr.tile;
 	int32_t fr=zc_max(1,wspr.frames);
 	int32_t spd=zc_max(1,wspr.speed);

--- a/src/zc/ffscript.cpp
+++ b/src/zc/ffscript.cpp
@@ -21730,8 +21730,11 @@ void do_createlweapon(const bool v)
 
 void do_createeweapon(const bool v)
 {
-	const int32_t ID = SH::get_arg(sarg1, v) / 10000;
+	int32_t ID = SH::get_arg(sarg1, v) / 10000;
 	
+	if (ID >= wMax && replay_is_active() && replay_get_meta_str("qst") == "terror_of_necromancy_demo5.qst")
+		ID = wScript10;
+		
 	if(BC::checkWeaponID(ID) != SH::_NoError)
 		return;
 		

--- a/src/zc/ffscript.cpp
+++ b/src/zc/ffscript.cpp
@@ -2671,10 +2671,10 @@ item_drop_object *checkDropSetData(int32_t ref)
 	return NULL;
 }
 
-wpndata *checkSpriteData(int32_t ref)
+sprite_data *checkSpriteData(int32_t ref)
 {
-	if(ref > 0 && ref < MAXWPNS)
-		return &wpnsbuf[ref];
+	if(ref > 0 && ref < MAXSPRITES)
+		return &sprite_data_buf[ref];
 
 	scripting_log_error_with_context("Invalid {} using UID = {}", "spritedata", ref);
 	return NULL;
@@ -2997,13 +2997,13 @@ int32_t get_register(int32_t arg)
 
 	#define GET_SPRITEDATA_VAR_INT(member) \
 	{ \
-		if(unsigned(GET_REF(spritedataref)) > (MAXWPNS-1) )    \
+		if(unsigned(GET_REF(spritedataref)) > (MAXSPRITES-1) )    \
 		{ \
 			ret = -10000; \
 			scripting_log_error_with_context("Invalid Sprite ID: {}", GET_REF(spritedataref)*10000); \
 		} \
 		else \
-			ret = (wpnsbuf[GET_REF(spritedataref)].member * 10000); \
+			ret = (sprite_data_buf.get(GET_REF(spritedataref)).member * 10000); \
 	}
 
 	current_zasm_register = arg;
@@ -6202,7 +6202,7 @@ int32_t get_register(int32_t arg)
 		case SPRITEDATATYPE: GET_SPRITEDATA_VAR_INT(type) break;
 		case SPRITEDATAID:
 		{
-			if(unsigned(GET_REF(spritedataref)) > (MAXWPNS-1) )
+			if(unsigned(GET_REF(spritedataref)) > (MAXSPRITES-1) )
 			{
 				ret = -10000;
 				Z_scripterrlog("Invalid Sprite ID passed to spritedata->ID: %d\n", GET_REF(spritedataref));
@@ -10397,25 +10397,25 @@ void set_register(int32_t arg, int32_t value)
 	
 	#define	SET_SPRITEDATA_VAR_INT(member, str) \
 	{ \
-		if(unsigned(GET_REF(spritedataref)) > (MAXWPNS-1) ) \
+		if(unsigned(GET_REF(spritedataref)) > (MAXSPRITES-1) ) \
 		{ \
 			Z_scripterrlog("Invalid Sprite ID passed to spritedata->%s: %d\n", str, GET_REF(spritedataref)); \
 		} \
 		else \
 		{ \
-			wpnsbuf[GET_REF(spritedataref)].member = vbound((value / 10000),0,214747); \
+			sprite_data_buf[GET_REF(spritedataref)].member = vbound((value / 10000),0,214747); \
 		} \
 	} \
 
 	#define	SET_SPRITEDATA_VAR_BYTE(member, str) \
 	{ \
-		if(unsigned(GET_REF(spritedataref)) > (MAXWPNS-1) ) \
+		if(unsigned(GET_REF(spritedataref)) > (MAXSPRITES-1) ) \
 		{ \
 			Z_scripterrlog("Invalid Sprite ID passed to spritedata->%s: %d\n", str, GET_REF(spritedataref)); \
 		} \
 		else \
 		{ \
-			wpnsbuf[GET_REF(spritedataref)].member = vbound((value / 10000),0,255); \
+			sprite_data_buf[GET_REF(spritedataref)].member = vbound((value / 10000),0,255); \
 		} \
 	} \
 
@@ -12739,7 +12739,7 @@ void set_register(int32_t arg, int32_t value)
 		case LWPNSHADOWSPR:
 			if(auto s=checkLWpn(GET_REF(lwpnref)))
 			{
-				s->spr_shadow = vbound(value/10000, 0, 255);
+				s->spr_shadow = vbound(value/10000, 0, MAXSPRITES-1);
 			}
 			break;
 		case LWSWHOOKED:
@@ -12771,7 +12771,7 @@ void set_register(int32_t arg, int32_t value)
 		case LWPNDEATHSPRITE:
 			if(auto s=checkLWpn(GET_REF(lwpnref)))
 			{
-				s->death_sprite = vbound(value/10000,-255,MAXWPNS-1);
+				s->death_sprite = vbound(value/10000,-255,MAXSPRITES-1);
 			}
 			break;
 		case LWPNDEATHSFX:
@@ -13308,7 +13308,7 @@ void set_register(int32_t arg, int32_t value)
 		case EWPNSHADOWSPR:
 			if(auto s=checkEWpn(GET_REF(ewpnref)))
 			{
-				s->spr_shadow = vbound(value/10000, 0, 255);
+				s->spr_shadow = vbound(value/10000, 0, MAXSPRITES-1);
 			}
 			break;
 		case EWSWHOOKED:
@@ -13339,7 +13339,7 @@ void set_register(int32_t arg, int32_t value)
 		case EWPNDEATHSPRITE:
 			if(auto s=checkEWpn(GET_REF(ewpnref)))
 			{
-				s->death_sprite = vbound(value/10000,-255,MAXWPNS-1);
+				s->death_sprite = vbound(value/10000,-255,MAXSPRITES-1);
 			}
 			break;
 		case EWPNDEATHSFX:
@@ -13783,27 +13783,27 @@ void set_register(int32_t arg, int32_t value)
 		case SPRITEDATAMISC: SET_SPRITEDATA_VAR_BYTE(misc, "Misc"); break;
 		case SPRITEDATACSETS:
 		{
-			if(unsigned(GET_REF(spritedataref)) > (MAXWPNS-1) )
+			if(unsigned(GET_REF(spritedataref)) > (MAXSPRITES-1) )
 			{
 				Z_scripterrlog("Invalid Sprite ID passed to spritedata->CSet: %d\n", GET_REF(spritedataref));
 			}
 			else
 			{
-				wpnsbuf[GET_REF(spritedataref)].csets &= 0xF0;
-				wpnsbuf[GET_REF(spritedataref)].csets |= vbound((value / 10000),0,15);
+				sprite_data_buf[GET_REF(spritedataref)].csets &= 0xF0;
+				sprite_data_buf[GET_REF(spritedataref)].csets |= vbound((value / 10000),0,15);
 			}
 			break;
 		}
 		case SPRITEDATAFLCSET:
 		{
-			if(unsigned(GET_REF(spritedataref)) > (MAXWPNS-1) )
+			if(unsigned(GET_REF(spritedataref)) > (MAXSPRITES-1) )
 			{
 				Z_scripterrlog("Invalid Sprite ID passed to spritedata->FlashCSet: %d\n", GET_REF(spritedataref));
 			}
 			else
 			{
-				wpnsbuf[GET_REF(spritedataref)].csets &= 0x0F;
-				wpnsbuf[GET_REF(spritedataref)].csets |= vbound((value / 10000),0,15)<<4;
+				sprite_data_buf[GET_REF(spritedataref)].csets &= 0x0F;
+				sprite_data_buf[GET_REF(spritedataref)].csets |= vbound((value / 10000),0,15)<<4;
 			}
 			break;
 		}
@@ -15050,7 +15050,7 @@ void set_register(int32_t arg, int32_t value)
 		{
 			if (!checkComboRef()) break;
 
-			combobuf[GET_REF(combodataref)].liftsprite = vbound(value/10000, 0, 255);
+			combobuf[GET_REF(combodataref)].liftsprite = vbound(value/10000, 0, MAXSPRITES-1);
 			break;
 		}
 		case COMBODLIFTSFX:
@@ -15064,7 +15064,7 @@ void set_register(int32_t arg, int32_t value)
 		{
 			if (!checkComboRef()) break;
 
-			combobuf[GET_REF(combodataref)].liftbreaksprite = vbound(value/10000, -4, 255);
+			combobuf[GET_REF(combodataref)].liftbreaksprite = vbound(value/10000, -4, MAXSPRITES-1);
 			break;
 		}
 		case COMBODLIFTBREAKSFX:
@@ -15841,19 +15841,19 @@ void set_register(int32_t arg, int32_t value)
 		case NPCDSHADOWSPR:
 		{
 			if (checkNPCDataRef())
-				guysbuf[GET_REF(npcdataref)].spr_shadow = vbound(value/10000, 0, 255);
+				guysbuf[GET_REF(npcdataref)].spr_shadow = vbound(value/10000, 0, MAXSPRITES-1);
 			break;
 		}
 		case NPCDSPAWNSPR:
 		{
 			if (checkNPCDataRef())
-				guysbuf[GET_REF(npcdataref)].spr_spawn = vbound(value/10000, 0, 255);
+				guysbuf[GET_REF(npcdataref)].spr_spawn = vbound(value/10000, 0, MAXSPRITES-1);
 			break;
 		}
 		case NPCDDEATHSPR:
 		{
 			if (checkNPCDataRef())
-				guysbuf[GET_REF(npcdataref)].spr_death = vbound(value/10000, 0, 255);
+				guysbuf[GET_REF(npcdataref)].spr_death = vbound(value/10000, 0, MAXSPRITES-1);
 			break;
 		}
 
@@ -21654,7 +21654,7 @@ void FFScript::do_loadspritedata(const bool v)
 {
 	int32_t ID = SH::get_arg(sarg1, v) / 10000;
 	
-	if ( (unsigned)ID > (MAXWPNS-1) )
+	if ( (unsigned)ID > (MAXSPRITES-1) )
 	{
 		Z_scripterrlog("Invalid Sprite ID passed to Game->LoadSpriteData: %d\n", ID);
 		ri->spritedataref = 0; 

--- a/src/zc/ffscript.h
+++ b/src/zc/ffscript.h
@@ -18,6 +18,7 @@
 #include "zc/jit.h"
 #include "zc/zelda.h"
 #include "zc/hero.h"
+#include "sprite_data.h"
 
 extern std::string current_zasm_context;
 extern std::string current_zasm_extra_context;
@@ -616,7 +617,7 @@ weapon* checkEWpn(int32_t uid);
 bottletype* checkBottleData(int32_t ref, bool skipError = false);
 bottleshoptype *checkBottleShopData(int32_t ref, bool skipError = false);
 item_drop_object *checkDropSetData(int32_t ref);
-wpndata *checkSpriteData(int32_t ref);
+sprite_data *checkSpriteData(int32_t ref);
 MsgStr *checkMessageData(int32_t ref);
 user_genscript *checkGenericScr(int32_t ref);
 SubscrWidget *checkSubWidg(int32_t ref, std::set<int> const& req_sub_tys = {}, int req_widg_ty = -1);
@@ -1361,7 +1362,7 @@ public:
 	
 	static INLINE int32_t checkWeaponMiscSprite(const int32_t ID)
 	{
-		return checkBounds(ID, 0, MAXWPNS-1);
+		return checkBounds(ID, 0, MAXSPRITES-1);
 	}
 	
 	static INLINE int32_t checkSFXID(const int32_t ID)

--- a/src/zc/ffscript.h
+++ b/src/zc/ffscript.h
@@ -1356,7 +1356,7 @@ public:
 	
 	static INLINE int32_t checkWeaponID(const int32_t ID)
 	{
-		return checkBounds(ID, 0, MAXWPNS-1);
+		return checkBounds(ID, 0, wMax-1);
 	}
 	
 	static INLINE int32_t checkWeaponMiscSprite(const int32_t ID)

--- a/src/zc/guys.cpp
+++ b/src/zc/guys.cpp
@@ -1013,7 +1013,7 @@ bool enemy::do_falling(int32_t index)
 			}
 		}
 		
-		wpndata& spr = wpnsbuf[QMisc.sprites[sprFALL]];
+		sprite_data const& spr = sprite_data_buf.get(QMisc.sprites[sprFALL]);
 		cs = spr.csets & 0xF;
 		int32_t fr = spr.frames ? spr.frames : 1;
 		int32_t spd = spr.speed ? spr.speed : 1;
@@ -1054,7 +1054,7 @@ bool enemy::do_drowning(int32_t index)
 		}
 		
 		bool lava = (drownCombo && combobuf[drownCombo].usrflags&cflag1);
-		wpndata &spr = wpnsbuf[QMisc.sprites[lava ? sprLAVADROWN : sprDROWN]];
+		sprite_data const& spr = sprite_data_buf.get(QMisc.sprites[lava ? sprLAVADROWN : sprDROWN]);
 		cs = spr.csets & 0xF;
 		int32_t fr = spr.frames ? spr.frames : 1;
 		int32_t spd = spr.speed ? spr.speed : 1;
@@ -1819,9 +1819,9 @@ void enemy::FireBreath(bool seekhero)
 		ew->angle=fire_angle;
 	}
 	
-	if(wpn==ewFlame && wpnsbuf[ewFLAME].frames>1)
+	if(wpn==ewFlame && sprite_data_buf.get(ewFLAME).frames>1)
 	{
-		ew->aframe=zc_oldrand()%wpnsbuf[ewFLAME].frames;
+		ew->aframe=zc_oldrand()%sprite_data_buf.get(ewFLAME).frames;
 		if ( ew->do_animation ) ew->tile+=ew->aframe;
 	}
 	
@@ -4087,7 +4087,8 @@ void enemy::draw(BITMAP *dest)
 		}
 		
 		flip = 0;
-		tile = wpnsbuf[spr_death].tile;
+		auto const& deathspr = sprite_data_buf.get(spr_death);
+		tile = deathspr.tile;
 		if ( do_animation ) 
 		{
 			int32_t offs = 0;
@@ -4103,11 +4104,11 @@ void enemy::draw(BITMAP *dest)
 				if(clk2==1 && spr_death_anim_clk>-1)
 				{
 					++clk2;
-					spr_death_anim_frm=(spr_death_anim_clk/zc_max(wpnsbuf[spr_death].speed,1));
+					spr_death_anim_frm=(spr_death_anim_clk/zc_max(deathspr.speed,1));
 					spr_death_anim_frm *= zc_max(1,txsz);
 					int32_t rows = TILEROW(tile+spr_death_anim_frm)-TILEROW(tile);
 					spr_death_anim_frm += TILES_PER_ROW*(zc_min(0,tysz-1)*rows);
-					if(++spr_death_anim_clk >= (zc_max(wpnsbuf[spr_death].speed,1) * zc_max(wpnsbuf[spr_death].frames,1)))
+					if(++spr_death_anim_clk >= deathspr.total_duration())
 					{
 						spr_death_anim_clk=-1;
 						clk2=1;
@@ -4134,7 +4135,7 @@ void enemy::draw(BITMAP *dest)
 		}
 		
 		if(!get_qr(qr_HARDCODED_ENEMY_ANIMS) || BSZ || fading==fade_blue_poof)
-			cs = wpnsbuf[spr_death].csets&15;
+			cs = deathspr.csets&15;
 		else
 			cs = (((clk2+5)>>1)&3)+6;
 	}
@@ -4192,7 +4193,8 @@ void enemy::drawzcboss(BITMAP *dest)
 		}
 		
 		flip = 0;
-		tile = wpnsbuf[spr_death].tile;
+		auto const& deathspr = sprite_data_buf.get(spr_death);
+		tile = deathspr.tile;
 		
 		if ( do_animation ) 
 		{
@@ -4208,11 +4210,11 @@ void enemy::drawzcboss(BITMAP *dest)
 				if(clk2==1 && spr_death_anim_clk>-1)
 				{
 					++clk2;
-					spr_death_anim_frm=(spr_death_anim_clk/zc_max(wpnsbuf[spr_death].speed,1));
+					spr_death_anim_frm=(spr_death_anim_clk/zc_max(deathspr.speed,1));
 					spr_death_anim_frm *= zc_max(1,txsz);
 					int32_t rows = TILEROW(tile+spr_death_anim_frm)-TILEROW(tile);
 					spr_death_anim_frm += TILES_PER_ROW*(zc_min(0,tysz-1)*rows);
-					if(++spr_death_anim_clk >= (zc_max(wpnsbuf[spr_death].speed,1) * zc_max(wpnsbuf[spr_death].frames,1)))
+					if(++spr_death_anim_clk >= deathspr.total_duration())
 					{
 						spr_death_anim_clk=-1;
 						clk2=1;
@@ -4227,7 +4229,7 @@ void enemy::drawzcboss(BITMAP *dest)
 		}
 		
 		if(!get_qr(qr_HARDCODED_ENEMY_ANIMS) || BSZ || fading==fade_blue_poof)
-			cs = wpnsbuf[spr_death].csets&15;
+			cs = deathspr.csets&15;
 		else
 			cs = (((clk2+5)>>1)&3)+6;
 	}
@@ -4366,7 +4368,7 @@ void enemy::drawshadow(BITMAP *dest, bool translucent)
 	if(!can_drawshadow())
 		return;
 	if(enemycanfall(id, false) && shadowtile == 0)
-		shadowtile = wpnsbuf[spr_shadow].tile;
+		shadowtile = sprite_data_buf.get(spr_shadow).tile;
 	
 	sprite::drawshadow(dest,translucent);
 }
@@ -8581,7 +8583,7 @@ void eTektite::drawshadow(BITMAP *dest,bool translucent)
 	int32_t f2=get_qr(qr_NEWENEMYTILES)?
 		   efrate:((clk>=(frate>>1))?1:0);
 	flip = 0;
-	shadowtile = wpnsbuf[spr_shadow].tile;
+	shadowtile = sprite_data_buf.get(spr_shadow).tile;
 	
 	if(get_qr(qr_NEWENEMYTILES))
 	{
@@ -8724,7 +8726,7 @@ void ePeahat::drawshadow(BITMAP *dest, bool translucent)
 	if(!can_drawshadow())
 		return;
 	int32_t tempy=yofs;
-	shadowtile = wpnsbuf[spr_shadow].tile+posframe;
+	shadowtile = sprite_data_buf.get(spr_shadow).tile+posframe;
 	
 	if(!get_qr(qr_ENEMIESZAXIS))
 	{
@@ -9833,7 +9835,7 @@ void eRock::drawshadow(BITMAP *dest, bool translucent)
 	int32_t efrate = fdiv == 0 ? 0 : clk/fdiv;
 	int32_t f2=get_qr(qr_NEWENEMYTILES)?
 		   efrate:((clk>=(frate>>1))?1:0);
-	shadowtile = wpnsbuf[spr_shadow].tile+f2;
+	shadowtile = sprite_data_buf.get(spr_shadow).tile+f2;
 	
 	yofs+=8;
 	yofs+=zc_max(0,zc_min(29-clk3,clk3));
@@ -9956,7 +9958,7 @@ void eBoulder::drawshadow(BITMAP *dest, bool translucent)
 	int32_t tempy=yofs;
 	flip = 0;
 	int32_t f2=((clk<<2)/frate)<<1;
-	shadowtile = wpnsbuf[spr_shadow].tile+f2;
+	shadowtile = sprite_data_buf.get(spr_shadow).tile+f2;
 	yofs+=zc_max(0,zc_min(29-clk3,clk3));
 	
 	yofs+=8;
@@ -10151,7 +10153,7 @@ void eTrigger::death_sfx()
 
 eNPC::eNPC(zfix X,zfix Y,int32_t Id,int32_t Clk) : enemy(X,Y,Id,Clk)
 {
-	o_tile+=wpnsbuf[iwNPCs].tile;
+	o_tile+=sprite_data_buf.get(iwNPCs).tile;
 	if (!(editorflags&ENEMY_FLAG3)) count_enemy=false;
 	SIZEflags = d->SIZEflags;
 	if (SIZEflags != 0) init_size_flags();;
@@ -10339,7 +10341,7 @@ void eSpinTile::drawshadow(BITMAP *dest, bool translucent)
 	flip = 0;
 	if(!can_drawshadow())
 		return;
-	shadowtile = wpnsbuf[spr_shadow].tile+(clk%4);
+	shadowtile = sprite_data_buf.get(spr_shadow).tile+(clk%4);
 	yofs+=4;
 	enemy::drawshadow(dest, translucent);
 	yofs-=4;
@@ -10984,9 +10986,9 @@ bool eStalfos::animate(int32_t index)
 		int32_t i=Ewpns.Count()-1;
 		weapon *ew = (weapon*)(Ewpns.spr(i));
 		
-		if(wpn==ewFIRETRAIL && wpnsbuf[ewFIRETRAIL].frames>1)
+		if(wpn==ewFIRETRAIL && sprite_data_buf.get(ewFIRETRAIL).frames>1)
 		{
-			ew->aframe=zc_oldrand()%wpnsbuf[ewFIRETRAIL].frames;
+			ew->aframe=zc_oldrand()%sprite_data_buf.get(ewFIRETRAIL).frames;
 			if ( ew->do_animation ) ew->tile+=ew->aframe;
 		}
 	}
@@ -11173,7 +11175,7 @@ void eStalfos::drawshadow(BITMAP *dest, bool translucent)
 		
 		int32_t f2=get_qr(qr_NEWENEMYTILES)?
 			   efrate:((clk>=(frate>>1))?1:0);
-		shadowtile = wpnsbuf[spr_shadow].tile;
+		shadowtile = sprite_data_buf.get(spr_shadow).tile;
 		
 		if(get_qr(qr_NEWENEMYTILES))
 		{
@@ -11195,7 +11197,7 @@ void eStalfos::drawshadow(BITMAP *dest, bool translucent)
 		
 		int32_t f2=get_qr(qr_NEWENEMYTILES)?
 			   efrate:((clk>=(frate>>1))?1:0);
-		shadowtile = wpnsbuf[spr_shadow].tile;
+		shadowtile = sprite_data_buf.get(spr_shadow).tile;
 		
 		if(get_qr(qr_NEWENEMYTILES))
 		{
@@ -11563,7 +11565,7 @@ void eKeese::drawshadow(BITMAP *dest, bool translucent)
 	if(!can_drawshadow())
 		return;
 	int32_t tempy=yofs;
-	shadowtile = wpnsbuf[spr_shadow].tile+posframe;
+	shadowtile = sprite_data_buf.get(spr_shadow).tile+posframe;
 	
 	yofs+=zc_min(int32_t(step/zslongToFix(dstep*10)), 8);
 	if(!get_qr(qr_ENEMIESZAXIS))
@@ -21546,7 +21548,7 @@ int32_t enemy::getFlashingCSet()
 	if(dying)
 	{
 		if (!get_qr(qr_HARDCODED_ENEMY_ANIMS) || BSZ || fading == fade_blue_poof)
-			return wpnsbuf[spr_death].csets & 15;
+			return sprite_data_buf.get(spr_death).csets & 15;
 		else
 			return (((clk2 + 5) >> 1) & 3) + 6;
 	}

--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -1970,7 +1970,7 @@ void HeroClass::drawshadow(BITMAP* dest, bool translucent)
 {
     int32_t tempy=yofs;
     yofs+=8;
-    shadowtile = wpnsbuf[spr_shadow].tile;
+    shadowtile = sprite_data_buf.get(spr_shadow).tile;
     sprite::drawshadow(dest,translucent);
     yofs=tempy;
 }
@@ -2324,9 +2324,7 @@ void HeroClass::positionSword(weapon *w, int32_t itemid)
     
     if(game->get_canslash() && itm.flags & item_flag4 && attackclk<11)
     {
-        int32_t wpn2=itm.wpn2;
-        wpn2=vbound(wpn2, 0, MAXWPNS);
-        
+		auto const& spr2 = sprite_data_buf.get(itm.wpn_sprites[1]);
         //slashing tiles
         switch(dir)
         {
@@ -2340,8 +2338,8 @@ void HeroClass::positionSword(weapon *w, int32_t itemid)
             {
                 wy-=9;
                 wx-=3;
-                t = wpnsbuf[wpn2].tile;
-                cs2 = wpnsbuf[wpn2].csets&15;
+                t = spr2.tile;
+                cs2 = spr2.csets&15;
                 f=0;
             }
             
@@ -2357,8 +2355,8 @@ void HeroClass::positionSword(weapon *w, int32_t itemid)
             {
                 wy+=15;
                 wx+=2;
-                t = wpnsbuf[wpn2].tile;
-                cs2 = wpnsbuf[wpn2].csets&15;
+                t = spr2.tile;
+                cs2 = spr2.csets&15;
                 ++t;
                 f=0;
             }
@@ -2376,8 +2374,8 @@ void HeroClass::positionSword(weapon *w, int32_t itemid)
                 wx-=15;
                 wy+=3;
                 slashxofs-=1;
-                t = wpnsbuf[wpn2].tile;
-                cs2 = wpnsbuf[wpn2].csets&15;
+                t = spr2.tile;
+                cs2 = spr2.csets&15;
                 t+=2;
                 f=0;
             }
@@ -2404,8 +2402,8 @@ void HeroClass::positionSword(weapon *w, int32_t itemid)
             {
                 wx+=15;
                 slashxofs+=1;
-                t = wpnsbuf[wpn2].tile;
-                cs2 = wpnsbuf[wpn2].csets&15;
+                t = spr2.tile;
+                cs2 = spr2.csets&15;
                 
                 if(spins>0 || (itm.flags & item_flag8))
                 {
@@ -2554,7 +2552,7 @@ void HeroClass::draw(BITMAP* dest)
 					}
 					positionNet(w, itemid);
 				}
-				else if((attack==wSword || attack==wWand || ((attack==wFire || attack==wCByrna) && itm.wpn)) && wpnsbuf[itm.wpn].tile)
+				else if((attack==wSword || attack==wWand || ((attack==wFire || attack==wCByrna) && itm.wpn_sprites[0])) && sprite_data_buf.get(itm.wpn_sprites[0]).tile)
 				{
 					// Create a sword weapon at the right spot.
 					weapon *w=find_first_wtype(attack==wSword ? wSword : wWand);
@@ -7508,8 +7506,8 @@ void HeroClass::addsparkle(int32_t wpn)
     if(itemtype!=itype_cbyrna && frame%4)
         return;
         
-    int32_t wpn2 = (itemtype==itype_cbyrna) ? itm.wpn4 : itm.wpn2;
-    int32_t wpn3 = (itemtype==itype_cbyrna) ? itm.wpn5 : itm.wpn3;
+    int32_t wpn2 = itm.wpn_sprites[(itemtype==itype_cbyrna) ? 3 : 1];
+    int32_t wpn3 = itm.wpn_sprites[(itemtype==itype_cbyrna) ? 4 : 2];
     // Either one (wpn2) or the other (wpn3). If both are present, randomise.
     int32_t sparkle_type = (!wpn2 ? (!wpn3 ? 0 : wpn3) : (!wpn3 ? wpn2 : (zc_oldrand()&1 ? wpn2 : wpn3)));
     int32_t direction=w->dir;
@@ -8055,8 +8053,8 @@ heroanimate_skip_liftwpn:;
 		for_each_rpos_stood_on([&](const rpos_handle_t& handle)
 			{
 				auto& cmb = handle.combo();
-				byte csfx = action == walking ? cmb.sfx_walking : cmb.sfx_standing;
-				byte cspr = action == walking ? cmb.spr_walking : cmb.spr_standing;
+				word csfx = action == walking ? cmb.sfx_walking : cmb.sfx_standing;
+				word cspr = action == walking ? cmb.spr_walking : cmb.spr_standing;
 				if(csfx)
 					sfx_no_repeat(csfx, pan(x));
 				auto indx = decorations.idFirst(dCUSTOMWALK);
@@ -10707,7 +10705,7 @@ void HeroClass::doMirror(int32_t mirrorid)
 		else if(mirror.flags & item_flag1) //Place portal!
 		{
 			//Place the portal
-			game->set_portal(sourcedmap, destdmap, offscr, x.getZLong(), y.getZLong(), mirror.usesound, mirror.misc1, mirror.wpn);
+			game->set_portal(sourcedmap, destdmap, offscr, x.getZLong(), y.getZLong(), mirror.usesound, mirror.misc1, mirror.wpn_sprites[0]);
 			//Since it was placed after loading this screen, load the portal object now
 			game->load_portal();
 			//Don't immediately trigger the warp back
@@ -11507,8 +11505,8 @@ void HeroClass::doSwitchHook(byte style)
 	{
 		default: case swPOOF:
 		{
-			wpndata const& spr = wpnsbuf[QMisc.sprites[sprSWITCHPOOF]];
-			switchhookmaxtime = switchhookclk = zc_max(spr.frames,1) * zc_max(spr.speed,1);
+			sprite_data const& spr = sprite_data_buf.get(QMisc.sprites[sprSWITCHPOOF]);
+			switchhookmaxtime = switchhookclk = spr.total_duration();
 			decorations.add(new comboSprite(x, y, dCOMBOSPRITE, 0, QMisc.sprites[sprSWITCHPOOF]));
 			if(hooked_comborpos != rpos_t::None)
 			{
@@ -12853,8 +12851,8 @@ bool HeroClass::doattack()
 	// * a cane thrust
 	// In which case it should continue.
 	if((attack==wCatching && attackclk>4)||(attack!=wWand && attack!=wSword && attack!=wHammer
-											&& (attack!=wFire || (valid_item_id(candleid) && !(itemsbuf[candleid].wpn)))
-											&& (attack!=wCByrna || (valid_item_id(byrnaid) && !(itemsbuf[byrnaid].wpn)))
+											&& (attack!=wFire || (valid_item_id(candleid) && !(itemsbuf[candleid].wpn_sprites[0])))
+											&& (attack!=wCByrna || (valid_item_id(byrnaid) && !(itemsbuf[byrnaid].wpn_sprites[0])))
 											&& (attack != wBugNet) && attackclk>7))
 	{
 		if (getInput(btnUp, INPUT_DRUNK | INPUT_HERO_ACTION) || getInput(btnDown, INPUT_DRUNK | INPUT_HERO_ACTION) || getInput(btnLeft, INPUT_DRUNK | INPUT_HERO_ACTION) || getInput(btnRight, INPUT_DRUNK | INPUT_HERO_ACTION))
@@ -12943,7 +12941,7 @@ bool HeroClass::doattack()
 	}
 	else if(attack==wCByrna && valid_item_id(byrnaid))
 	{
-		if(!(itemsbuf[byrnaid].wpn))
+		if(!(itemsbuf[byrnaid].wpn_sprites[0]))
 		{
 			attack = wNone;
 			return startwpn(attackid); // Beam if the Byrna stab animation WASN'T used.
@@ -13073,7 +13071,7 @@ bool HeroClass::doattack()
 			tapping = false;
 	}
 	
-	if(attackclk==1 && attack==wFire && valid_item_id(candleid) && !(itemsbuf[candleid].wpn))
+	if(attackclk==1 && attack==wFire && valid_item_id(candleid) && !(itemsbuf[candleid].wpn_sprites[0]))
 	{
 		return startwpn(attackid); // Flame if the Candle stab animation WASN'T used.
 	}
@@ -13128,10 +13126,10 @@ bool HeroClass::doattack()
 		if(attack==wWand)
 			startwpn(attackid); // Flame if the Wand stab animation WAS used (it always is).
 			
-		if(attack==wFire && valid_item_id(candleid) && itemsbuf[candleid].wpn) // Flame if the Candle stab animation WAS used.
+		if(attack==wFire && valid_item_id(candleid) && itemsbuf[candleid].wpn_sprites[0]) // Flame if the Candle stab animation WAS used.
 			startwpn(attackid);
 			
-		if(attack==wCByrna && valid_item_id(byrnaid) && itemsbuf[byrnaid].wpn) // Beam if the Byrna stab animation WAS used.
+		if(attack==wCByrna && valid_item_id(byrnaid) && itemsbuf[byrnaid].wpn_sprites[0]) // Beam if the Byrna stab animation WAS used.
 			startwpn(attackid);
 	}
 	
@@ -13867,7 +13865,7 @@ bool HeroClass::try_hover()
 		
 		sfx(itm.usesound,pan(x));
 	}
-	if (itm.wpn)
+	if (itm.wpn_sprites[0])
 		decorations.add(new dHover(x, y, dHOVER, 0));
 	return true;
 }
@@ -31077,7 +31075,7 @@ void getitem(int32_t id, bool nosound, bool doRunPassive)
 				
 				if(w->id==wBrang)
 				{
-					w->LOADGFX(idat.wpn);
+					w->LOADGFX(idat.wpn_sprites[0]);
 				}
 			}
 	}
@@ -31315,7 +31313,7 @@ void takeitem(int32_t id)
 		case itype_brang:
 			if (auto brang_id = current_item_id(itype_brang); valid_item_id(brang_id))
 			{
-				auto wpn = get_item_data(brang_id).wpn;
+				auto wpn = get_item_data(brang_id).wpn_sprites[0];
 				for(int32_t i=0; i<Lwpns.Count(); i++)
 				{
 					weapon *w = ((weapon*)Lwpns.spr(i));
@@ -32508,16 +32506,17 @@ void HeroClass::heroDeathAnimation()
 				}
                     
 				extend = 0;
-				cs = wpnsbuf[spr_death].csets&15;
-				tile = wpnsbuf[spr_death].tile;
+				auto const& dyingspr = sprite_data_buf.get(spr_death);
+				cs = dyingspr.csets&15;
+				tile = dyingspr.tile;
 				if(!get_qr(qr_HARDCODED_ENEMY_ANIMS))
 				{
 					tile += deathfrm;
 					f = 206;
-					if(++deathclk >= wpnsbuf[spr_death].speed)
+					if(++deathclk >= dyingspr.speed)
 					{
 						deathclk=0;
-						if(++deathfrm >= wpnsbuf[spr_death].frames)
+						if(++deathfrm >= dyingspr.frames)
 						{
 							f = 208;
 							deathfrm = 0;

--- a/src/zc/scripting/arrays.h
+++ b/src/zc/scripting/arrays.h
@@ -168,7 +168,7 @@ static T* resolveScriptingObject(int ref)
 		return checkBottleShopData(ref);
 	else if constexpr (std::is_same<T, item_drop_object>::value)
 		return checkDropSetData(ref);
-	else if constexpr (std::is_same<T, wpndata>::value)
+	else if constexpr (std::is_same<T, sprite_data>::value)
 		return checkSpriteData(ref);
 	else if constexpr (std::is_same<T, MsgStr>::value)
 		return checkMessageData(ref);

--- a/src/zc/scripting/types/game.cpp
+++ b/src/zc/scripting/types/game.cpp
@@ -1087,7 +1087,7 @@ static ArrayRegistrar GAMEMISCSFX_registrar(GAMEMISCSFX, []{
 static ArrayRegistrar GAMEMISCSPR_registrar(GAMEMISCSPR, []{
 	static ScriptingArray_GlobalCArray impl(QMisc.sprites, comptime_array_size(QMisc.sprites));
 	impl.compatSetDefaultValue(-10000);
-	impl.setValueTransform(transforms::vboundByte);
+	impl.setValueTransform(transforms::vboundWord);
 	impl.setMul10000(true);
 	return &impl;
 }());

--- a/src/zc/scripting/types/itemdata.cpp
+++ b/src/zc/scripting/types/itemdata.cpp
@@ -41,7 +41,7 @@ static ArrayRegistrar IDATABURNINGSPR_registrar(IDATABURNINGSPR, []{
 	static ScriptingArray_ObjectSubMemberCArray<itemdata, &itemdata::weap_data, &weapon_data::burnsprs> impl;
 	impl.compatSetDefaultValue(-10000);
 	impl.setMul10000(true);
-	impl.setValueTransform(transforms::vboundByte);
+	impl.setValueTransform(transforms::vboundWord);
 	return &impl;
 }());
 
@@ -142,46 +142,10 @@ static ArrayRegistrar IDATAATTRIB_L_registrar(IDATAATTRIB_L, []{
 }());
 
 static ArrayRegistrar IDATASPRITE_registrar(IDATASPRITE, []{
-	static ScriptingArray_ObjectComputed<itemdata, int> impl(
-		[](itemdata* item){
-			return 10;
-		},
-		[](itemdata* item, int index) -> int {
-			switch(index)
-			{
-				case 0: return (item->wpn);
-				case 1: return (item->wpn2);
-				case 2: return (item->wpn3);
-				case 3: return (item->wpn4);
-				case 4: return (item->wpn5);
-				case 5: return (item->wpn6);
-				case 6: return (item->wpn7);
-				case 7: return (item->wpn8);
-				case 8: return (item->wpn9);
-				case 9: return (item->wpn10);
-				default: NOTREACHED();
-			}
-		},
-		[](itemdata* item, int index, int value){
-			switch(index)
-			{
-				case 0: item->wpn = value; break;
-				case 1: item->wpn2 = value; break;
-				case 2: item->wpn3 = value; break;
-				case 3: item->wpn4 = value; break;
-				case 4: item->wpn5 = value; break;
-				case 5: item->wpn6 = value; break;
-				case 6: item->wpn7 = value; break;
-				case 7: item->wpn8 = value; break;
-				case 8: item->wpn9 = value; break;
-				case 9: item->wpn10 = value; break;
-				default: NOTREACHED();
-			}
-		}
-	);
+	static ScriptingArray_ObjectMemberCArray<itemdata, &itemdata::wpn_sprites> impl;
 	impl.compatSetDefaultValue(-10000);
 	impl.setMul10000(true);
-	impl.setValueTransform(transforms::vboundByte);
+	impl.setValueTransform(transforms::vboundWord);
 	return &impl;
 }());
 

--- a/src/zc/scripting/types/itemsprite.cpp
+++ b/src/zc/scripting/types/itemsprite.cpp
@@ -1110,7 +1110,7 @@ bool itemsprite_set_register(int32_t reg, int32_t value)
 		case ITEMSHADOWSPR:
 			if (auto s = checkItem(GET_REF(itemref)))
 			{
-				s->spr_shadow=vbound(value/10000,0,255);
+				s->spr_shadow=vbound(value/10000,0,MAXSPRITES-1);
 			}
 			break;
 		case ITEMDROPPEDBY:

--- a/src/zc/scripting/types/npc.cpp
+++ b/src/zc/scripting/types/npc.cpp
@@ -1739,7 +1739,7 @@ bool npc_set_register(int32_t reg, int32_t value)
 			int32_t weapon = value / 10000;
 			
 			if(GuyH::loadNPC(GET_REF(npcref)) == SH::_NoError &&
-					BC::checkBounds(weapon, 0, MAXWPNS-1) == SH::_NoError)
+					BC::checkBounds(weapon, 0, wMax-1) == SH::_NoError)
 			{
 				GuyH::getNPC()->wpn = weapon;
 			
@@ -1882,19 +1882,19 @@ bool npc_set_register(int32_t reg, int32_t value)
 		case NPCSHADOWSPR:
 			if(GuyH::loadNPC(GET_REF(npcref)) == SH::_NoError)
 			{
-				GuyH::getNPC()->spr_shadow = vbound(value/10000,0,255);
+				GuyH::getNPC()->spr_shadow = vbound(value/10000,0,MAXSPRITES-1);
 			}
 			break;
 		case NPCSPAWNSPR:
 			if(GuyH::loadNPC(GET_REF(npcref)) == SH::_NoError)
 			{
-				GuyH::getNPC()->spr_spawn = vbound(value/10000,0,255);
+				GuyH::getNPC()->spr_spawn = vbound(value/10000,0,MAXSPRITES-1);
 			}
 			break;
 		case NPCDEATHSPR:
 			if(GuyH::loadNPC(GET_REF(npcref)) == SH::_NoError)
 			{
-				GuyH::getNPC()->spr_death = vbound(value/10000,0,255);
+				GuyH::getNPC()->spr_death = vbound(value/10000,0,MAXSPRITES-1);
 			}
 			break;
 		case NPCSWHOOKED:

--- a/src/zc/scripting/types/sprite.cpp
+++ b/src/zc/scripting/types/sprite.cpp
@@ -775,7 +775,7 @@ bool sprite_set_register(int32_t reg, int32_t value)
 		case SPRITE_SHADOW_SPR:
 		{
 			if (auto s = get_sprite(GET_REF(spriteref)))
-				s->spr_shadow = vbound(value / 10000, 0, 255);
+				s->spr_shadow = vbound(value / 10000, 0, MAXSPRITES-1);
 			break;
 		}
 		case SPRITE_DROWN_CLK:

--- a/src/zc/scripting/types/spritedata.cpp
+++ b/src/zc/scripting/types/spritedata.cpp
@@ -3,7 +3,7 @@
 // spritedata arrays.
 
 static ArrayRegistrar SPRITEDATAFLAGS_registrar(SPRITEDATAFLAGS, []{
-	static ScriptingArray_ObjectMemberBitwiseFlags<wpndata, &wpndata::misc, 4> impl;
+	static ScriptingArray_ObjectMemberBitwiseFlags<sprite_data, &sprite_data::misc, 4> impl;
 	impl.setMul10000(true);
 	return &impl;
 }());

--- a/src/zc/scripting/types/weapon.cpp
+++ b/src/zc/scripting/types/weapon.cpp
@@ -49,6 +49,6 @@ static WeaponArrayRegistrar WPNSPRITES_registrar(LWPNSPRITES, EWPNSPRITES, []{
 	static ScriptingArray_ObjectMemberCArray<weapon, &weapon::misc_wsprites> impl;
 	impl.compatSetDefaultValue(-10000);
 	impl.setMul10000(true);
-	impl.setValueTransform(transforms::vboundByte);
+	impl.setValueTransform(transforms::vboundWord);
 	return &impl;
 }());

--- a/src/zc/weapons.cpp
+++ b/src/zc/weapons.cpp
@@ -1773,7 +1773,7 @@ weapon::weapon(zfix X,zfix Y,zfix Z,int32_t Id,int32_t Type,int32_t pow,int32_t 
 		light_rads[q] = 0;
 	}
 	
-	optional<byte> wpnspr;
+	optional<word> wpnspr;
 	
 	weapon_data const* wdata = nullptr;
 	switch(id)
@@ -1815,7 +1815,7 @@ weapon::weapon(zfix X,zfix Y,zfix Z,int32_t Id,int32_t Type,int32_t pow,int32_t 
 		else wpnspr = _handle_loadsprite(nullopt, isDummy, true);
 	}
 }
-optional<byte> weapon::_ewpn_sprite(int parentid) const
+optional<word> weapon::_ewpn_sprite(int parentid) const
 {
 	if(parentid > -1 && !isLWeapon)
 		if(enemy *e = (enemy*)guys.getByUID(parentid))
@@ -1824,9 +1824,9 @@ optional<byte> weapon::_ewpn_sprite(int parentid) const
 	return nullopt;
 }
 
-optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool force)
+optional<word> weapon::_handle_loadsprite(optional<word> spr, bool isDummy, bool force)
 {
-	optional<byte> ret;
+	optional<word> ret;
 	if(force) ret = 0;
 	itemdata const& parent = get_item_data(parentitem);
 	auto tmp_dir = dir;
@@ -1838,7 +1838,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 		{
 			if(spr)
 				ret = *spr;
-			else ret = parent.wpn;
+			else ret = parent.wpn_sprites[0];
 			LOADGFX(*ret);
 			break;
 		}
@@ -1851,7 +1851,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				if(spr)
 					ret = *spr;
 				else if (valid_item_id(parentitem))
-					ret = parent.wpn;
+					ret = parent.wpn_sprites[0];
 				LOADGFX(*ret);
 				if (valid_item_id(parentitem))
 				{
@@ -1905,7 +1905,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				if(isDummy || itemid < 0)
 					itemid = getCanonicalItemID(itype_sword);
 				if (valid_item_id(itemid))
-					ret = itemsbuf[itemid].wpn;
+					ret = itemsbuf[itemid].wpn_sprites[0];
 				else ret = wSWORD;
 			}
 			LOADGFX(*ret);
@@ -1921,7 +1921,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				if(isDummy || itemid < 0)
 					itemid = getCanonicalItemID(itype_wand);
 				if (valid_item_id(itemid))
-					ret = itemsbuf[itemid].wpn;
+					ret = itemsbuf[itemid].wpn_sprites[0];
 				else ret = wWAND;
 			}
 			LOADGFX(*ret);
@@ -1937,7 +1937,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				if(isDummy || itemid < 0)
 					itemid = getCanonicalItemID(itype_hammer);
 				if (valid_item_id(itemid))
-					ret = itemsbuf[itemid].wpn;
+					ret = itemsbuf[itemid].wpn_sprites[0];
 				else ret = wHAMMER;
 			}
 			LOADGFX(*ret);
@@ -1953,7 +1953,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				if(isDummy || itemid < 0)
 					itemid = getCanonicalItemID(itype_cbyrna);
 				if (valid_item_id(itemid))
-					ret = itemsbuf[itemid].wpn3;
+					ret = itemsbuf[itemid].wpn_sprites[2];
 				else ret = wCBYRNA;
 			}
 			LOADGFX(*ret);
@@ -1969,7 +1969,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				if(isDummy || itemid < 0)
 					itemid = getCanonicalItemID(itype_whistle);
 				if (valid_item_id(itemid))
-					ret = itemsbuf[itemid].wpn;
+					ret = itemsbuf[itemid].wpn_sprites[0];
 				else ret = wWIND;
 			}
 			LOADGFX(*ret);
@@ -1985,7 +1985,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				if(isDummy || itemid < 0)
 					itemid = getCanonicalItemID(itype_whistle);
 				if (valid_item_id(itemid))
-					ret = itemsbuf[itemid].wpn3;
+					ret = itemsbuf[itemid].wpn_sprites[2];
 				else ret = ewSWORD;
 			}
 			LOADGFX(*ret);
@@ -2020,7 +2020,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				if(isDummy || itemid < 0)
 					itemid = getCanonicalItemID(itype_arrow);
 				if (valid_item_id(itemid))
-					ret = itemsbuf[itemid].wpn;
+					ret = itemsbuf[itemid].wpn_sprites[0];
 				else ret = wARROW;
 			}
 			LOADGFX(*ret);
@@ -2071,16 +2071,16 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				{
 					case itype_divinefire: // Divine Fire. This uses magicitem rather than itemid
 						if (valid_item_id(magicitem) && !isDummy)
-							ret = itemsbuf[magicitem].wpn5;
+							ret = itemsbuf[magicitem].wpn_sprites[4];
 						else ret = wFIRE;
 						break;
 						
 					case itype_book:
-						ret = isDummy ? wFIRE : parent.wpn2;
+						ret = isDummy ? wFIRE : parent.wpn_sprites[1];
 						break;
 						
 					case itype_candle:
-						ret = (parentid > -1 && !isDummy) ? parent.wpn3 : wFIRE;
+						ret = (parentid > -1 && !isDummy) ? parent.wpn_sprites[2] : wFIRE;
 						break;
 				}
 			}
@@ -2100,7 +2100,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				if(isDummy || itemid < 0)
 					itemid = getCanonicalItemID(itype_bomb);
 				if (valid_item_id(itemid))
-					ret = itemsbuf[itemid].wpn;
+					ret = itemsbuf[itemid].wpn_sprites[0];
 				else
 					ret = wBOMB;
 			}
@@ -2118,7 +2118,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				if(isDummy || itemid < 0)
 					itemid = getCanonicalItemID(itype_sbomb);
 				if (valid_item_id(itemid))
-					ret = itemsbuf[itemid].wpn;
+					ret = itemsbuf[itemid].wpn_sprites[0];
 				else
 					ret = wSBOMB;
 			}
@@ -2135,7 +2135,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				if(isDummy || itemid < 0)
 					itemid = getCanonicalItemID(itype_bait);
 				if (valid_item_id(itemid))
-					ret = itemsbuf[itemid].wpn;
+					ret = itemsbuf[itemid].wpn_sprites[0];
 				else
 					ret = wBAIT;
 			}
@@ -2166,8 +2166,8 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				if (valid_item_id(itemid))
 				{
 					auto const& itm = itemsbuf[itemid];
-					// Book Magic sprite is wpn, Wand Magic sprite is wpn3.
-					ret = book ? itm.wpn : itm.wpn3;
+					// Book Magic sprite is wpn_sprites[0], Wand Magic sprite is wpn_sprites[2].
+					ret = itm.wpn_sprites[book ? 0 : 2];
 				}
 				else
 					ret = wMAGIC;
@@ -2200,7 +2200,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				if(isDummy || itemid < 0)
 					itemid = getCanonicalItemID(itype_brang);
 				if (valid_item_id(itemid))
-					ret = itemsbuf[itemid].wpn;
+					ret = itemsbuf[itemid].wpn_sprites[0];
 				else
 					ret = wBRANG;
 			}
@@ -2220,9 +2220,9 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				{
 					auto const& itm = itemsbuf[itemid];
 					if(dir > 3 && dir < 8)
-						ret = itm.wpn5; //diagonal
+						ret = itm.wpn_sprites[4]; //diagonal
 					else
-						ret = itm.wpn;
+						ret = itm.wpn_sprites[0];
 				}
 				else
 					ret = wHSHEAD;
@@ -2284,8 +2284,8 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				{
 					auto const& itm = itemsbuf[itemid];
 					if(dir > 3 && dir < 8)
-						ret = itm.wpn6; //diagonal
-					else ret = itm.wpn4;
+						ret = itm.wpn_sprites[5]; //diagonal
+					else ret = itm.wpn_sprites[3];
 				}
 				else
 					ret = wHSHANDLE;
@@ -2348,11 +2348,11 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				{
 					auto const& itm = itemsbuf[itemid];
 					if(dir > 3 && dir < 8)
-						ret = itm.wpn7; //diagonal
+						ret = itm.wpn_sprites[6]; //diagonal
 					else if(dir < left)
-						ret = itm.wpn3;
+						ret = itm.wpn_sprites[2];
 					else
-						ret = itm.wpn2;
+						ret = itm.wpn_sprites[1];
 				}
 				else
 					ret = dir < left ? wHSCHAIN_V : wHSCHAIN_H;
@@ -2657,22 +2657,22 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 				{
 					case pDIVINEFIREROCKET:
 					case pDIVINEPROTECTIONROCKET1:
-						ret = parent.wpn;
+						ret = parent.wpn_sprites[0];
 						break;
 						
 					case pDIVINEFIREROCKETRETURN:
 					case pDIVINEPROTECTIONROCKETRETURN1:
-						ret = parent.wpn2;
+						ret = parent.wpn_sprites[1];
 						break;
 						
 					case pDIVINEFIREROCKETTRAIL:
 					case pDIVINEPROTECTIONROCKETTRAIL1:
-						ret = parent.wpn3;
+						ret = parent.wpn_sprites[2];
 						break;
 						
 					case pDIVINEFIREROCKETTRAILRETURN:
 					case pDIVINEPROTECTIONROCKETTRAILRETURN1:
-						ret = parent.wpn4;
+						ret = parent.wpn_sprites[3];
 						break;
 						
 					case pMESSAGEMORE:
@@ -2680,19 +2680,19 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 						break;
 						
 					case pDIVINEPROTECTIONROCKET2:
-						ret = parent.wpn6;
+						ret = parent.wpn_sprites[5];
 						break;
 						
 					case pDIVINEPROTECTIONROCKETRETURN2:
-						ret = parent.wpn7;
+						ret = parent.wpn_sprites[6];
 						break;
 						
 					case pDIVINEPROTECTIONROCKETTRAIL2:
-						ret = parent.wpn8;
+						ret = parent.wpn_sprites[7];
 						break;
 						
 					case pDIVINEPROTECTIONROCKETTRAILRETURN2:
-						ret = parent.wpn9;
+						ret = parent.wpn_sprites[8];
 						break;
 						
 					default:
@@ -2715,7 +2715,7 @@ optional<byte> weapon::_handle_loadsprite(optional<byte> spr, bool isDummy, bool
 	return ret;
 }
 
-void weapon::load_weap_data(weapon_data const& data, optional<byte>* out_wpnspr)
+void weapon::load_weap_data(weapon_data const& data, optional<word>* out_wpnspr)
 {
 	switch(id)
 	{
@@ -2914,23 +2914,24 @@ bool weapon::isHeroMelee()
 
 void weapon::LOADGFX(int32_t wpn)
 {
-    if(wpn<0)
-        return;
-        
-    wid = wpn;
-    flash = wpnsbuf[wid].misc&3;
-    tile  = wpnsbuf[wid].tile;
-    cs = wpnsbuf[wid].csets&15;
-    o_tile = wpnsbuf[wid].tile;
-    tile = o_tile;
-    ref_o_tile = o_tile;
-    o_cset = wpnsbuf[wid].csets;
-    o_flip=(wpnsbuf[wid].misc>>2)&3;
-    o_speed = wpnsbuf[wid].speed;
-    o_type = wpnsbuf[wid].type;
-    frames = wpnsbuf[wid].frames;
-    temp1 = wpnsbuf[wFIRE].tile;
-    behind = (wpnsbuf[wid].misc&WF_BEHIND)!=0;
+	if(wpn<0)
+		return;
+	
+	wid = wpn;
+	auto const& wspr = sprite_data_buf.get(wid);
+	flash = wspr.misc&3;
+	tile  = wspr.tile;
+	cs = wspr.cs();
+	o_tile = wspr.tile;
+	tile = o_tile;
+	ref_o_tile = o_tile;
+	o_cset = wspr.csets;
+	o_flip = wspr.flip();
+	o_speed = wspr.speed;
+	o_type = wspr.type;
+	frames = wspr.frames;
+	temp1 = sprite_data_buf.get(wFIRE).tile;
+	behind = (wspr.misc&WF_BEHIND)!=0;
 }
 void weapon::LOADGFX_CMB(int32_t cid, int32_t cset)
 {
@@ -3423,7 +3424,7 @@ bool weapon::animate(int32_t index)
 			return true;
 		}
 		
-		wpndata& spr = wpnsbuf[QMisc.sprites[sprFALL]];
+		sprite_data const& spr = sprite_data_buf.get(QMisc.sprites[sprFALL]);
 		cs = spr.csets & 0xF;
 		int32_t fr = spr.frames ? spr.frames : 1;
 		int32_t spd = spr.speed ? spr.speed : 1;
@@ -3462,7 +3463,7 @@ bool weapon::animate(int32_t index)
 		}
 		
 		bool lava = (drownCombo && combobuf[drownCombo].usrflags&cflag1);
-		wpndata &spr = wpnsbuf[QMisc.sprites[lava ? sprLAVADROWN : sprDROWN]];
+		sprite_data const& spr = sprite_data_buf.get(QMisc.sprites[lava ? sprLAVADROWN : sprDROWN]);
 		cs = spr.csets & 0xF;
 		int32_t fr = spr.frames ? spr.frames : 1;
 		int32_t spd = spr.speed ? spr.speed : 1;
@@ -4330,7 +4331,7 @@ bool weapon::animate(int32_t index)
 				dead=1;
 			}
 			
-			if(clk>=frames*o_speed-1) //(((wpnsbuf[wSSPARKLE].frames) * (wpnsbuf[wSSPARKLE].speed))-1))
+			if(clk>=frames*o_speed-1)
 			{
 				dead=1;
 			}
@@ -4350,7 +4351,7 @@ bool weapon::animate(int32_t index)
 				dead=1;
 			}
 			
-			if(clk>=frames*o_speed-1) //(((wpnsbuf[wFSPARKLE].frames) * (wpnsbuf[wFSPARKLE].speed))-1))
+			if(clk>=frames*o_speed-1)
 			{
 				dead=1;
 			}
@@ -4582,9 +4583,9 @@ bool weapon::animate(int32_t index)
 				return false;
 			}
 			//Diagonal Hookshot (10)
-			//Sprites wpn5: Head, diagonal
-			//	  wpn6: handle, diagonal
-			//	  wpn7: chainlink, diagonal
+			//Sprites wpn_sprites[4]: Head, diagonal
+			//	  wpn_sprites[5]: handle, diagonal
+			//	  wpn_sprites[6]: chainlink, diagonal
 			//This sets the direction for digaonals based on controller input. 
 			if(clk==1 && allow_diagonal)    
 			{
@@ -4592,7 +4593,7 @@ bool weapon::animate(int32_t index)
 				{
 					if(getInput(btnLeft, INPUT_HERO_ACTION) )  
 					{
-						LOADGFX(hshot.wpn5);
+						LOADGFX(hshot.wpn_sprites[4]);
 						dir=l_up;
 						update_weapon_frame(((frames>1)?frames:0),o_tile);
 						if (!get_qr(qr_BROKEN_HORIZONTAL_WEAPON_ANIM)) o_tile = tile;
@@ -4613,7 +4614,7 @@ bool weapon::animate(int32_t index)
 					
 					else if(getInput(btnRight, INPUT_HERO_ACTION) ) 
 					{
-						LOADGFX(hshot.wpn5);
+						LOADGFX(hshot.wpn_sprites[4]);
 						dir=r_up;
 						update_weapon_frame(((frames>1)?frames:0),o_tile);
 						if (!get_qr(qr_BROKEN_HORIZONTAL_WEAPON_ANIM)) o_tile = tile;
@@ -4641,7 +4642,7 @@ bool weapon::animate(int32_t index)
 					
 					if(getInput(btnLeft, INPUT_HERO_ACTION) )  
 					{
-						LOADGFX(hshot.wpn5);
+						LOADGFX(hshot.wpn_sprites[4]);
 						dir=l_down;
 						update_weapon_frame(((frames>1)?frames:0),o_tile);
 						if (!get_qr(qr_BROKEN_HORIZONTAL_WEAPON_ANIM)) o_tile = tile;
@@ -4662,7 +4663,7 @@ bool weapon::animate(int32_t index)
 					
 					else if(getInput(btnRight, INPUT_HERO_ACTION) ) 
 					{
-						LOADGFX(hshot.wpn5);
+						LOADGFX(hshot.wpn_sprites[4]);
 						dir=r_down;
 						update_weapon_frame(((frames>1)?frames:0),o_tile);
 						if (!get_qr(qr_BROKEN_HORIZONTAL_WEAPON_ANIM)) o_tile = tile;
@@ -4884,7 +4885,7 @@ bool weapon::animate(int32_t index)
 				{
 					if(getInput(btnLeft, INPUT_HERO_ACTION) )  
 					{
-						LOADGFX(hshot.wpn6);
+						LOADGFX(hshot.wpn_sprites[5]);
 						dir=l_up;
 						update_weapon_frame(((frames>1)?frames:0),o_tile);
 						if (!get_qr(qr_BROKEN_HORIZONTAL_WEAPON_ANIM)) o_tile = tile;
@@ -4905,7 +4906,7 @@ bool weapon::animate(int32_t index)
 					
 					else if(getInput(btnRight, INPUT_HERO_ACTION) ) 
 					{
-						LOADGFX(hshot.wpn6);
+						LOADGFX(hshot.wpn_sprites[5]);
 						dir=r_up;
 						update_weapon_frame(((frames>1)?frames:0),o_tile);
 						if (!get_qr(qr_BROKEN_HORIZONTAL_WEAPON_ANIM)) o_tile = tile;
@@ -4934,7 +4935,7 @@ bool weapon::animate(int32_t index)
 					
 					if(getInput(btnLeft, INPUT_HERO_ACTION) )  
 					{
-						LOADGFX(hshot.wpn6);
+						LOADGFX(hshot.wpn_sprites[5]);
 						dir=l_down;
 						update_weapon_frame(((frames>1)?frames:0),o_tile);
 						if (!get_qr(qr_BROKEN_HORIZONTAL_WEAPON_ANIM)) o_tile = tile;
@@ -4955,7 +4956,7 @@ bool weapon::animate(int32_t index)
 					
 					else if(getInput(btnRight, INPUT_HERO_ACTION) ) 
 					{
-						LOADGFX(hshot.wpn6);
+						LOADGFX(hshot.wpn_sprites[5]);
 						dir=r_down;
 						update_weapon_frame(((frames>1)?frames:0),o_tile);
 						if (!get_qr(qr_BROKEN_HORIZONTAL_WEAPON_ANIM)) o_tile = tile;
@@ -5002,7 +5003,7 @@ bool weapon::animate(int32_t index)
 				{
 					if(getInput(btnLeft, INPUT_HERO_ACTION) )  
 					{
-						LOADGFX(hshot.wpn7);
+						LOADGFX(hshot.wpn_sprites[6]);
 						dir=l_up;
 						update_weapon_frame(((frames>1)?frames:0),o_tile);
 						if (!get_qr(qr_BROKEN_HORIZONTAL_WEAPON_ANIM)) o_tile = tile;
@@ -5023,7 +5024,7 @@ bool weapon::animate(int32_t index)
 					
 					else if(getInput(btnRight, INPUT_HERO_ACTION) ) 
 					{
-						LOADGFX(hshot.wpn7);
+						LOADGFX(hshot.wpn_sprites[6]);
 						dir=r_up;
 						update_weapon_frame(((frames>1)?frames:0),o_tile);
 						if (!get_qr(qr_BROKEN_HORIZONTAL_WEAPON_ANIM)) o_tile = tile;
@@ -5052,7 +5053,7 @@ bool weapon::animate(int32_t index)
 					
 					if(getInput(btnLeft, INPUT_HERO_ACTION) )  
 					{
-						LOADGFX(hshot.wpn7);
+						LOADGFX(hshot.wpn_sprites[6]);
 						dir=l_down;
 						update_weapon_frame(((frames>1)?frames:0),o_tile);
 						if (!get_qr(qr_BROKEN_HORIZONTAL_WEAPON_ANIM)) o_tile = tile;
@@ -5073,7 +5074,7 @@ bool weapon::animate(int32_t index)
 					
 					else if(getInput(btnRight, INPUT_HERO_ACTION) ) 
 					{
-						LOADGFX(hshot.wpn7);
+						LOADGFX(hshot.wpn_sprites[6]);
 						dir=r_down;
 						update_weapon_frame(((frames>1)?frames:0),o_tile);
 						if (!get_qr(qr_BROKEN_HORIZONTAL_WEAPON_ANIM)) o_tile = tile;
@@ -5117,7 +5118,7 @@ bool weapon::animate(int32_t index)
 					break;
 					
 				case pDIVINEFIREROCKETTRAIL:                                             //Divine Fire Rocket trail
-					if(clk>=(((wpnsbuf[wDIVINEFIRES1A].frames) * (wpnsbuf[wDIVINEFIRES1A].speed))-1))
+					if(clk>=(sprite_data_buf.get(wDIVINEFIRES1A).total_duration(false))-1)
 					{
 						dead=0;
 					}
@@ -5125,7 +5126,7 @@ bool weapon::animate(int32_t index)
 					break;
 					
 				case pDIVINEFIREROCKETTRAILRETURN:                                             //Divine Fire Rocket return trail
-					if(clk>=(((wpnsbuf[wDIVINEFIRES1B].frames) * (wpnsbuf[wDIVINEFIRES1B].speed))-1))
+					if(clk>=(sprite_data_buf.get(wDIVINEFIRES1B).total_duration(false))-1)
 					{
 						dead=0;
 					}
@@ -5142,7 +5143,7 @@ bool weapon::animate(int32_t index)
 					break;
 					
 				case pDIVINEPROTECTIONROCKETTRAIL1:                                             //Divine Protection Rocket trail
-					if(clk>=(((wpnsbuf[wDIVINEPROTECTIONS1A].frames) * (wpnsbuf[wDIVINEPROTECTIONS1A].speed))-1))
+					if(clk>=(sprite_data_buf.get(wDIVINEPROTECTIONS1A).total_duration(false))-1)
 					{
 						dead=0;
 					}
@@ -5150,7 +5151,7 @@ bool weapon::animate(int32_t index)
 					break;
 					
 				case pDIVINEPROTECTIONROCKETTRAILRETURN1:                                             //Divine Protection Rocket return trail
-					if(clk>=(((wpnsbuf[wDIVINEPROTECTIONS1B].frames) * (wpnsbuf[wDIVINEPROTECTIONS1B].speed))-1))
+					if(clk>=(sprite_data_buf.get(wDIVINEPROTECTIONS1B).total_duration(false))-1)
 					{
 						dead=0;
 					}
@@ -5167,7 +5168,7 @@ bool weapon::animate(int32_t index)
 					break;
 					
 				case pDIVINEPROTECTIONROCKETTRAIL2:                                             //Divine Protection Rocket trail
-					if(clk>=(((wpnsbuf[wDIVINEPROTECTIONS2A].frames) * (wpnsbuf[wDIVINEPROTECTIONS2A].speed))-1))
+					if(clk>=(sprite_data_buf.get(wDIVINEPROTECTIONS2A).total_duration(false))-1)
 					{
 						dead=0;
 					}
@@ -5175,7 +5176,7 @@ bool weapon::animate(int32_t index)
 					break;
 					
 				case pDIVINEPROTECTIONROCKETTRAILRETURN2:                                             //Divine Protection Rocket return trail
-					if(clk>=(((wpnsbuf[wDIVINEPROTECTIONS2B].frames) * (wpnsbuf[wDIVINEPROTECTIONS2B].speed))-1))
+					if(clk>=(sprite_data_buf.get(wDIVINEPROTECTIONS2B).total_duration(false))-1)
 					{
 						dead=0;
 					}
@@ -7194,7 +7195,7 @@ void weapon::animate_graphics()
 					id2=wBOOM;
 					
 					if (valid_parent)
-						id2 = prnt_itm.wpn2;
+						id2 = prnt_itm.wpn_sprites[1];
 					
 					break;
 				}
@@ -7204,7 +7205,7 @@ void weapon::animate_graphics()
 					id2=wSBOOM;
 					
 					if(valid_parent)
-						id2 = prnt_itm.wpn2;
+						id2 = prnt_itm.wpn_sprites[1];
 					
 					break;
 				}
@@ -7218,9 +7219,10 @@ void weapon::animate_graphics()
 					break;
 				}
 				
-				tile = wpnsbuf[id2].tile;
-				cs = wpnsbuf[id2].csets&15;
-				boomframes = wpnsbuf[id2].frames;
+				auto const& sprdata = sprite_data_buf.get(id2);
+				tile = sprdata.tile;
+				cs = sprdata.cs();
+				boomframes = sprdata.frames;
 				
 				if(boomframes != 0)
 				{
@@ -7340,7 +7342,7 @@ void weapon::animate_graphics()
 					flip ^= o_flip;
 					
 				if(Dead() && !BSZ && do_animation)
-					tile = temp1;//wpnsbuf[wFIRE].tile;
+					tile = temp1;
 			}
 			break;
 		}
@@ -7348,7 +7350,7 @@ void weapon::animate_graphics()
 	
 	if (can_drawshadow())
 	{
-		wpndata const& spr = wpnsbuf[spr_shadow];
+		sprite_data const& spr = sprite_data_buf.get(spr_shadow);
 		if(!suspt)
 		{
 			if(++shd_aclk >= zc_max(spr.speed,1))
@@ -7479,21 +7481,6 @@ void weapon::drawshadow(BITMAP* dest, bool translucent)
 	if(get_qr(qr_OLD_WEAPON_DRAW_ANIMATE_TIMING) || !can_drawshadow())
 		return;
 	sprite::drawshadow(dest, translucent);
-}
-
-void putweapon(BITMAP *dest,int32_t x,int32_t y,int32_t weapon_id, int32_t type, int32_t dir, int32_t &aclk, int32_t &aframe, int32_t parentid)
-{
-    weapon temp((zfix)x,(zfix)y,(zfix)0,weapon_id,type,0,dir,-1,parentid,true);
-    temp.ignoreHero=true;
-    temp.fake_weapon = true;
-    temp.yofs=0;
-    temp.clk2=aclk;
-    temp.aframe=aframe;
-    temp.script = 0; //Can not have script data.
-    temp.animate(0); //Scripts run in this function. Call after forcing script data to 0.
-    temp.draw(dest);
-    aclk=temp.clk2;
-    aframe=temp.aframe;
 }
 
 void weapon::findcombotriggers()

--- a/src/zc/weapons.h
+++ b/src/zc/weapons.h
@@ -28,13 +28,13 @@ private:
 	int32_t minX, maxX, minY, maxY;
 	friend void setScreenLimits(weapon&);
     
-	optional<byte> _handle_loadsprite(optional<byte> spr, bool isDummy = false, bool force = false);
-	optional<byte> _ewpn_sprite(int parentid) const;
+	optional<word> _handle_loadsprite(optional<word> spr, bool isDummy = false, bool force = false);
+	optional<word> _ewpn_sprite(int parentid) const;
 	
 	bool _prism_dupe(zfix newx, zfix newy, rpos_t cpos, ffc_id_t ffcpos, int tdir);
 	bool _mirror_refl(zfix newx, zfix newy, rpos_t cpos, ffc_id_t ffcpos, newcombo const& mirror_cmb);
 public:
-	void load_weap_data(weapon_data const& data, optional<byte>* out_wpnspr = nullptr);
+	void load_weap_data(weapon_data const& data, optional<word>* out_wpnspr = nullptr);
     void setAngle(double angletoset);
     void doAutoRotate(bool dodir = false, bool doboth = false);
     int32_t power,dead,clk2,misc2;
@@ -61,7 +61,7 @@ public:
 	byte unblockable;
 	
     weapon_flags misc_wflags;
-	byte misc_wsprites[WPNSPR_MAX];
+	word misc_wsprites[WPNSPR_MAX];
 	byte light_rads[WPNSPR_MAX];
 	byte last_burnstate;
 	byte get_burnstate() const;
@@ -186,7 +186,5 @@ void killgenwpn(weapon* w);
 void do_generic_combo(const rpos_handle_t& rpos_handle, weapon *w, int32_t wid, 
 	int32_t cid, int32_t flag, int32_t flag2, int32_t ft, bool single16);
 void do_generic_combo_ffc(weapon *w, const ffc_handle_t& ffc_handle, int32_t cid, int32_t ft);
-void putweapon(BITMAP *dest,int32_t x,int32_t y,int32_t weapon_id, int32_t type, int32_t dir, int32_t &aclk, int32_t &aframe,
-               int32_t parentid);
 	       
 #endif

--- a/src/zc/zc_sys.cpp
+++ b/src/zc/zc_sys.cpp
@@ -2611,7 +2611,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
 								tempweapony=y;
 							}
 							
-							putweapon(dest,tempweaponx,tempweapony,tempweapon, 0, up, lens_hint_weapon[tempweapon][0], lens_hint_weapon[tempweapon][1],-1);
+							draw_lens_hint_sprite(dest, tempweaponx, tempweapony, tempweapon, 0, up, -1);
 							draw_lens_hint_item(dest,tempitemx,tempitemy,tempitem, 0);
 						}
 						
@@ -2727,7 +2727,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
 								tempweapony=y;
 							}
 							
-							putweapon(dest,tempweaponx,tempweapony+lens_hint_weapon[tempweapon][4],tempweapon, 0, up, lens_hint_weapon[tempweapon][0], lens_hint_weapon[tempweapon][1],-1);
+							draw_lens_hint_sprite(dest, tempweaponx, tempweapony, tempweapon, 0, up, -1);
 						}
 						
 						break;
@@ -2750,7 +2750,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
 								tempweapony=y;
 							}
 							
-							putweapon(dest,tempweaponx,tempweapony+lens_hint_weapon[tempweapon][4],tempweapon, 0, up, lens_hint_weapon[tempweapon][0], lens_hint_weapon[tempweapon][1],-1);
+							draw_lens_hint_sprite(dest, tempweaponx, tempweapony, tempweapon, 0, up, -1);
 						}
 						
 						break;
@@ -2844,7 +2844,7 @@ void draw_lens_under(BITMAP *dest, bool layer)
 							
 							if(tempitem<0) break;
 							
-							tempweapon=get_item_data(tempitem).wpn3;
+							tempweapon=get_item_data(tempitem).wpn_sprites[2];
 							
 							if((!(get_debug() && zc_getkey(KEY_N)) && (lensclk&blink_rate))
 									|| ((get_debug() && zc_getkey(KEY_N)) && (frame&blink_rate)))
@@ -2856,15 +2856,10 @@ void draw_lens_under(BITMAP *dest, bool layer)
 							{
 								tempweaponx=x;
 								tempweapony=y;
-								--lens_hint_weapon[wMagic][4];
-								
-								if(lens_hint_weapon[wMagic][4]<-8)
-								{
-									lens_hint_weapon[wMagic][4]=8;
-								}
+								update_lens_hint_weapon(wMagic);
 							}
 							
-							putweapon(dest,tempweaponx,tempweapony+lens_hint_weapon[tempweapon][4],tempweapon, 0, up, lens_hint_weapon[tempweapon][0], lens_hint_weapon[tempweapon][1],-1);
+							draw_lens_hint_sprite(dest, tempweaponx, tempweapony, tempweapon, 0, up, -1, false, wMagic);
 							draw_lens_hint_item(dest,tempitemx,tempitemy,tempitem, 0);
 						}
 						
@@ -2893,29 +2888,11 @@ void draw_lens_under(BITMAP *dest, bool layer)
 							{
 								tempweaponx=x;
 								tempweapony=y;
-								
-								if(lens_hint_weapon[ewMagic][2]==up)
-								{
-									--lens_hint_weapon[ewMagic][4];
-								}
-								else
-								{
-									++lens_hint_weapon[ewMagic][4];
-								}
-								
-								if(lens_hint_weapon[ewMagic][4]>8)
-								{
-									lens_hint_weapon[ewMagic][2]=up;
-								}
-								
-								if(lens_hint_weapon[ewMagic][4]<=0)
-								{
-									lens_hint_weapon[ewMagic][2]=down;
-								}
+								update_lens_hint_weapon(ewMagic);
 							}
 							
 							draw_lens_hint_item(dest,tempitemx,tempitemy,tempitem, 0);
-							putweapon(dest,tempweaponx,tempweapony+lens_hint_weapon[tempweapon][4],tempweapon, 0, lens_hint_weapon[ewMagic][2], lens_hint_weapon[tempweapon][0], lens_hint_weapon[tempweapon][1],-1);
+							draw_lens_hint_sprite(dest, tempweaponx, tempweapony, tempweapon, 0, up, -1, false, ewMagic);
 						}
 						
 						break;
@@ -2940,26 +2917,11 @@ void draw_lens_under(BITMAP *dest, bool layer)
 								tempitemy=y;
 								tempweaponx=x;
 								tempweapony=y;
-								++lens_hint_weapon[ewFireball][3];
-								
-								if(lens_hint_weapon[ewFireball][3]>8)
-								{
-									lens_hint_weapon[ewFireball][3]=-8;
-									lens_hint_weapon[ewFireball][4]=8;
-								}
-								
-								if(lens_hint_weapon[ewFireball][3]>0)
-								{
-									++lens_hint_weapon[ewFireball][4];
-								}
-								else
-								{
-									--lens_hint_weapon[ewFireball][4];
-								}
+								update_lens_hint_weapon(ewFireball);
 							}
 							
 							draw_lens_hint_item(dest,tempitemx,tempitemy,tempitem, 0);
-							putweapon(dest,tempweaponx+lens_hint_weapon[tempweapon][3],tempweapony+lens_hint_weapon[ewFireball][4],tempweapon, 0, up, lens_hint_weapon[tempweapon][0], lens_hint_weapon[tempweapon][1],-1);
+							draw_lens_hint_sprite(dest, tempweaponx, tempweapony, tempweapon, 0, up, -1, false, ewFireball);
 						}
 						
 						break;

--- a/src/zc/zelda.cpp
+++ b/src/zc/zelda.cpp
@@ -130,7 +130,6 @@ ZCMIXER *zcmixer = NULL;
 int32_t colordepth;
 int32_t db=0;
 int32_t detail_int[10];                                         //temporary holder for things you want to detail
-int32_t lens_hint_weapon[MAXWPNS][5] = {{0,0},{0,0}};                           //aclk, aframe, dir, x, y
 int32_t strike_hint_counter=0;
 int32_t strike_hint_timer=0;
 int32_t strike_hint = 0;
@@ -211,7 +210,6 @@ BITMAP* framebuf_no_passive_subscreen;
 BITMAP     *zcmouse[NUM_ZCMOUSE];
 PALETTE    pal_gui;
 byte       *colordata, *trashbuf;
-wpndata    *wpnsbuf;
 comboclass *combo_class_buf;
 guydata    *guysbuf;
 item_drop_object    item_drop_sets[MAXITEMDROPSETS];
@@ -898,7 +896,6 @@ bool bad_version(int32_t version)
     return false;
 }
 
-extern char *weapon_string[];
 extern char *guy_string[];
 
 bool get_debug()
@@ -1654,12 +1651,7 @@ void init_game_vars(bool is_cont_game = false)
 	show_subscreen_life=true;
 	msgscr=nullptr;
 	maps_init_game_vars();
-	reset_lens_hint_items();
-	for(int32_t x = 0; x < MAXWPNS; x++)
-	{
-		lens_hint_weapon[x][0]=0;
-		lens_hint_weapon[x][1]=0;
-	}
+	reset_lens_hints();
 	for(int32_t i=0; i<6; i++)
 	{
 		visited[i]=-1;
@@ -3460,22 +3452,17 @@ void game_loop()
 
 		if(linkedmsgclk==1 && !do_end_str)
 		{
-			if(wpnsbuf[iwMore].tile!=0)
+			if(sprite_data_buf.get(iwMore).tile!=0)
 			{
 				if (drawPassiveSubscreenSeparate)
 				{
-					// Need to draw to two bitmaps.
-					int aclk_before = lens_hint_weapon[wPhantom][0];
-					int aframe_before = lens_hint_weapon[wPhantom][1];
-					// This will modify the two local variables.
-					putweapon(framebuf, zinit.msg_more_x + viewport.x, message_more_y() + viewport.y, wPhantom, 4, up, aclk_before, aframe_before, -1);
-					// This will modify the lens_hint_weapon animation data.
-					putweapon(framebuf_no_passive_subscreen, zinit.msg_more_x + viewport.x, message_more_y() + viewport.y, wPhantom, 4, up, lens_hint_weapon[wPhantom][0], lens_hint_weapon[wPhantom][1],-1);
-					// Result is one clk/frame step, not two.
+					// Need to draw to two bitmaps. 'peek = true' for first call to not increment clks.
+					draw_lens_hint_sprite(framebuf, zinit.msg_more_x + viewport.x, message_more_y() + viewport.y, wPhantom, 4, up, -1, true);
+					draw_lens_hint_sprite(framebuf_no_passive_subscreen, zinit.msg_more_x + viewport.x, message_more_y() + viewport.y, wPhantom, 4, up, -1);
 				}
 				else
 				{
-					putweapon(framebuf, zinit.msg_more_x + viewport.x, message_more_y() + viewport.y, wPhantom, 4, up, lens_hint_weapon[wPhantom][0], lens_hint_weapon[wPhantom][1],-1);
+					draw_lens_hint_sprite(framebuf, zinit.msg_more_x + viewport.x, message_more_y() + viewport.y, wPhantom, 4, up, -1);
 				}
 			}
 		}
@@ -3930,11 +3917,6 @@ void zc_game_srand(int seed, zc_randgen* rng)
 
 static void allocate_crap()
 {
-	for(int32_t i=0; i<MAXWPNS; i++)
-	{
-		weapon_string[i] = new char[64];
-	}
-	
 	for(int32_t i=0; i<eMAXGUYS; i++)
 	{
 		guy_string[i] = new char[64];
@@ -4940,11 +4922,6 @@ void quit_game()
 	zcmixer_exit(zcmixer);
 	
 	al_trace("Misc... \n");
-	
-	for(int32_t i=0; i<MAXWPNS; i++)
-	{
-		delete [] weapon_string[i];
-	}
 	
 	for(int32_t i=0; i<eMAXGUYS; i++)
 	{

--- a/src/zc/zelda.h
+++ b/src/zc/zelda.h
@@ -199,7 +199,6 @@ extern ZCMIXER* zcmixer;
 extern int32_t colordepth;
 extern int32_t db;
 extern int32_t detail_int[10];                                  //temporary holder for things you want to detail
-extern int32_t lens_hint_weapon[MAXWPNS][5];                    //aclk, aframe, dir, x, y
 extern int32_t strike_hint_counter;
 extern int32_t strike_hint_timer;
 extern int32_t strike_hint;
@@ -219,7 +218,6 @@ extern bool lightbeam_present;
 extern BITMAP *zcmouse[NUM_ZCMOUSE];
 extern PALETTE  pal_gui;
 extern byte     *colordata;
-extern wpndata  *wpnsbuf;
 extern comboclass *combo_class_buf;
 extern guydata  *guysbuf;
 extern item_drop_object    item_drop_sets[MAXITEMDROPSETS];

--- a/src/zc_list_data.cpp
+++ b/src/zc_list_data.cpp
@@ -10,8 +10,8 @@
 #include "core/misctypes.h"
 #include "core/autocombo.h"
 #include <fmt/format.h>
+#include "sprite_data.h"
 
-extern char *weapon_string[];
 extern const char* old_guy_string[OLDMAXGUYS];
 extern char *guy_string[eMAXGUYS];
 extern item_drop_object item_drop_sets[MAXITEMDROPSETS];
@@ -62,7 +62,6 @@ static bool skipchar(char c)
 GUI::ListData GUI::ZCListData::fonts(bool ss_fonts, bool numbered, bool sorted)
 {
 	map<std::string, int32_t> ids;
-	std::set<std::string> names;
 	std::vector<std::string> strings;
 	if(ss_fonts)
 	{
@@ -77,7 +76,6 @@ GUI::ListData GUI::ZCListData::fonts(bool ss_fonts, bool numbered, bool sorted)
 			if(sorted)
 			{
 				ids[name] = q;
-				names.insert(name);
 			}
 			else strings.push_back(name);
 		}
@@ -93,7 +91,6 @@ GUI::ListData GUI::ZCListData::fonts(bool ss_fonts, bool numbered, bool sorted)
 		if(sorted)
 		{
 			ids[name] = q;
-			names.insert(name);
 		}
 		else strings.push_back(name);
 	}
@@ -101,10 +98,8 @@ GUI::ListData GUI::ZCListData::fonts(bool ss_fonts, bool numbered, bool sorted)
 		return GUI::ListData(strings);
 	
 	GUI::ListData ls;
-	for(auto it = names.begin(); it != names.end(); ++it)
-	{
-		ls.add(*it, ids[*it]);
-	}
+	for(auto& [name, val] : ids)
+		ls.add(name, val);
 	return ls;
 }
 
@@ -190,7 +185,6 @@ GUI::ListData GUI::ZCListData::shadow_types()
 GUI::ListData GUI::ZCListData::enemies(bool numbered, bool defaultFilter)
 {
 	map<std::string, int32_t> ids;
-	std::set<std::string> names;
 	
 	for(int32_t q=1; q < eMAXGUYS; ++q)
 	{
@@ -208,15 +202,12 @@ GUI::ListData GUI::ZCListData::enemies(bool numbered, bool defaultFilter)
 		else name = npcname;
 		
 		ids[name] = q;
-		names.insert(name);
 	}
 	
 	GUI::ListData ls;
 	ls.add(numbered ? "(None) (000)" : "(None)", 0);
-	for(auto it = names.begin(); it != names.end(); ++it)
-	{
-		ls.add(*it, ids[*it]);
-	}
+	for(auto& [name, val] : ids)
+		ls.add(name, val);
 	return ls;
 }
 
@@ -241,32 +232,31 @@ GUI::ListData GUI::ZCListData::efamilies(bool numbered)
 GUI::ListData GUI::ZCListData::items(bool numbered, bool none)
 {
 	map<std::string, word> ids;
-	std::set<std::string> names;
 	
 	for(word q = 0; q < itemsbuf.capacity(); ++q)
 	{
 		std::string name = itemsbuf[q].name;
 		if(numbered)
-			name = fmt::format("{} ({:03})", name, q);
+			name = fmt::format("{} ({:04})", name, q);
 		
 		ids[name] = q;
-		names.insert(name);
 	}
 	
 	GUI::ListData ls;
 	if(none)
-		ls.add("(None)", -1);
-	for(auto it = names.begin(); it != names.end(); ++it)
 	{
-		ls.add(*it, ids[*it]);
+		if(numbered)
+			ls.add("(None) (-0001)", -1);
+		else ls.add("(None)", -1);
 	}
+	for(auto& [name, val] : ids)
+		ls.add(name, val);
 	return ls;
 }
 
 GUI::ListData GUI::ZCListData::dropsets(bool numbered, bool none)
 {
 	map<std::string, int32_t> ids;
-	std::set<std::string> names;
 	
 	for(int32_t q=0; q < MAXITEMDROPSETS; ++q)
 	{
@@ -281,23 +271,19 @@ GUI::ListData GUI::ZCListData::dropsets(bool numbered, bool none)
 		else name = dropname;
 		
 		ids[name] = q;
-		names.insert(name);
 	}
 	
 	GUI::ListData ls;
 	if(none)
 		ls.add("(None)", -1);
-	for(auto it = names.begin(); it != names.end(); ++it)
-	{
-		ls.add(*it, ids[*it]);
-	}
+	for(auto& [name, val] : ids)
+		ls.add(name, val);
 	return ls;
 }
 
 GUI::ListData GUI::ZCListData::itemclass(bool numbered, bool zero_none)
 {
 	map<std::string, int32_t> fams;
-	std::set<std::string> famnames;
 	
 	for(int32_t i=zero_none?1:0; i<itype_max; ++i)
 	{
@@ -312,7 +298,6 @@ GUI::ListData GUI::ZCListData::itemclass(bool numbered, bool zero_none)
 			else name = itname;
 			
 			fams[name] = i;
-			famnames.insert(name);
 		}
 		else 
 		{
@@ -322,17 +307,14 @@ GUI::ListData GUI::ZCListData::itemclass(bool numbered, bool zero_none)
 			else name = fmt::format("zz{:03}",i);
 			
 			fams[name] = i;
-			famnames.insert(name);
 		}
 	}
 	
 	GUI::ListData ls;
 	if(zero_none)
 		ls.add(numbered ? "(None) (000)" : "(None)", 0);
-	for(auto it = famnames.begin(); it != famnames.end(); ++it)
-	{
-		ls.add(*it, fams[*it]);
-	}
+	for(auto& [name, val] : fams)
+		ls.add(name, val);
 	return ls;
 }
 
@@ -368,7 +350,6 @@ GUI::ListData GUI::ZCListData::combotype(bool numbered, bool skipNone)
 {
 	GUI::ListData ls;
 	map<std::string, int32_t> types;
-	std::set<std::string> typenames;
 
 	if(!skipNone) ls.add(numbered ? "(None) (000)" : "(None)", 0);
 	for(int32_t i=1; i<cMAX; ++i)
@@ -384,7 +365,6 @@ GUI::ListData GUI::ZCListData::combotype(bool numbered, bool skipNone)
 			else name = module_str;
 			
 			types[name] = i;
-			typenames.insert(name);
 		}
 		else 
 		{
@@ -394,14 +374,11 @@ GUI::ListData GUI::ZCListData::combotype(bool numbered, bool skipNone)
 			else name = fmt::format("zz{:03}",i);
 			
 			types[name] = i;
-			typenames.insert(name);
 		}
 	}
 
-	for(auto it = typenames.begin(); it != typenames.end(); ++it)
-	{
-		ls.add(*it, types[*it]);
-	}
+	for(auto& [name, val] : types)
+		ls.add(name, val);
 	return ls;
 }
 
@@ -409,7 +386,6 @@ GUI::ListData GUI::ZCListData::mapflag(int32_t numericalFlags, bool numbered, bo
 {
 	GUI::ListData ls;
 	std::map<std::string, int32_t> vals;
-	std::set<std::string> names;
 	
 	if(!skipNone) ls.add(numbered ? "(None) (000)" : "(None)", 0);
 	for(int32_t q = 1; q < mfMAX; ++q)
@@ -425,17 +401,12 @@ GUI::ListData GUI::ZCListData::mapflag(int32_t numericalFlags, bool numbered, bo
 		if (numericalFlags)
 			ls.add(name, q);
 		else
-		{
 			vals[name] = q;
-			names.insert(name);
-		}
 	}
 	if (!numericalFlags)
 	{
-		for(auto it = names.begin(); it != names.end(); ++it)
-		{
-			ls.add(*it, vals[*it]);
-		}
+		for(auto& [name, val] : vals)
+			ls.add(name, val);
 	}
 	
 	return ls;
@@ -459,8 +430,6 @@ GUI::ListData GUI::ZCListData::dmaps(bool numbered)
 GUI::ListData GUI::ZCListData::counters(bool numbered, bool skipNone)
 {
 	GUI::ListData ls;
-	// std::map<std::string, int32_t> vals;
-	// std::set<std::string> names;
 	
 	if(!skipNone) ls.add("(None)", crNONE);
 	for(int32_t q = 0; q < MAX_COUNTERS; ++q)
@@ -473,15 +442,8 @@ GUI::ListData GUI::ZCListData::counters(bool numbered, bool skipNone)
 			sname = fmt::format("{} ({:03})", module_str, q);
 		else sname = module_str;
 		
-		// vals[sname] = q;
-		// names.insert(sname);
 		ls.add(sname, q);
 	}
-	
-	// for(auto it = names.begin(); it != names.end(); ++it)
-	// {
-		// ls.add(*it, vals[*it]);
-	// }
 	
 	return ls;
 }
@@ -489,17 +451,16 @@ GUI::ListData GUI::ZCListData::counters(bool numbered, bool skipNone)
 GUI::ListData GUI::ZCListData::miscsprites(bool skipNone, bool inclNegSpecialVals, bool numbered)
 {
 	std::map<std::string, int32_t> ids;
-	std::set<std::string> sprnames;
 	
-	for(int32_t i=0; i<MAXWPNS; ++i)
+	for(int32_t i=0; i<sprite_data_buf.capacity(); ++i)
 	{
 		std::string name;
+		auto const& spr = sprite_data_buf.get(i);
 		if(numbered)
-			name = fmt::format("{} ({:03})", weapon_string[i], i);
-		else name = weapon_string[i];
+			name = fmt::format("{} ({:04})", spr.name, i);
+		else name = spr.name;
 		
 		ids[name] = i;
-		sprnames.insert(name);
 	}
 	
 	GUI::ListData ls;
@@ -507,9 +468,9 @@ GUI::ListData GUI::ZCListData::miscsprites(bool skipNone, bool inclNegSpecialVal
 	{
 		if(numbered)
 		{
-			ls.add("Grass Clippings (-004)", -4);
-			ls.add("Flower Clippings (-003)", -3);
-			ls.add("Bush Leaves (-002)", -2);
+			ls.add("Grass Clippings (-0004)", -4);
+			ls.add("Flower Clippings (-0003)", -3);
+			ls.add("Bush Leaves (-0002)", -2);
 		}
 		else
 		{
@@ -519,11 +480,13 @@ GUI::ListData GUI::ZCListData::miscsprites(bool skipNone, bool inclNegSpecialVal
 		}
 	}
 	if(!skipNone)
-		ls.add("(None)", -1);
-	for(auto it = sprnames.begin(); it != sprnames.end(); ++it)
 	{
-		ls.add(*it, ids[*it]);
+		if(numbered)
+			ls.add("(None) (-0001)", -1);
+		else ls.add("(None)", -1);
 	}
+	for(auto& [name, val] : ids)
+		ls.add(name, val);
 	return ls;
 }
 
@@ -701,12 +664,12 @@ GUI::ListData GUI::ZCListData::sfxnames(bool numbered)
 	std::map<std::string, int32_t> vals;
 	
 	GUI::ListData ls;
-	ls.add(numbered ? "(None) (000)" : "(None)", 0);
+	ls.add(numbered ? "(None) (00000)" : "(None)", 0);
 	for(size_t q = 0; q < quest_sounds.size(); ++q)
 	{
 		string const& sfx_name = quest_sounds[q].sfx_name;
 		if(numbered)
-			ls.add(fmt::format("{} ({:03})", sfx_name, q+1), q+1);
+			ls.add(fmt::format("{} ({:05})", sfx_name, q+1), q+1);
 		else ls.add(sfx_name, q+1);
 	}
 	
@@ -772,9 +735,9 @@ GUI::ListData GUI::ZCListData::music_names(bool numbered, bool incl_override)
 		if(numbered)
 		{
 			if(amus.name.empty())
-				ls.add(fmt::format("zz{:02} ({:03})",q+1,q+1),q+1);
+				ls.add(fmt::format("zz{:02} ({:05})",q+1,q+1),q+1);
 			else
-				ls.add(fmt::format("{} ({:03})",amus.name,q+1),q+1);
+				ls.add(fmt::format("{} ({:05})",amus.name,q+1),q+1);
 		}
 		else if(amus.name.empty())
 			ls.add(fmt::format("zz{:02}", q+1), q+1);
@@ -884,7 +847,7 @@ GUI::ListData GUI::ZCListData::doorsets()
 	return ls;
 }
 //SCRIPTS
-static void load_scriptnames(std::set<std::string> &names, std::map<std::string, int32_t> &vals,
+static void load_scriptnames(std::map<std::string, int32_t> &vals,
 	std::map<int32_t, script_slot_data> scrmap, int32_t count)
 {
 	for(int32_t i = 0; i < count; ++i)
@@ -895,7 +858,6 @@ static void load_scriptnames(std::set<std::string> &names, std::map<std::string,
 		sname += " (" + std::to_string(i+1) + ")";
 		
 		vals[sname] = i+1;
-		names.insert(sname);
 	}
 }
 
@@ -907,7 +869,6 @@ extern std::string player_slotnames[NUMSCRIPTHERO - 1];
 static GUI::ListData load_scriptnames_slots(std::map<int32_t, script_slot_data> scrmap, int32_t count, std::string* slotnames, bool alphabetize, bool skipempty)
 {
 	std::map<std::string, int32_t> vals;
-	std::set<std::string> names;
 	vector<std::pair<string, int>> empties;
 
 	GUI::ListData ls;
@@ -936,7 +897,6 @@ static GUI::ListData load_scriptnames_slots(std::map<int32_t, script_slot_data> 
 			else
 			{
 				vals[sname] = i + 1;
-				names.insert(sname);
 			}
 		}
 		else
@@ -944,11 +904,9 @@ static GUI::ListData load_scriptnames_slots(std::map<int32_t, script_slot_data> 
 	}
 	if (alphabetize)
 	{
-		ls.add(names, vals);
+		ls.add(vals);
 		for (auto [name, index] : empties)
-		{
 			ls.add(name, index);
-		}
 	}
 	if (ls.empty())
 		ls.add("[No Scripts Found]", 0);
@@ -959,143 +917,132 @@ static GUI::ListData load_scriptnames_slots(std::map<int32_t, script_slot_data> 
 GUI::ListData GUI::ZCListData::itemdata_script()
 {
 	std::map<std::string, int32_t> vals;
-	std::set<std::string> names;
 	
-	load_scriptnames(names,vals,itemmap,NUMSCRIPTITEM-1);
+	load_scriptnames(vals,itemmap,NUMSCRIPTITEM-1);
 	
 	GUI::ListData ls;
 	ls.add("(None)", 0);
-	ls.add(names,vals);
+	ls.add(vals);
 	return ls;
 }
 
 GUI::ListData GUI::ZCListData::itemsprite_script()
 {
 	std::map<std::string, int32_t> vals;
-	std::set<std::string> names;
 	
-	load_scriptnames(names,vals,itemspritemap,NUMSCRIPTSITEMSPRITE-1);
+	load_scriptnames(vals,itemspritemap,NUMSCRIPTSITEMSPRITE-1);
 	
 	GUI::ListData ls;
 	ls.add("(None)", 0);
-	ls.add(names,vals);
+	ls.add(vals);
 	return ls;
 }
 
 GUI::ListData GUI::ZCListData::ffc_script()
 {
 	std::map<std::string, int32_t> vals;
-	std::set<std::string> names;
 	
-	load_scriptnames(names,vals,ffcmap,NUMSCRIPTFFC-1);
+	load_scriptnames(vals,ffcmap,NUMSCRIPTFFC-1);
 	
 	GUI::ListData ls;
 	ls.add("(None)", 0);
-	ls.add(names,vals);
+	ls.add(vals);
 	return ls;
 }
 
 GUI::ListData GUI::ZCListData::npc_script()
 {
 	std::map<std::string, int32_t> vals;
-	std::set<std::string> names;
 
-	load_scriptnames(names, vals, npcmap, NUMSCRIPTGUYS - 1);
+	load_scriptnames(vals, npcmap, NUMSCRIPTGUYS - 1);
 
 	GUI::ListData ls;
 	ls.add("(None)", 0);
-	ls.add(names, vals);
+	ls.add(vals);
 	return ls;
 }
 
 GUI::ListData GUI::ZCListData::dmap_script()
 {
 	std::map<std::string, int32_t> vals;
-	std::set<std::string> names;
 
-	load_scriptnames(names, vals, dmapmap, NUMSCRIPTSDMAP - 1);
+	load_scriptnames(vals, dmapmap, NUMSCRIPTSDMAP - 1);
 
 	GUI::ListData ls;
 	ls.add("(None)", 0);
-	ls.add(names, vals);
+	ls.add(vals);
 	return ls;
 }
 
 GUI::ListData GUI::ZCListData::screen_script()
 {
 	std::map<std::string, int32_t> vals;
-	std::set<std::string> names;
 	
-	load_scriptnames(names,vals,screenmap,NUMSCRIPTSCREEN-1);
+	load_scriptnames(vals,screenmap,NUMSCRIPTSCREEN-1);
 	
 	GUI::ListData ls;
 	ls.add("(None)", 0);
-	ls.add(names,vals);
+	ls.add(vals);
 	return ls;
 }
 
 GUI::ListData GUI::ZCListData::lweapon_script()
 {
 	std::map<std::string, int32_t> vals;
-	std::set<std::string> names;
 	
-	load_scriptnames(names,vals,lwpnmap,NUMSCRIPTWEAPONS-1);
+	load_scriptnames(vals,lwpnmap,NUMSCRIPTWEAPONS-1);
 	
 	GUI::ListData ls;
 	ls.add("(None)", 0);
-	ls.add(names,vals);
+	ls.add(vals);
 	return ls;
 }
 
 GUI::ListData GUI::ZCListData::eweapon_script()
 {
 	std::map<std::string, int32_t> vals;
-	std::set<std::string> names;
 	
-	load_scriptnames(names,vals,ewpnmap,NUMSCRIPTWEAPONS-1);
+	load_scriptnames(vals,ewpnmap,NUMSCRIPTWEAPONS-1);
 	
 	GUI::ListData ls;
 	ls.add("(None)", 0);
-	ls.add(names,vals);
+	ls.add(vals);
 	return ls;
 }
 
 GUI::ListData GUI::ZCListData::combodata_script()
 {
 	std::map<std::string, int32_t> vals;
-	std::set<std::string> names;
 	
-	load_scriptnames(names,vals,comboscriptmap,NUMSCRIPTSCOMBODATA-1);
+	load_scriptnames(vals,comboscriptmap,NUMSCRIPTSCOMBODATA-1);
 	
 	GUI::ListData ls;
 	ls.add("(None)", 0);
-	ls.add(names,vals);
+	ls.add(vals);
 	return ls;
 }
 
 GUI::ListData GUI::ZCListData::generic_script()
 {
 	std::map<std::string, int32_t> vals;
-	std::set<std::string> names;
 	
-	load_scriptnames(names,vals,genericmap,NUMSCRIPTSGENERIC-1);
+	load_scriptnames(vals,genericmap,NUMSCRIPTSGENERIC-1);
 	
 	GUI::ListData ls;
 	ls.add("(None)", 0);
-	ls.add(names,vals);
+	ls.add(vals);
 	return ls;
 }
 
 GUI::ListData GUI::ZCListData::subscreen_script()
 {
 	std::map<std::string, int32_t> vals;
-	std::set<std::string> names;
 	
-	load_scriptnames(names,vals,subscreenmap,NUMSCRIPTSSUBSCREEN-1);
+	load_scriptnames(vals,subscreenmap,NUMSCRIPTSSUBSCREEN-1);
 	
 	GUI::ListData ls;
 	ls.add("(None)", 0);
-	ls.add(names,vals);
+	ls.add(vals);
 	return ls;
 }
 

--- a/src/zinfo.cpp
+++ b/src/zinfo.cpp
@@ -1083,7 +1083,7 @@ int32_t readzinfo(PACKFILE *f, zinfo& z, zquestheader const& hdr)
 		word num_wpns;
 		if(!p_igetw(&num_wpns,f))
 			return qe_invalid;
-		if (num_wpns > MAXWPNS)
+		if (num_wpns > MAXSPRITES)
 			return qe_invalid;
 		for(auto q = 0; q < num_wpns; ++q)
 		{

--- a/src/zq/zq_class.cpp
+++ b/src/zq/zq_class.cpp
@@ -6754,7 +6754,7 @@ int32_t write_weap_data(weapon_data const& data, PACKFILE* f)
 	
 	for (int32_t q = 0; q < WPNSPR_MAX; ++q)
 	{
-		if (!p_putc(data.burnsprs[q], f))
+		if (!p_iputw(data.burnsprs[q], f))
 			new_return(5);
 		if (!p_putc(data.light_rads[q], f))
 			new_return(6);
@@ -8157,7 +8157,7 @@ int32_t writemisc(PACKFILE *f, zquestheader *Header)
 		//V_MISC >= 12
 		for(int32_t q = 0; q < sprMAX; ++q)
 		{
-			if(!p_putc(QMisc.sprites[q],f))
+			if(!p_iputw(QMisc.sprites[q],f))
 				new_return(24);
 		}
 		
@@ -8395,35 +8395,9 @@ int32_t write_single_item(PACKFILE *f, word index)
 		if(!p_iputl(item_ref.initiald[j],f))
 			new_return(24);
 	
-	if(!p_putc(item_ref.wpn,f))
-		new_return(26);
-	
-	if(!p_putc(item_ref.wpn2,f))
-		new_return(27);
-	
-	if(!p_putc(item_ref.wpn3,f))
-		new_return(28);
-	
-	if(!p_putc(item_ref.wpn4,f))
-		new_return(29);
-	
-	if(!p_putc(item_ref.wpn5,f))
-		new_return(30);
-	
-	if(!p_putc(item_ref.wpn6,f))
-		new_return(31);
-	
-	if(!p_putc(item_ref.wpn7,f))
-		new_return(32);
-	
-	if(!p_putc(item_ref.wpn8,f))
-		new_return(33);
-	
-	if(!p_putc(item_ref.wpn9,f))
-		new_return(34);
-	
-	if(!p_putc(item_ref.wpn10,f))
-		new_return(35);
+	for (int q = 0; q < 10; ++q)
+		if(!p_iputw(item_ref.wpn_sprites[q],f))
+			new_return(26);
 	
 	if(!p_putc(item_ref.pickup_hearts,f))
 		new_return(36);
@@ -8611,11 +8585,29 @@ int32_t writeitems(PACKFILE *f, zquestheader *)
     new_return(0);
 }
 
-int32_t writeweapons(PACKFILE *f, zquestheader *Header)
+int32_t write_single_spritedata(PACKFILE* f, word index)
 {
-    //these are here to bypass compiler warnings about unused arguments
-    Header=Header;
-    
+	sprite_data const& wpnspr = sprite_data_buf.get(index);
+	if (!p_putcstr(wpnspr.name, f))
+		new_return(6);
+	if(!p_putc(wpnspr.misc, f))
+		new_return(7);
+	if(!p_putc(wpnspr.csets, f))
+		new_return(8);
+	if(!p_putc(wpnspr.frames, f))
+		new_return(9);
+	if(!p_putc(wpnspr.speed, f))
+		new_return(10);
+	if(!p_putc(wpnspr.type, f))
+		new_return(11);
+	if(!p_iputw(wpnspr.script, f))
+		new_return(12);
+	if(!p_iputl(wpnspr.tile, f))
+		new_return(13);
+	return 0;
+}
+int32_t writeweapons(PACKFILE *f, zquestheader*)
+{
     dword section_id=ID_WEAPONS;
     dword section_version=V_WEAPONS;
     dword section_size = 0;
@@ -8637,6 +8629,7 @@ int32_t writeweapons(PACKFILE *f, zquestheader *Header)
         new_return(3);
     }
     
+	sprite_data_buf.normalize();
     for(int32_t writecycle=0; writecycle<2; ++writecycle)
     {
         fake_pack_writing=(writecycle==0);
@@ -8650,61 +8643,20 @@ int32_t writeweapons(PACKFILE *f, zquestheader *Header)
         writesize=0;
         
         //finally...  section data
-        if(!p_iputw(MAXWPNS,f))
+		word sprite_count = sprite_data_buf.capacity();
+        if(!p_iputw(sprite_count,f))
         {
             new_return(5);
         }
-        
-        for(int32_t i=0; i<MAXWPNS; i++)
+		
+        for(word i=0; i < sprite_count; i++)
         {
-            if(!pfwrite((char *)weapon_string[i], 64, f))
-            {
-                new_return(5);
-            }
-        }
-        
-        for(int32_t i=0; i<MAXWPNS; i++)
-        {            
-            if(!p_putc(wpnsbuf[i].misc,f))
-            {
-                new_return(7);
-            }
-            
-            if(!p_putc(wpnsbuf[i].csets,f))
-            {
-                new_return(8);
-            }
-            
-            if(!p_putc(wpnsbuf[i].frames,f))
-            {
-                new_return(9);
-            }
-            
-            if(!p_putc(wpnsbuf[i].speed,f))
-            {
-                new_return(10);
-            }
-            
-            if(!p_putc(wpnsbuf[i].type,f))
-            {
-                new_return(11);
-            }
-	    
-	        if(!p_iputw(wpnsbuf[i].script,f))
-            {
-                new_return(12);
-            }
-	    
-	        if(!p_iputl(wpnsbuf[i].tile,f))
-            {
-                new_return(12);
-            }
+			if (auto ret = write_single_spritedata(f, i))
+				return ret;          
         }
         
         if(writecycle==0)
-        {
             section_size=writesize;
-        }
     }
     
     if(writesize!=int32_t(section_size) && save_warn)
@@ -9644,7 +9596,7 @@ int32_t writecombo_loop(PACKFILE *f, word section_version, newcombo const& tmp_c
 			return 61;
 		if(!p_putc(tmp_cmb.liftgfx,f))
 			return 62;
-		if(!p_putc(tmp_cmb.liftsprite,f))
+		if(!p_iputw(tmp_cmb.liftsprite,f))
 			return 63;
 		if(!p_iputw(tmp_cmb.liftsfx,f))
 			return 64;
@@ -9679,23 +9631,23 @@ int32_t writecombo_loop(PACKFILE *f, word section_version, newcombo const& tmp_c
 			return 82;
 		if(!p_iputw(tmp_cmb.sfx_standing,f))
 			return 83;
-		if(!p_putc(tmp_cmb.spr_appear,f))
+		if(!p_iputw(tmp_cmb.spr_appear,f))
 			return 84;
-		if(!p_putc(tmp_cmb.spr_disappear,f))
+		if(!p_iputw(tmp_cmb.spr_disappear,f))
 			return 85;
-		if(!p_putc(tmp_cmb.spr_walking,f))
+		if(!p_iputw(tmp_cmb.spr_walking,f))
 			return 86;
-		if(!p_putc(tmp_cmb.spr_standing,f))
+		if(!p_iputw(tmp_cmb.spr_standing,f))
 			return 87;
 		if(!p_iputw(tmp_cmb.sfx_tap,f))
 			return 88;
 		if(!p_iputw(tmp_cmb.sfx_landing,f))
 			return 89;
-		if(!p_putc(tmp_cmb.spr_falling,f))
+		if(!p_iputw(tmp_cmb.spr_falling,f))
 			return 90;
-		if(!p_putc(tmp_cmb.spr_drowning,f))
+		if(!p_iputw(tmp_cmb.spr_drowning,f))
 			return 91;
-		if(!p_putc(tmp_cmb.spr_lava_drowning,f))
+		if(!p_iputw(tmp_cmb.spr_lava_drowning,f))
 			return 92;
 		if(!p_iputw(tmp_cmb.sfx_falling,f))
 			return 93;
@@ -11238,11 +11190,11 @@ int32_t writeguys(PACKFILE *f, zquestheader *Header)
 			}
 			if(!p_iputl(guysbuf[i].moveflags,f))
 				new_return(99);
-			if(!p_putc(guysbuf[i].spr_shadow,f))
+			if(!p_iputw(guysbuf[i].spr_shadow,f))
 				new_return(100);
-			if(!p_putc(guysbuf[i].spr_death,f))
+			if(!p_iputw(guysbuf[i].spr_death,f))
 				new_return(101);
-			if(!p_putc(guysbuf[i].spr_spawn,f))
+			if(!p_iputw(guysbuf[i].spr_spawn,f))
 				new_return(102);
 			if (!p_iputw(guysbuf[i].specialsfx, f))
 				new_return(103);

--- a/src/zq/zq_class.h
+++ b/src/zq/zq_class.h
@@ -556,6 +556,7 @@ void center_zq_class_dialogs();
 
 int32_t write_single_item(PACKFILE *f, word index);
 int32_t writeitems(PACKFILE *f, zquestheader *Header);
+int32_t write_single_spritedata(PACKFILE *f, word index);
 int32_t writeweapons(PACKFILE *f, zquestheader *Header);
 int32_t writemisccolors(PACKFILE *f, zquestheader *Header);
 int32_t writegameicons(PACKFILE *f, zquestheader *Header);

--- a/src/zq/zq_custom.cpp
+++ b/src/zq/zq_custom.cpp
@@ -32,8 +32,6 @@
 extern int32_t ex;
 extern void reset_itembuf(itemdata *item, int32_t id);
 
-extern int32_t biw_cnt;
-
 void large_dialog(DIALOG *d)
 {
 	large_dialog(d, 1.5f);
@@ -250,7 +248,7 @@ int32_t onMiscSprites()
 	{
 		mark_save_dirty();
 		for(auto q = 0; q < sprMAX; ++q)
-			QMisc.sprites[q] = byte(newsprs[q]);
+			QMisc.sprites[q] = word(newsprs[q]);
 	}).show();
 	return D_O_K;
 }
@@ -696,12 +694,15 @@ int32_t readonenpc(PACKFILE *f, int32_t index)
 			}
 
 			//was missing for some reason has been added
-			if (!p_getc(&tempguy.spr_shadow, f))
+			if (!p_getc(&tempbyte, f))
 				return 0;
-			if (!p_getc(&tempguy.spr_death, f))
+			tempguy.spr_shadow = tempbyte;
+			if (!p_getc(&tempbyte, f))
 				return 0;
-			if (!p_getc(&tempguy.spr_spawn, f))
+			tempguy.spr_death = tempbyte;
+			if (!p_getc(&tempbyte, f))
 				return 0;
+			tempguy.spr_spawn = tempbyte;
 			if (!p_igetl(&tempguy.moveflags, f))
 				return 0;
 			
@@ -736,8 +737,9 @@ int32_t readonenpc(PACKFILE *f, int32_t index)
 			tempguy.weap_data.step = zslongToFix(temp_step*100);
 			for (int q=0; q < WPNSPR_MAX; ++q)
 			{
-				if (!p_getc(&tempguy.weap_data.burnsprs[q], f))
+				if (!p_getc(&tempbyte, f))
 					return 0;
+				tempguy.weap_data.burnsprs[q] = tempbyte;
 				if (!p_getc(&tempguy.weap_data.light_rads[q], f))
 					return 0;
 			}

--- a/src/zq/zq_misc.h
+++ b/src/zq/zq_misc.h
@@ -52,7 +52,6 @@ extern char ns_string[4];
 extern const char *old_item_string[iLast];
 extern const char *old_weapon_string[wLast];
 extern const char *old_sfx_string[Z35];
-extern char *weapon_string[MAXWPNS];
 extern const char *warptype_string[MAXWARPTYPES];
 extern const char *warpeffect_string[MAXWARPEFFECTS];
 extern const char	*old_guy_string[OLDMAXGUYS];

--- a/src/zq/zq_tiles.cpp
+++ b/src/zq/zq_tiles.cpp
@@ -38,6 +38,8 @@
 #include <fmt/format.h>
 #include <functional>
 #include "zq/moveinfo.h"
+#include "zc_list_data.h"
+#include "sprite_data.h"
 using std::set;
 
 
@@ -6436,23 +6438,23 @@ bool _handle_tile_move(TileMoveProcess dest_process, optional<TileMoveProcess> s
 			? "The tiles used by the following weapons will be partially cleared by the move."
 			: "The tiles used by the following weapons will be partially or completely overwritten by this process."
 			));
-		build_biw_list();
+		GUI::ListData biw_list = GUI::ZCListData::miscsprites(true, false, true);
 		
-		for(int32_t u=0; u<MAXWPNS; u++)
+		for(int32_t u=0; u<sprite_data_buf.capacity(); u++)
 		{
 			bool ignore_frames=false;
 			int32_t m=0;
 			
-			auto id = biw[u].i;
-			auto& wpn = wpnsbuf[id];
+			auto id = biw_list.getValue(u);
+			auto& wpn = sprite_data_buf[id];
 			
-			switch(biw[u].i)
+			switch(id)
 			{
 			case wSWORD:
 			case wWSWORD:
 			case wMSWORD:
 			case wXSWORD:
-				m=3+((wpnsbuf[biw[u].i].type==3)?1:0);
+				m=3+((wpn.type==3)?1:0);
 				break;
 				
 			case wSWORDSLASH:
@@ -6533,7 +6535,7 @@ bool _handle_tile_move(TileMoveProcess dest_process, optional<TileMoveProcess> s
 			}
 			
 			movelist->add_tile(&wpn.tile, zc_max((ignore_frames?0:wpn.frames),1)*m,
-				1, fmt::format("{} {}", biw[u].s, id));
+				1, fmt::format("{} {}", wpn.name, id));
 			
 			//Tile 54+55 are "Impact (not shown in sprite list)", for u==3 "Arrow" and u==9 "Boomerang"
 			//...these can't be updated by a move.

--- a/src/zq/zquest.cpp
+++ b/src/zq/zquest.cpp
@@ -457,7 +457,6 @@ int32_t showxypos_cursor_color;
 bool showxypos_dummy = false;
 
 bool canfill=true;                                          //to prevent double-filling (which stops undos)
-int32_t lens_hint_weapon[MAXWPNS][5];                           //aclk, aframe, dir, x, y
 //int32_t mode, switch_mode, orig_mode;
 int32_t tempmode=GFX_AUTODETECT;
 RGB_MAP* zq_rgb_table;
@@ -465,7 +464,6 @@ MIDI *song=NULL;
 BITMAP *mapscreenbmp, *screen2, *mouse_bmp[MOUSE_BMP_MAX][4], *mouse_bmp_1x[MOUSE_BMP_MAX][4], *icon_bmp[ICON_BMP_MAX][4], *flag_bmp[16][4], *select_bmp[2], *dmapbmp_small, *dmapbmp_large;
 BITMAP *arrow_bmp[MAXARROWS],*brushbmp, *brushscreen; //*brushshadowbmp;
 byte *colordata=NULL, *trashbuf=NULL;
-wpndata  *wpnsbuf;
 comboclass *combo_class_buf;
 guydata  *guysbuf;
 item_drop_object item_drop_sets[MAXITEMDROPSETS];
@@ -12354,35 +12352,12 @@ static DIALOG list_dlg[] =
     { NULL,                 0,    0,    0,    0,   0,       0,       0,       0,          0,             0,       NULL,                           NULL,  NULL }
 };
 
-weapon_struct biw[MAXWPNS];
-int32_t biw_cnt=-1;
-
-void build_biw_list()
-{
-    int32_t start=biw_cnt=0;
-    
-    for(int32_t i=start; i<MAXWPNS; i++)
-    {
-        biw[biw_cnt].s = (char *)weapon_string[i];
-        biw[biw_cnt].i = i;
-        ++biw_cnt;
-    }
-    
-    for(int32_t i=start; i<biw_cnt-1; i++)
-    {
-        for(int32_t j=i+1; j<biw_cnt; j++)
-            if(stricmp(biw[i].s,biw[j].s)>0 && strcmp(biw[j].s,""))
-                zc_swap(biw[i],biw[j]);
-    }
-}
-
 int32_t writeoneweapon(PACKFILE *f, int32_t index)
 {
     dword section_version=V_WEAPONS;
     int32_t zversion = ZELDA_VERSION;
     int32_t zbuild = VERSION_BUILD;
-    int32_t iid = biw[index].i;
-    al_trace("Writing Weapon Sprite .zwpnspr file for weapon id: %d\n", iid);
+    al_trace("Writing Weapon Sprite .zwpnspr file for weapon id: %d\n", index);
   
     //section version info
     if(!p_iputl(zversion,f))
@@ -12403,48 +12378,8 @@ int32_t writeoneweapon(PACKFILE *f, int32_t index)
 	    return 0;
     }
     
-    //weapon string
-	
-    if(!pfwrite((char *)weapon_string[iid], 64, f))
-    {
-        return 0;
-    }
-            
-    if(!p_putc(wpnsbuf[iid].misc,f))
-    {
-        return 0;
-    }
-            
-    if(!p_putc(wpnsbuf[iid].csets,f))
-    {
-        return 0;
-    }
-            
-    if(!p_putc(wpnsbuf[iid].frames,f))
-    {
-        return 0;
-    }
-            
-    if(!p_putc(wpnsbuf[iid].speed,f))
-    {
-        return 0;
-    }
-            
-    if(!p_putc(wpnsbuf[iid].type,f))
-    {
-        return 0;
-    }
-	    
-    if(!p_iputw(wpnsbuf[iid].script,f))
-    {
-        return 0;
-    }
-	    
-    //2.55 starts here
-    if(!p_iputl(wpnsbuf[iid].tile,f))
-    {
-        return 0;
-    }
+	if (write_single_spritedata(f, index))
+		return 0;
 
     return 1;
 }
@@ -12455,11 +12390,7 @@ int32_t readoneweapon(PACKFILE *f, int32_t index)
 	dword section_version = 0;
 	int32_t zversion = 0;
 	int32_t zbuild = 0;
-	wpndata tempwpnspr;
-	memset(&tempwpnspr, 0, sizeof(wpndata));
-     
-   
-	//char dmapstring[64]={0};
+    
 	//section version info
 	if(!p_igetl(&zversion,f))
 	{
@@ -12496,66 +12427,14 @@ int32_t readoneweapon(PACKFILE *f, int32_t index)
 		al_trace("Reading a .zwpnspr packfile made in ZC Version: %x, Build: %d\n", zversion, zbuild);
 	}
 	
-	char tmp_wpn_name[64];
-	memset(tmp_wpn_name,0,64);
-	if(!pfread(&tmp_wpn_name, 64, f))
-	{
+	char tmp_wpn_name[65] = {0};
+	if (section_version < 9)
+		if(!pfread(&tmp_wpn_name, 64, f))
+			return 0;
+	if (read_single_spritedata(f, &header, section_version, index))
 		return 0;
-	}
-	
-    word oldtile = 0;
-    if(section_version < 8)
-	    if(!p_igetw(&oldtile,f))
-            return 0;
-            
-    if(!p_getc(&tempwpnspr.misc,f))
-    {
-        return 0;
-    }
-            
-    if(!p_getc(&tempwpnspr.csets,f))
-    {
-        return 0;
-    }
-            
-    if(!p_getc(&tempwpnspr.frames,f))
-    {
-        return 0;
-    }
-            
-    if(!p_getc(&tempwpnspr.speed,f))
-    {
-        return 0;
-    }
-    
-    if(!p_getc(&tempwpnspr.type,f))
-    {
-        return 0;
-    }
-	
-	if(!p_igetw(&tempwpnspr.script,f))
-    {
-        return 0;
-    }
-
-	//2.55 starts here
-	if ( zversion >= 0x255 )
-	{
-		if  ( section_version >= 7 )
-		{
-			if(!p_igetl(&tempwpnspr.tile,f))
-			{
-				return 0;
-			}
-		}
-	}
-	if ( zversion < 0x255 ) 
-	{
-		tempwpnspr.tile = oldtile;
-	}
-	::memcpy( &(wpnsbuf[biw[index].i]),&tempwpnspr, sizeof(wpndata));
-	::memcpy(weapon_string[biw[index].i], tmp_wpn_name, 64);
-       
+	if (section_version < 9)
+		sprite_data_buf[index].name = tmp_wpn_name;
 	return 1;
 }
 
@@ -19600,13 +19479,6 @@ static void allocate_crap()
 		Z_error_fatal("Error: no memory for file paths!");
 	}
 	
-	for(int32_t i=0; i<MAXWPNS; i++)
-	{
-		if(weapon_string[i]!=NULL) delete weapon_string[i];
-		weapon_string[i] = new char[64];
-		memset(weapon_string[i], 0, 64);
-	}
-	
 	for(int32_t i=0; i<eMAXGUYS; i++)
 	{
 		if(guy_string[i]!=NULL) delete guy_string[i];
@@ -20198,13 +20070,7 @@ int32_t main(int32_t argc,char **argv)
 		zq_exit(0);
 	}
 
-	reset_lens_hint_items();
-	
-	for(int32_t x=0; x<MAXWPNS; x++)
-	{
-		lens_hint_weapon[x][0]=0;
-		lens_hint_weapon[x][1]=0;
-	}
+	reset_lens_hints();
 	
 	load_selections();
 	load_arrows();
@@ -21086,11 +20952,6 @@ void quit_game()
     remove_locked_params_on_exit();
 
 	quest_sounds.clear();
-    
-    for(int32_t i=0; i<MAXWPNS; i++)
-    {
-        delete [] weapon_string[i];
-    }
     
     for(int32_t i=0; i<eMAXGUYS; i++)
     {

--- a/src/zq/zquest.h
+++ b/src/zq/zquest.h
@@ -130,14 +130,12 @@ extern BITMAP* asset_arrows_bmp;
 extern MIDI* asset_tunes_midi;
 extern PALETTE asset_pal;
 
-extern int32_t lens_hint_weapon[MAXWPNS][5];                    //aclk, aframe, dir, x, y
 extern RGB_MAP* zq_rgb_table;
 extern MIDI *song;
 extern BITMAP *mapscreenbmp, *screen2, *mouse_bmp[MOUSE_BMP_MAX][4], *mouse_bmp_1x[MOUSE_BMP_MAX][4], *icon_bmp[ICON_BMP_MAX][4], *flag_bmp[16][4], *panel_button_icon_bmp[m_menucount][4], *select_bmp[2],*dmapbmp_small, *dmapbmp_large;
 extern BITMAP *arrow_bmp[MAXARROWS],*brushbmp, *brushscreen;
 extern byte *colordata, *trashbuf;
 extern comboclass *combo_class_buf;
-extern wpndata  *wpnsbuf;
 extern guydata  *guysbuf;
 extern item_drop_object    item_drop_sets[MAXITEMDROPSETS];
 extern midi_info Midi_Info;
@@ -421,19 +419,9 @@ int32_t onUnderCombo();
 int32_t onCompileScript();
 int32_t onSlotPreview();
 
-typedef struct weapon_struct
-{
-    char *s;
-    int32_t i;
-} weapon_struct;
-
-extern weapon_struct biw[MAXWPNS];
-
 int32_t set_comboaradio(byte layermask);
 extern int32_t alias_origin;
 void draw_combo_alias_thumbnail(BITMAP *dest, combo_alias const* combo, int32_t x, int32_t y, int32_t size);
-
-void build_biw_list();
 
 int32_t d_combo_proc(int32_t msg,DIALOG *d,int32_t c);
 int32_t onDoors();


### PR DESCRIPTION
Done:
- Changed sprite data in memory
- renamed from `wpndata` -> `sprite_data`, `wpnsbuf` -> `sprite_data_buf`.
- Increase sprite ID storage vars `byte`->`word`