### PR TITLE
fix!: OGG SFX not properly cleaning up allocated stream when stopped

### DIFF
--- a/src/zcsfx.cpp
+++ b/src/zcsfx.cpp
@@ -369,8 +369,7 @@ namespace // sample implementations
 	}
 	void SampleOGG::stop()
 	{
-		if (stream)
-			al_set_audio_stream_playing(stream, false);
+		cleanup_stream();
 	}
 	bool SampleOGG::ensure_stream()
 	{


### PR DESCRIPTION
This caused an OGG used for a Whistle sfx to softlock.