### PR TITLE
fix(zc)!: exstate carryover checking wrong state

### DIFF
--- a/src/zc/maps.cpp
+++ b/src/zc/maps.cpp
@@ -1688,7 +1688,7 @@ void setxmapflag_mi(int32_t mi, uint32_t flag)
 		
 		while((nmap!=0) && !looped && !(nscr>=128))
 		{
-			if(!(game->maps.get(((nmap-1)<<7)+nscr) & flag))
+			if(!(game->xstates.get(((nmap-1)<<7)+nscr) & flag))
 			{
 				log_state_change(nmap, nscr, "ExState change carried over");
 				if (replay_is_active())


### PR DESCRIPTION
a normal state being set could prevent the exstate from carrying over.