### PR TITLE
fix(zc): Stunned hero no longer stops dead in his tracks on ice

### DIFF
--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -9832,8 +9832,7 @@ heroanimate_skip_liftwpn:;
 		// call the main movement routine
 		if(get_qr(qr_NEW_HERO_MOVEMENT2))
 		{
-			if(premove())
-				movehero();
+			movehero(premove());
 		}
 		else
 		{
@@ -19475,13 +19474,19 @@ bool HeroClass::premove()
 	}
 	return true;
 }
-void HeroClass::movehero()
+void HeroClass::movehero(bool premove_passed)
 {
 	bool earlyret = false;
 	bool nohorz = (isdungeon() && (y<=26 || y>=world_h-42) && !get_qr(qr_FREEFORM) && !walk_through_walls);
 	bool novert = (isdungeon() && (x<=26 || x>=world_w - 42) && !get_qr(qr_FREEFORM) && !walk_through_walls);
 	zfix dx, dy;
 	auto push=pushing;
+	if (!premove_passed)
+	{
+		if (sliding)
+			goto newmove_slide;
+		else return;
+	}
 	pushing=0;
 	
 	if(!is_conveyor_stunned && !is_autowalking()) //these do not apply to conveyor auto-walk

--- a/src/zc/hero.h
+++ b/src/zc/hero.h
@@ -386,7 +386,7 @@ public:
 	bool can_moveDir(int dir, zfix px, bool kb = false, bool ign_sv = false, bool shove = false);
 	void snap_platform();
 	bool premove();
-	void movehero();
+	void movehero(bool premove_passed);
 	bool new_engine_move(zfix dx, zfix dy);
 	void moveOld(int32_t d2);
 	void moveOld2(int32_t d2, int32_t forceRate = -1);


### PR DESCRIPTION
The ice momentum now continues while stunned (as though you were pressing no inputs)