### PR TITLE
feat: Light Offsets

### DIFF
--- a/resources/include/bindings/eweapon.zh
+++ b/resources/include/bindings/eweapon.zh
@@ -283,6 +283,12 @@ class eweapon {
 	// @zasm_var EWPNBURNLIGHTRADIUS
 	internal int BurnLightRadius[];
 
+	// The burning light offsets associated with sprites of the weapon.
+	//
+	// @index [enum WeaponSpriteIndex]
+	// @zasm_var EWPNBURNLIGHTOFFSET
+	internal int BurnLightOffset[];
+
 	// @deprecated - This is now just the internal engine ID, which is the same as doing `<int>some_sprite`.
 	// @zasm_var EWEAPONSCRIPTUID
 	internal const int UID;

--- a/resources/include/bindings/lweapon.zh
+++ b/resources/include/bindings/lweapon.zh
@@ -327,6 +327,12 @@ class lweapon {
 	// @zasm_var LWPNBURNLIGHTRADIUS
 	internal int BurnLightRadius[];
 
+	// The burning light offsets associated with sprites of the weapon.
+	//
+	// @index [enum WeaponSpriteIndex]
+	// @zasm_var LWPNBURNLIGHTOFFSET
+	internal int BurnLightOffset[];
+
 	// @deprecated - This is now just the internal engine ID, which is the same as doing `<int>some_sprite`.
 	// @zasm_var LWEAPONSCRIPTUID
 	internal const int UID;

--- a/resources/include/bindings/sprite.zh
+++ b/resources/include/bindings/sprite.zh
@@ -315,6 +315,12 @@ class sprite {
 	// @zasm_var SPRITE_LIGHT_RADIUS
 	internal int LightRadius;
 
+	// The offset of the light emitted by this sprite, in pixels.
+	// Positive offset goes in the [Dir], while negative is opposite of [Dir].
+	//
+	// @zasm_var SPRITE_LIGHT_OFFSET
+	internal int LightOffset;
+
 	// The shape of light emitted by this sprite.
 	//
 	// @value [enum LightShape]

--- a/src/components/zasm/defines.h
+++ b/src/components/zasm/defines.h
@@ -3379,6 +3379,9 @@ enum ASM_DEFINE
 #define LWPN_BOUNCE_ADD                0x16AF
 #define EWPN_BOUNCE_MULT               0x16B0
 #define EWPN_BOUNCE_ADD                0x16B1
+#define SPRITE_LIGHT_OFFSET            0x16B2
+#define LWPNBURNLIGHTOFFSET            0x16B3
+#define EWPNBURNLIGHTOFFSET            0x16B4
 
 // unused block (we can fill this out)
 #define SPRITE_SHADOW_XOFS      0x16E7

--- a/src/components/zasm/table.cpp
+++ b/src/components/zasm/table.cpp
@@ -930,6 +930,7 @@ static constexpr script_variable variable_list[]=
 	{ "SPRITE_MOVE_FLAGS", SPRITE_MOVE_FLAGS, 0 },
 	{ "SPRITE_LIGHT_RADIUS", SPRITE_LIGHT_RADIUS, 0 },
 	{ "SPRITE_LIGHT_SHAPE", SPRITE_LIGHT_SHAPE, 0 },
+	{ "SPRITE_LIGHT_OFFSET", SPRITE_LIGHT_OFFSET, 0 },
 	{ "SPRITE_SWHOOKED", SPRITE_SWHOOKED, 0 },
 	{ "SPRITE_SHADOW_SPR", SPRITE_SHADOW_SPR, 0 },
 	{ "SPRITE_DROWN_CLK", SPRITE_DROWN_CLK, 0 },
@@ -2453,6 +2454,8 @@ static constexpr script_variable variable_list[]=
 
 	{ "LWPNBURNLIGHTRADIUS", LWPNBURNLIGHTRADIUS, 0},
 	{ "EWPNBURNLIGHTRADIUS", EWPNBURNLIGHTRADIUS, 0},
+	{ "LWPNBURNLIGHTOFFSET", LWPNBURNLIGHTOFFSET, 0},
+	{ "EWPNBURNLIGHTOFFSET", EWPNBURNLIGHTOFFSET, 0},
 
 	{ "IDATAATTRIB_L", IDATAATTRIB_L, 0},
 
@@ -3095,6 +3098,7 @@ static std::vector<int> _get_register_dependencies(int reg)
 		case DROPSETCHANCES:
 		case DROPSETITEMS:
 		case EWPNBURNLIGHTRADIUS:
+		case EWPNBURNLIGHTOFFSET:
 		case EWPNFLAGS:
 		case EWPNINITD:
 		case EWPNMISCD:
@@ -3161,6 +3165,7 @@ static std::vector<int> _get_register_dependencies(int reg)
 		case LINKITEMD:
 		case LINKMISCD:
 		case LWPNBURNLIGHTRADIUS:
+		case LWPNBURNLIGHTOFFSET:
 		case LWPNFLAGS:
 		case LWPNINITD:
 		case LWPNMISCD:
@@ -3686,6 +3691,7 @@ std::optional<int> get_register_ref_dependency(int reg)
 		case EWPNAUTOROTATE:
 		case EWPNBEHIND:
 		case EWPNBURNLIGHTRADIUS:
+		case EWPNBURNLIGHTOFFSET:
 		case EWPNCOLLDET:
 		case EWPNCSET:
 		case EWPNDEAD:
@@ -3965,6 +3971,7 @@ std::optional<int> get_register_ref_dependency(int reg)
 		case LWPNAUTOROTATE:
 		case LWPNBEHIND:
 		case LWPNBURNLIGHTRADIUS:
+		case LWPNBURNLIGHTOFFSET:
 		case LWPNCOLLDET:
 		case LWPNCSET:
 		case LWPNDEAD:
@@ -4489,6 +4496,7 @@ std::optional<int> get_register_ref_dependency(int reg)
 		case SPRITE_JUMP:
 		case SPRITE_LIGHT_RADIUS:
 		case SPRITE_LIGHT_SHAPE:
+		case SPRITE_LIGHT_OFFSET:
 		case SPRITE_MISCD:
 		case SPRITE_MOVE_FLAGS:
 		case SPRITE_ROTATION:

--- a/src/core/qst.cpp
+++ b/src/core/qst.cpp
@@ -911,6 +911,9 @@ int32_t read_weap_data(weapon_data& data, PACKFILE* f)
 			return qe_invalid;
 		if (!p_getc(&(data.light_rads[q]), f))
 			return qe_invalid;
+		if (v_weapon_data >= 3)
+			if (!p_igetl(&(data.light_offsets[q]), f))
+				return qe_invalid;
 	}
 	if (!p_getc(&(data.glow_shape), f))
 		return qe_invalid;

--- a/src/core/weapon_data.h
+++ b/src/core/weapon_data.h
@@ -27,6 +27,7 @@ struct weapon_data
 	
 	word burnsprs[WPNSPR_MAX];
 	byte light_rads[WPNSPR_MAX];
+	int32_t light_offsets[WPNSPR_MAX];
 	byte glow_shape;
 	
 	int32_t override_flags;

--- a/src/core/zdefs.h
+++ b/src/core/zdefs.h
@@ -167,7 +167,7 @@ enum {ENC_METHOD_192B104=0, ENC_METHOD_192B105, ENC_METHOD_192B185, ENC_METHOD_2
 
 // not 'real' sections, just separate version numbers
 #define V_COMPATRULE       108
-#define V_WEAP_DATA        2
+#define V_WEAP_DATA        3
 
 //= V_SHOPS is under V_MISC
 

--- a/src/dialog/comboeditor.cpp
+++ b/src/dialog/comboeditor.cpp
@@ -1867,6 +1867,10 @@ void ComboEditorDialog::loadComboType()
 			h_attribute[9] = "The shape of light. 0=circle, 1=cone, 2=square";
 			l_attribute[10] = "Direction:";
 			h_attribute[10] = "The direction the torch is facing, for direction-requiring shapes like 'cone'.";
+			l_attribute[11] = "Offset:";
+			h_attribute[11] = "An offset for the source of the light, in pixels."
+				"\nPositive offsets are in the specified direction,"
+				" negative offsets are in the opposite direction.";
 			break;
 		}
 		case cSPOTLIGHT:

--- a/src/dialog/combowizard.cpp
+++ b/src/dialog/combowizard.cpp
@@ -2462,9 +2462,11 @@ std::shared_ptr<GUI::Widget> ComboWizardDialog::view()
 			zfix& radius = local_ref.c_attributes[8];
 			zfix& shape = local_ref.c_attributes[9];
 			zfix& dir = local_ref.c_attributes[10];
+			zfix& offset = local_ref.c_attributes[11];
 			radius.doTrunc();
 			shape.doTrunc();
 			dir.doTrunc();
+			offset.doTrunc();
 			
 			windowRow->add(
 				Rows<3>(
@@ -2493,7 +2495,20 @@ std::shared_ptr<GUI::Widget> ComboWizardDialog::view()
 						{
 							dir = val;
 						}),
-					INFOBTN("The direction to cast light in, if the shape is directional (like a cone)")
+					INFOBTN("The direction to cast light in, if the shape is directional (like a cone)."
+						" Also determines the direction of the Offset."),
+					Label(text = "Offset", hAlign = 1.0),
+					TextField(
+						fitParent = true, minwidth = 8_em,
+						type = GUI::TextField::type::INT_DECIMAL,
+						low = -255, high = 255, val = offset,
+						onValChangedFunc = [&](GUI::TextField::type,std::string_view,int32_t val)
+						{
+							offset = val;
+						}),
+					INFOBTN("An offset for the source of the light, in pixels."
+						"\nPositive offsets are in the specified direction,"
+						" negative offsets are in the opposite Direction.")
 				)
 			);
 			break;

--- a/src/dialog/itemeditor.cpp
+++ b/src/dialog/itemeditor.cpp
@@ -987,6 +987,9 @@ void loadinfo(ItemNameInfo * inf, itemdata const& ref)
 			_SET(misc[0], "Shape", "What shape to use for the light area emitted.\n"
 				"0 = circular, 1 = cone in front, 2 = square");
 			_SET(misc[1], "Range", "The range, in pixels, of the light.");
+			_SET(misc[2], "Offset", "An offset for the source of the light, in pixels."
+				"\nPositive offsets are in the direction the player is facing,"
+				" negative offsets are in the opposite direction.");
 			_SET(flag[0], "No Light 'Wave'", "The light cast from this item is not affected by the 'light wave' settings");
 			break;
 		}

--- a/src/dialog/itemwizard.cpp
+++ b/src/dialog/itemwizard.cpp
@@ -27,6 +27,7 @@ bool hasItemWizard(int32_t type)
 	{
 		case itype_shield:
 		case itype_note:
+		case itype_lantern:
 			return true;
 	}
 	return false;
@@ -83,6 +84,7 @@ void ItemWizardDialog::update([[maybe_unused]] bool first)
 			break;
 		}
 		case itype_note:
+		case itype_lantern:
 			break;
 	}
 	disable(-1, true); //always disabled
@@ -132,6 +134,7 @@ void ItemWizardDialog::endUpdate()
 			break;
 		}
 		case itype_note:
+		case itype_lantern:
 			break;
 	}
 }
@@ -169,7 +172,10 @@ void item_default(itemdata& ref)
 			ref.misc1 = sh_rock|sh_arrow|sh_brang;
 			break;
 		case itype_note:
-			ref.misc1 = 0;
+			break;
+		case itype_lantern:
+			ref.misc1 = 1; // Cone
+			ref.misc2 = 40; // Range
 			break;
 	}
 }
@@ -424,6 +430,49 @@ std::shared_ptr<GUI::Widget> ItemWizardDialog::view()
 					INFOBTN("Plays when the note is opened")
 				)
 			));
+			break;
+		}
+		case itype_lantern:
+		{
+			auto& shape = local_ref.misc1;
+			auto& radius = local_ref.misc2;
+			auto& offset = local_ref.misc3;
+			
+			lists[0] = GUI::ZCListData::light_shapes();
+			windowRow->add(
+				Rows<3>(
+					Label(text = "Size", hAlign = 1.0),
+					TextField(
+						fitParent = true, minwidth = 8_em,
+						type = GUI::TextField::type::SWAP_BYTE,
+						low = 0, high = 255, val = radius,
+						onValChangedFunc = [&](GUI::TextField::type,std::string_view,int32_t val)
+						{
+							radius = val;
+						}),
+					INFOBTN("The size in pixels of the light area. Acts as a radius for most shapes."),
+					Label(text = "Shape", hAlign = 1.0),
+					DropDownList(data = lists[0],
+						fitParent = true, selectedValue = shape,
+						onSelectFunc = [&](int32_t val)
+						{
+							shape = val;
+						}),
+					INFOBTN("The shape to cast light in."),
+					Label(text = "Offset", hAlign = 1.0),
+					TextField(
+						fitParent = true, minwidth = 8_em,
+						type = GUI::TextField::type::INT_DECIMAL,
+						low = -255, high = 255, val = offset,
+						onValChangedFunc = [&](GUI::TextField::type,std::string_view,int32_t val)
+						{
+							offset = val;
+						}),
+					INFOBTN("An offset for the source of the light, in pixels."
+						"\nPositive offsets are in the direction the player is facing,"
+						" negative offsets are in the opposite direction.")
+				)
+			);
 			break;
 		}
 		default: //Should be unreachable

--- a/src/dialog/weap_data_editor.cpp
+++ b/src/dialog/weap_data_editor.cpp
@@ -315,8 +315,12 @@ std::shared_ptr<GUI::Widget> WeaponDataDialog::view()
 							}
 						)
 					),
-					burn_grid = Rows<4>(
-						_d, Label(text = "Sprite"), glow_label = Label(text = "Light Radius"), _d,
+					burn_grid = Rows<5>(
+						_d,
+						Label(text = "Sprite"),
+						glow_label = Label(text = "Light Radius"),
+						glow_off_label = Label(text = "Light Offset"),
+						_d,
 						//
 						Label(text = "No Fire:", hAlign = 1.0),
 						DropDownList(
@@ -326,7 +330,8 @@ std::shared_ptr<GUI::Widget> WeaponDataDialog::view()
 							{
 								local_ref.burnsprs[WPNSPR_BASE] = val;
 							}),
-						burn_field_base = NUM_FIELD(light_rads[WPNSPR_BASE], 0, 255),
+						glow_field_base = NUM_FIELD(light_rads[WPNSPR_BASE], 0, 255),
+						glow_off_field_base = NUM_FIELD(light_offsets[WPNSPR_BASE], -255, 255),
 						INFOBTN("Settings used for the weapon when not on fire"),
 						//
 						Label(text = "Normal Fire:", hAlign = 1.0),
@@ -338,6 +343,7 @@ std::shared_ptr<GUI::Widget> WeaponDataDialog::view()
 								local_ref.burnsprs[WPNSPR_IGNITE_ANY] = val;
 							}),
 						NUM_FIELD(light_rads[WPNSPR_IGNITE_ANY], 0, 255),
+						NUM_FIELD(light_offsets[WPNSPR_IGNITE_ANY], -255, 255),
 						INFOBTN("Settings used for the weapon when on 'Normal' fire"),
 						//
 						Label(text = "Strong Fire:", hAlign = 1.0),
@@ -349,6 +355,7 @@ std::shared_ptr<GUI::Widget> WeaponDataDialog::view()
 								local_ref.burnsprs[WPNSPR_IGNITE_STRONG] = val;
 							}),
 						NUM_FIELD(light_rads[WPNSPR_IGNITE_STRONG], 0, 255),
+						NUM_FIELD(light_offsets[WPNSPR_IGNITE_STRONG], -255, 255),
 						INFOBTN("Settings used for the weapon when on 'Strong' fire"),
 						//
 						Label(text = "Magic Fire:", hAlign = 1.0),
@@ -360,6 +367,7 @@ std::shared_ptr<GUI::Widget> WeaponDataDialog::view()
 								local_ref.burnsprs[WPNSPR_IGNITE_MAGIC] = val;
 							}),
 						NUM_FIELD(light_rads[WPNSPR_IGNITE_MAGIC], 0, 255),
+						NUM_FIELD(light_offsets[WPNSPR_IGNITE_MAGIC], -255, 255),
 						INFOBTN("Settings used for the weapon when on 'Magic' fire"),
 						//
 						Label(text = "Divine Fire:", hAlign = 1.0),
@@ -371,6 +379,7 @@ std::shared_ptr<GUI::Widget> WeaponDataDialog::view()
 								local_ref.burnsprs[WPNSPR_IGNITE_DIVINE] = val;
 							}),
 						NUM_FIELD(light_rads[WPNSPR_IGNITE_DIVINE], 0, 255),
+						NUM_FIELD(light_offsets[WPNSPR_IGNITE_DIVINE], -255, 255),
 						INFOBTN("Settings used for the weapon when on 'Divine' fire")
 					),
 					Row(
@@ -732,7 +741,9 @@ void WeaponDataDialog::refresh_burnglow()
 	for(auto [idx, child] : burn_grid->get_children())
 		child->setDisabled(!burn);
 	glow_label->setDisabled(!burn && !glow);
-	burn_field_base->setDisabled(!burn && !glow);
+	glow_off_label->setDisabled(!burn && !glow);
+	glow_field_base->setDisabled(!burn && !glow);
+	glow_off_field_base->setDisabled(!burn && !glow);
 	burn_box->setChecked(burn);
 	glow_box->setChecked(glow);
 }

--- a/src/dialog/weap_data_editor.h
+++ b/src/dialog/weap_data_editor.h
@@ -35,8 +35,8 @@ private:
 	bool is_lw, togglable;
 	std::shared_ptr<GUI::Window> window;
 	std::shared_ptr<GUI::Grid> burn_grid;
-	std::shared_ptr<GUI::TextField> burn_field_base, step_tf;
-	std::shared_ptr<GUI::Label> glow_label;
+	std::shared_ptr<GUI::TextField> glow_field_base, glow_off_field_base, step_tf;
+	std::shared_ptr<GUI::Label> glow_label, glow_off_label;
 	std::shared_ptr<GUI::Checkbox> burn_box, glow_box;
 	std::shared_ptr<GUI::TextField> tf_initd[8];
 	std::shared_ptr<GUI::Label> l_initds[8];

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -238,7 +238,26 @@ void handle_lighting(int cx, int cy, dword shape, dword rad, dword dir, BITMAP* 
 void do_torch_combo(newcombo const& cmb, int cx, int cy, BITMAP* dest, BITMAP* transdest)
 {
 	ASSERT(cmb.type == cTORCH);
-	handle_lighting(cx, cy, cmb.c_attributes[9].getTrunc(), cmb.c_attributes[8].getTrunc(), cmb.c_attributes[10].getTrunc(), dest, transdest);
+	int dir = cmb.c_attributes[10].getTrunc();
+	if (int offs = cmb.c_attributes[11].getTrunc())
+	{
+		switch (dir)
+		{
+			case up:
+				cy -= offs;
+				break;
+			case down:
+				cy += offs;
+				break;
+			case left:
+				cx -= offs;
+				break;
+			case right:
+				cx += offs;
+				break;
+		}
+	}
+	handle_lighting(cx, cy, cmb.c_attributes[9].getTrunc(), cmb.c_attributes[8].getTrunc(), dir, dest, transdest);
 }
 
 bool dither_staticcheck(int x, int y, double percentage)

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -1372,6 +1372,7 @@ void itemdata::advpaste(itemdata const& other, bitstring const& pasteflags)
 		{
 			weap_data.burnsprs[q] = other.weap_data.burnsprs[q];
 			weap_data.light_rads[q] = other.weap_data.light_rads[q];
+			weap_data.light_offsets[q] = other.weap_data.light_offsets[q];
 		}
 	}
 	if(pasteflags.get(ITM_ADVP_ITEMSIZE))

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -110,6 +110,7 @@ sprite::sprite(): solid_object()
     }
 	glowRad = 0;
 	glowShape = 0;
+	glowOffset = 0;
 	switch_hooked = false;
 	ignore_delete = 0;
 	can_flicker = true;
@@ -152,6 +153,7 @@ sprite::sprite(sprite const & other):
 	spr_death_anim_frm(other.spr_death_anim_frm),
 	spr_spawn_anim_frm(other.spr_spawn_anim_frm),
 	glowRad(other.glowRad), glowShape(other.glowShape),
+	glowOffset(other.glowOffset),
 	ignore_delete(other.ignore_delete),
 	behind(other.behind)
 {
@@ -242,6 +244,7 @@ sprite::sprite(zfix X,zfix Y,int32_t T,int32_t CS,int32_t F,int32_t Clk,int32_t 
     }
 	glowRad = 0;
 	glowShape = 0;
+	glowOffset = 0;
 	switch_hooked = false;
 	ignore_delete = 0;
 	can_flicker = true;

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -135,6 +135,7 @@ public:
 	byte spr_death_anim_frm, spr_spawn_anim_frm;
 	
 	byte glowRad, glowShape;
+	int32_t glowOffset;
 	
 	int32_t ignore_delete;
 	

--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -28532,6 +28532,24 @@ void HeroClass::calc_darkroom_hero(int32_t x1, int32_t y1)
 	optional<word> wave_opt;
 	if(lamp.flags & item_flag1)
 		wave_opt = 0; // cancel wave effect
+	if (int offs = lamp.misc3)
+	{
+		switch (dir)
+		{
+			case up:
+				hy -= offs;
+				break;
+			case down:
+				hy += offs;
+				break;
+			case left:
+				hx -= offs;
+				break;
+			case right:
+				hx += offs;
+				break;
+		}
+	}
 	handle_lighting(hx, hy, lamp.misc1, lamp.misc2, dir, darkscr_bmp, NULL, -1, -1, -1, -1, wave_opt, wave_opt);
 }
 

--- a/src/zc/scripting/types.cpp
+++ b/src/zc/scripting/types.cpp
@@ -1226,6 +1226,7 @@ constexpr EngineSubsystem getEngineSubsystemForRegister(int reg)
 		case SPRITE_JUMP:
 		case SPRITE_LIGHT_RADIUS:
 		case SPRITE_LIGHT_SHAPE:
+		case SPRITE_LIGHT_OFFSET:
 		case SPRITE_ROTATION:
 		case SPRITE_SCALE:
 		case SPRITE_SCRIPT_FLIP:

--- a/src/zc/scripting/types/sprite.cpp
+++ b/src/zc/scripting/types/sprite.cpp
@@ -366,6 +366,12 @@ int32_t sprite_get_register(int32_t reg)
 				return s->glowShape * 10000;
 			return 0;
 		}
+		case SPRITE_LIGHT_OFFSET:
+		{
+			if (s)
+				return s->glowOffset * 10000;
+			return 0;
+		}
 		case SPRITE_SWHOOKED:
 		{
 			if (s)
@@ -855,6 +861,12 @@ void sprite_set_register(int32_t reg, int32_t value)
 		{
 			if (s)
 				s->glowShape = vbound(value / 10000, 0, 255);
+			break;
+		}
+		case SPRITE_LIGHT_OFFSET:
+		{
+			if (s)
+				s->glowOffset = value / 10000;
 			break;
 		}
 		case SPRITE_SWHOOKED:

--- a/src/zc/scripting/types/weapon.cpp
+++ b/src/zc/scripting/types/weapon.cpp
@@ -31,6 +31,12 @@ static WeaponArrayRegistrar WPNBURNLIGHTRADIUS_registrar(LWPNBURNLIGHTRADIUS, EW
 	impl.setValueTransform(transforms::vboundByte);
 	return &impl;
 }());
+static WeaponArrayRegistrar WPNBURNLIGHTOFFSET_registrar(LWPNBURNLIGHTOFFSET, EWPNBURNLIGHTOFFSET, []{
+	static ScriptingArray_ObjectMemberCArray<weapon, &weapon::light_offsets> impl;
+	impl.compatSetDefaultValue(-10000);
+	impl.setMul10000(true);
+	return &impl;
+}());
 
 static WeaponArrayRegistrar WPNINITD_registrar(LWPNINITD, EWPNINITD, []{
 	static ScriptingArray_ObjectMemberCArray<weapon, &weapon::initD> impl;

--- a/src/zc/weapons.cpp
+++ b/src/zc/weapons.cpp
@@ -809,6 +809,7 @@ weapon::weapon(weapon const & other):
 	{
 		misc_wsprites[q] = other.misc_wsprites[q];
 		light_rads[q] = other.light_rads[q];
+		light_offsets[q] = other.light_offsets[q];
 	}
 	for( int32_t q = 0; q < 8; q++ ) 
 	{
@@ -1772,6 +1773,7 @@ weapon::weapon(zfix X,zfix Y,zfix Z,int32_t Id,int32_t Type,int32_t pow,int32_t 
 	{
 		misc_wsprites[q] = 0;
 		light_rads[q] = 0;
+		light_offsets[q] = 0;
 	}
 	
 	optional<word> wpnspr;
@@ -2743,14 +2745,19 @@ void weapon::load_weap_data(weapon_data const& data, optional<word>* out_wpnspr)
 		{
 			misc_wsprites[q] = data.burnsprs[q];
 			light_rads[q] = data.light_rads[q];
+			light_offsets[q] = data.light_offsets[q];
 		}
 		last_burnstate = get_burnstate();
 		if(out_wpnspr)
 			*out_wpnspr = _handle_loadsprite(misc_wsprites[last_burnstate]);
 		glowRad = light_rads[last_burnstate];
+		glowOffset = light_offsets[last_burnstate];
 	}
 	else if(data.flags & wdata_glow_rad)
+	{
 		glowRad = light_rads[WPNSPR_BASE] = data.light_rads[WPNSPR_BASE];
+		glowOffset = light_offsets[WPNSPR_BASE] = data.light_offsets[WPNSPR_BASE];
+	}
 	
 	glowShape = data.glow_shape;
 	
@@ -3503,6 +3510,7 @@ bool weapon::animate([[maybe_unused]] int32_t index)
 			last_burnstate = burnstate;
 			_handle_loadsprite(misc_wsprites[burnstate]);
 			glowRad = light_rads[burnstate];
+			glowOffset = light_offsets[burnstate];
 		}
 	}
 	if(misc_wflags & WFLAG_PICKUP_ITEMS) //Weapon grabs touched items, giving them to the player, similar to engine melee weapons.

--- a/src/zc/weapons.h
+++ b/src/zc/weapons.h
@@ -64,6 +64,7 @@ public:
     weapon_flags misc_wflags;
 	word misc_wsprites[WPNSPR_MAX];
 	byte light_rads[WPNSPR_MAX];
+	int32_t light_offsets[WPNSPR_MAX];
 	byte last_burnstate;
 	byte get_burnstate() const;
 	

--- a/src/zc/zc_sprite.cpp
+++ b/src/zc/zc_sprite.cpp
@@ -23,6 +23,24 @@ void sprite::handle_sprlighting()
 		x0 += hxofs;
 		y0 += hyofs;
 	}
+	if (glowOffset)
+	{
+		switch (dir)
+		{
+			case up:
+				y0 -= glowOffset;
+				break;
+			case down:
+				y0 += glowOffset;
+				break;
+			case left:
+				x0 -= glowOffset;
+				break;
+			case right:
+				x0 += glowOffset;
+				break;
+		}
+	}
 
 	handle_lighting(x0, y0 + playing_field_offset, glowShape, glowRad, dir, darkscr_bmp);
 }

--- a/src/zq/zq_class.cpp
+++ b/src/zq/zq_class.cpp
@@ -6830,6 +6830,8 @@ int32_t write_weap_data(weapon_data const& data, PACKFILE* f)
 			new_return(5);
 		if (!p_putc(data.light_rads[q], f))
 			new_return(6);
+		if (!p_iputl(data.light_offsets[q], f))
+			new_return(31);
 	}
 	if (!p_putc(data.glow_shape, f))
 		new_return(7);

--- a/tests/scripts/misc/metadata_expected.txt
+++ b/tests/scripts/misc/metadata_expected.txt
@@ -1123,7 +1123,7 @@ stdout:
         "name": "b",
         "type": "Brand"
       },
-      "5183": {
+      "5186": {
         "loc": {
           "range": {
             "start": {
@@ -1139,7 +1139,7 @@ stdout:
         },
         "doc": "top class"
       },
-      "5184": {
+      "5187": {
         "loc": {
           "range": {
             "start": {
@@ -1155,7 +1155,7 @@ stdout:
         },
         "doc": "absolute trash"
       },
-      "5185": {
+      "5188": {
         "loc": {
           "range": {
             "start": {
@@ -1172,51 +1172,6 @@ stdout:
         "doc": "meh"
       },
       "custom.198": {
-        "loc": {
-          "range": {
-            "start": {
-              "line": 54,
-              "character": 5
-            },
-            "end": {
-              "line": 54,
-              "character": 19
-            }
-          },
-          "uri": "URI"
-        }
-      },
-      "5186": {
-        "loc": {
-          "range": {
-            "start": {
-              "line": 54,
-              "character": 5
-            },
-            "end": {
-              "line": 54,
-              "character": 19
-            }
-          },
-          "uri": "URI"
-        }
-      },
-      "5187": {
-        "loc": {
-          "range": {
-            "start": {
-              "line": 54,
-              "character": 5
-            },
-            "end": {
-              "line": 54,
-              "character": 19
-            }
-          },
-          "uri": "URI"
-        }
-      },
-      "5188": {
         "loc": {
           "range": {
             "start": {
@@ -1250,6 +1205,51 @@ stdout:
         "loc": {
           "range": {
             "start": {
+              "line": 54,
+              "character": 5
+            },
+            "end": {
+              "line": 54,
+              "character": 19
+            }
+          },
+          "uri": "URI"
+        }
+      },
+      "5191": {
+        "loc": {
+          "range": {
+            "start": {
+              "line": 54,
+              "character": 5
+            },
+            "end": {
+              "line": 54,
+              "character": 19
+            }
+          },
+          "uri": "URI"
+        }
+      },
+      "5192": {
+        "loc": {
+          "range": {
+            "start": {
+              "line": 54,
+              "character": 5
+            },
+            "end": {
+              "line": 54,
+              "character": 19
+            }
+          },
+          "uri": "URI"
+        }
+      },
+      "5193": {
+        "loc": {
+          "range": {
+            "start": {
               "line": 2,
               "character": 4
             },
@@ -1264,7 +1264,7 @@ stdout:
         "name": "postfix",
         "type": "int"
       },
-      "5191": {
+      "5194": {
         "loc": {
           "range": {
             "start": {
@@ -1282,7 +1282,7 @@ stdout:
         "name": "postfix2",
         "type": "int"
       },
-      "5192": {
+      "5195": {
         "loc": {
           "range": {
             "start": {
@@ -1300,7 +1300,7 @@ stdout:
         "name": "x",
         "type": "int"
       },
-      "5193": {
+      "5196": {
         "loc": {
           "range": {
             "start": {
@@ -1318,7 +1318,7 @@ stdout:
         "name": "y",
         "type": "int"
       },
-      "5194": {
+      "5197": {
         "loc": {
           "range": {
             "start": {
@@ -1336,7 +1336,7 @@ stdout:
         "name": "z",
         "type": "int"
       },
-      "fn.2385": {
+      "fn.2389": {
         "loc": {
           "range": {
             "start": {
@@ -1368,7 +1368,7 @@ stdout:
         },
         "doc": "Prints the passed value to the output console. Includes a newline character\nafter the value.\n\n\n**@deprecated_alias** TraceLWeapon\n\n**@deprecated_alias** TraceEWeapon\n\n**@deprecated_alias** TraceNPC\n\n**@deprecated_alias** TraceFFC\n\n**@deprecated_alias** TraceItem\n\n**@deprecated_alias** TraceItemData"
       },
-      "5345": {
+      "5348": {
         "loc": {
           "range": {
             "start": {
@@ -1383,7 +1383,7 @@ stdout:
           "uri": "URI"
         }
       },
-      "fn.4178": {
+      "fn.4188": {
         "loc": {
           "range": {
             "start": {
@@ -1416,7 +1416,7 @@ stdout:
         "name": "c2",
         "type": "Car"
       },
-      "5352": {
+      "5355": {
         "loc": {
           "range": {
             "start": {
@@ -1433,7 +1433,7 @@ stdout:
         "name": "c",
         "type": "Car"
       },
-      "fn.2386": {
+      "fn.2390": {
         "loc": {
           "range": {
             "start": {
@@ -1448,7 +1448,7 @@ stdout:
           "uri": "URI"
         }
       },
-      "fn.2387": {
+      "fn.2391": {
         "loc": {
           "range": {
             "start": {
@@ -1463,7 +1463,7 @@ stdout:
           "uri": "URI"
         }
       },
-      "5325": {
+      "5328": {
         "loc": {
           "range": {
             "start": {
@@ -1480,7 +1480,7 @@ stdout:
         "name": "b",
         "type": "bool"
       },
-      "5195": {
+      "5198": {
         "loc": {
           "range": {
             "start": {
@@ -1498,7 +1498,7 @@ stdout:
         "name": "hmm",
         "type": "int"
       },
-      "fn.2388": {
+      "fn.2392": {
         "loc": {
           "range": {
             "start": {
@@ -1529,7 +1529,7 @@ stdout:
           "uri": "URI"
         }
       },
-      "fn.2389": {
+      "fn.2393": {
         "loc": {
           "range": {
             "start": {
@@ -1561,7 +1561,7 @@ stdout:
         },
         "doc": "Prints the specified format_string to the output console, using the given\nargs to fill in parts of the string that are specially marked. Does not\ninclude a newline character after the string."
       },
-      "5398": {
+      "5401": {
         "loc": {
           "range": {
             "start": {
@@ -1579,7 +1579,7 @@ stdout:
         "name": "c",
         "type": "Car"
       },
-      "fn.2392": {
+      "fn.2396": {
         "loc": {
           "range": {
             "start": {
@@ -1611,7 +1611,7 @@ stdout:
         },
         "doc": "How fast it goes. See [`the vroom method`](command:zscript.openLink?%7B%22file%22%3A%22metadata.zs%22%2C%22position%22%3A%7B%22start%22%3A%7B%22line%22%3A32%2C%22character%22%3A9%7D%2C%22end%22%3A%7B%22line%22%3A32%2C%22character%22%3A14%7D%7D%7D) or [`speed`](command:zscript.openLink?%7B%22file%22%3A%22metadata.zs%22%2C%22position%22%3A%7B%22start%22%3A%7B%22line%22%3A24%2C%22character%22%3A8%7D%2C%22end%22%3A%7B%22line%22%3A24%2C%22character%22%3A13%7D%7D%7D) or [`x`](command:zscript.openLink?%7B%22file%22%3A%22metadata.zs%22%2C%22position%22%3A%7B%22start%22%3A%7B%22line%22%3A17%2C%22character%22%3A4%7D%2C%22end%22%3A%7B%22line%22%3A17%2C%22character%22%3A5%7D%7D%7D) or [`Waitframe()`](command:zscript.openLink?%7B%22file%22%3A%22global.zh%22%2C%22position%22%3A%7B%22start%22%3A%7B%22line%22%3A102%2C%22character%22%3A14%7D%2C%22end%22%3A%7B%22line%22%3A102%2C%22character%22%3A23%7D%7D%7D) or [`bitmap`](command:zscript.openLink?%7B%22file%22%3A%22bitmap.zh%22%2C%22position%22%3A%7B%22start%22%3A%7B%22line%22%3A3%2C%22character%22%3A6%7D%2C%22end%22%3A%7B%22line%22%3A3%2C%22character%22%3A12%7D%7D%7D) or [`bitmap::Width`](command:zscript.openLink?%7B%22file%22%3A%22bitmap.zh%22%2C%22position%22%3A%7B%22start%22%3A%7B%22line%22%3A13%2C%22character%22%3A20%7D%2C%22end%22%3A%7B%22line%22%3A13%2C%22character%22%3A25%7D%7D%7D)"
       },
-      "5392": {
+      "5395": {
         "loc": {
           "range": {
             "start": {
@@ -1643,7 +1643,7 @@ stdout:
         "name": "d",
         "type": "IhaveAdefCtor"
       },
-      "5399": {
+      "5402": {
         "loc": {
           "range": {
             "start": {
@@ -1660,7 +1660,7 @@ stdout:
         "name": "d",
         "type": "IhaveAdefCtor"
       },
-      "fn.4179": {
+      "fn.4189": {
         "loc": {
           "range": {
             "start": {
@@ -1675,7 +1675,7 @@ stdout:
           "uri": "URI"
         }
       },
-      "5400": {
+      "5403": {
         "loc": {
           "range": {
             "start": {
@@ -1692,7 +1692,7 @@ stdout:
         "name": "c2",
         "type": "Car"
       },
-      "5401": {
+      "5404": {
         "loc": {
           "range": {
             "start": {
@@ -1726,7 +1726,7 @@ stdout:
         },
         "doc": "Returns the [`degrees`](command:zscript.openLink?%7B%22file%22%3A%22global.zh%22%2C%22position%22%3A%7B%22start%22%3A%7B%22line%22%3A765%2C%22character%22%3A39%7D%2C%22end%22%3A%7B%22line%22%3A765%2C%22character%22%3A46%7D%7D%7D) value, wrapped between [-180,180)\n\n\n**@alias** WrapDeg"
       },
-      "5402": {
+      "5405": {
         "loc": {
           "range": {
             "start": {
@@ -1744,7 +1744,7 @@ stdout:
         "name": "arr",
         "type": "int[]"
       },
-      "5405": {
+      "5408": {
         "loc": {
           "range": {
             "start": {
@@ -1761,7 +1761,7 @@ stdout:
         "name": "v",
         "type": "int"
       },
-      "5403": {
+      "5406": {
         "loc": {
           "range": {
             "start": {
@@ -1778,7 +1778,7 @@ stdout:
         "name": "__LOOP_ITER",
         "type": "int"
       },
-      "5404": {
+      "5407": {
         "loc": {
           "range": {
             "start": {
@@ -1795,7 +1795,7 @@ stdout:
         "name": "__LOOP_ARR",
         "type": "int[]"
       },
-      "5406": {
+      "5409": {
         "loc": {
           "range": {
             "start": {
@@ -1812,7 +1812,7 @@ stdout:
         "name": "ahhh",
         "type": "int"
       },
-      "5407": {
+      "5410": {
         "loc": {
           "range": {
             "start": {
@@ -1829,7 +1829,7 @@ stdout:
         "name": "b",
         "type": "Brand"
       },
-      "5408": {
+      "5411": {
         "loc": {
           "range": {
             "start": {
@@ -1847,7 +1847,7 @@ stdout:
         "name": "s",
         "type": "char32[]"
       },
-      "5196": {
+      "5199": {
         "loc": {
           "range": {
             "start": {
@@ -1865,7 +1865,7 @@ stdout:
         "name": "speed",
         "type": "int"
       },
-      "fn.2390": {
+      "fn.2394": {
         "loc": {
           "range": {
             "start": {
@@ -1881,7 +1881,7 @@ stdout:
         },
         "doc": "Go fast"
       },
-      "fn.2391": {
+      "fn.2395": {
         "loc": {
           "range": {
             "start": {
@@ -1896,7 +1896,7 @@ stdout:
           "uri": "URI"
         }
       },
-      "7391": {
+      "7394": {
         "loc": {
           "range": {
             "start": {
@@ -1927,7 +1927,7 @@ stdout:
           "character": 4,
           "length": 5
         },
-        "symbol": "5183"
+        "symbol": "5186"
       },
       {
         "loc": {
@@ -1935,7 +1935,7 @@ stdout:
           "character": 4,
           "length": 4
         },
-        "symbol": "5184"
+        "symbol": "5187"
       },
       {
         "loc": {
@@ -1943,7 +1943,7 @@ stdout:
           "character": 4,
           "length": 3
         },
-        "symbol": "5185"
+        "symbol": "5188"
       },
       {
         "loc": {
@@ -1959,7 +1959,7 @@ stdout:
           "character": 4,
           "length": 7
         },
-        "symbol": "5186"
+        "symbol": "5189"
       },
       {
         "loc": {
@@ -1967,7 +1967,7 @@ stdout:
           "character": 13,
           "length": 6
         },
-        "symbol": "5187"
+        "symbol": "5190"
       },
       {
         "loc": {
@@ -1975,7 +1975,7 @@ stdout:
           "character": 21,
           "length": 7
         },
-        "symbol": "5188"
+        "symbol": "5191"
       },
       {
         "loc": {
@@ -1983,7 +1983,7 @@ stdout:
           "character": 30,
           "length": 6
         },
-        "symbol": "5189"
+        "symbol": "5192"
       },
       {
         "loc": {
@@ -1991,7 +1991,7 @@ stdout:
           "character": 4,
           "length": 7
         },
-        "symbol": "5190"
+        "symbol": "5193"
       },
       {
         "loc": {
@@ -1999,7 +1999,7 @@ stdout:
           "character": 4,
           "length": 8
         },
-        "symbol": "5191"
+        "symbol": "5194"
       },
       {
         "loc": {
@@ -2007,7 +2007,7 @@ stdout:
           "character": 15,
           "length": 7
         },
-        "symbol": "5190"
+        "symbol": "5193"
       },
       {
         "loc": {
@@ -2015,7 +2015,7 @@ stdout:
           "character": 4,
           "length": 1
         },
-        "symbol": "5192"
+        "symbol": "5195"
       },
       {
         "loc": {
@@ -2023,7 +2023,7 @@ stdout:
           "character": 4,
           "length": 1
         },
-        "symbol": "5193"
+        "symbol": "5196"
       },
       {
         "loc": {
@@ -2031,7 +2031,7 @@ stdout:
           "character": 7,
           "length": 1
         },
-        "symbol": "5194"
+        "symbol": "5197"
       },
       {
         "loc": {
@@ -2039,7 +2039,7 @@ stdout:
           "character": 15,
           "length": 9
         },
-        "symbol": "fn.2385"
+        "symbol": "fn.2389"
       },
       {
         "loc": {
@@ -2063,7 +2063,7 @@ stdout:
           "character": 10,
           "length": 1
         },
-        "symbol": "5345"
+        "symbol": "5348"
       },
       {
         "loc": {
@@ -2071,7 +2071,7 @@ stdout:
           "character": 11,
           "length": 1
         },
-        "symbol": "5345"
+        "symbol": "5348"
       },
       {
         "loc": {
@@ -2079,7 +2079,7 @@ stdout:
           "character": 4,
           "length": 8
         },
-        "symbol": "fn.4178"
+        "symbol": "fn.4188"
       },
       {
         "loc": {
@@ -2103,7 +2103,7 @@ stdout:
           "character": 8,
           "length": 1
         },
-        "symbol": "5352"
+        "symbol": "5355"
       },
       {
         "loc": {
@@ -2111,7 +2111,7 @@ stdout:
           "character": 11,
           "length": 1
         },
-        "symbol": "5352"
+        "symbol": "5355"
       },
       {
         "loc": {
@@ -2119,7 +2119,7 @@ stdout:
           "character": 5,
           "length": 1
         },
-        "symbol": "fn.2386"
+        "symbol": "fn.2390"
       },
       {
         "loc": {
@@ -2127,7 +2127,7 @@ stdout:
           "character": 5,
           "length": 2
         },
-        "symbol": "fn.2387"
+        "symbol": "fn.2391"
       },
       {
         "loc": {
@@ -2135,7 +2135,7 @@ stdout:
           "character": 6,
           "length": 1
         },
-        "symbol": "5325"
+        "symbol": "5328"
       },
       {
         "loc": {
@@ -2143,7 +2143,7 @@ stdout:
           "character": 18,
           "length": 1
         },
-        "symbol": "fn.2386"
+        "symbol": "fn.2390"
       },
       {
         "loc": {
@@ -2151,7 +2151,7 @@ stdout:
           "character": 8,
           "length": 1
         },
-        "symbol": "5325"
+        "symbol": "5328"
       },
       {
         "loc": {
@@ -2159,7 +2159,7 @@ stdout:
           "character": 8,
           "length": 3
         },
-        "symbol": "5195"
+        "symbol": "5198"
       },
       {
         "loc": {
@@ -2167,7 +2167,7 @@ stdout:
           "character": 9,
           "length": 2
         },
-        "symbol": "fn.2388"
+        "symbol": "fn.2392"
       },
       {
         "loc": {
@@ -2183,7 +2183,7 @@ stdout:
           "character": 9,
           "length": 3
         },
-        "symbol": "fn.2389"
+        "symbol": "fn.2393"
       },
       {
         "loc": {
@@ -2199,7 +2199,7 @@ stdout:
           "character": 26,
           "length": 7
         },
-        "symbol": "5190"
+        "symbol": "5193"
       },
       {
         "loc": {
@@ -2207,7 +2207,7 @@ stdout:
           "character": 36,
           "length": 8
         },
-        "symbol": "5191"
+        "symbol": "5194"
       },
       {
         "loc": {
@@ -2215,7 +2215,7 @@ stdout:
           "character": 50,
           "length": 1
         },
-        "symbol": "5192"
+        "symbol": "5195"
       },
       {
         "loc": {
@@ -2223,7 +2223,7 @@ stdout:
           "character": 15,
           "length": 2
         },
-        "symbol": "fn.2388"
+        "symbol": "fn.2392"
       },
       {
         "loc": {
@@ -2231,7 +2231,7 @@ stdout:
           "character": 18,
           "length": 7
         },
-        "symbol": "5190"
+        "symbol": "5193"
       },
       {
         "loc": {
@@ -2239,7 +2239,7 @@ stdout:
           "character": 8,
           "length": 9
         },
-        "symbol": "fn.2385"
+        "symbol": "fn.2389"
       },
       {
         "loc": {
@@ -2247,7 +2247,7 @@ stdout:
           "character": 18,
           "length": 7
         },
-        "symbol": "5186"
+        "symbol": "5189"
       },
       {
         "loc": {
@@ -2263,7 +2263,7 @@ stdout:
           "character": 13,
           "length": 1
         },
-        "symbol": "5398"
+        "symbol": "5401"
       },
       {
         "loc": {
@@ -2271,7 +2271,7 @@ stdout:
           "character": 21,
           "length": 3
         },
-        "symbol": "fn.2392"
+        "symbol": "fn.2396"
       },
       {
         "loc": {
@@ -2295,7 +2295,7 @@ stdout:
           "character": 29,
           "length": 1
         },
-        "symbol": "5398"
+        "symbol": "5401"
       },
       {
         "loc": {
@@ -2303,7 +2303,7 @@ stdout:
           "character": 39,
           "length": 6
         },
-        "symbol": "5392"
+        "symbol": "5395"
       },
       {
         "loc": {
@@ -2311,7 +2311,7 @@ stdout:
           "character": 54,
           "length": 3
         },
-        "symbol": "5195"
+        "symbol": "5198"
       },
       {
         "loc": {
@@ -2319,7 +2319,7 @@ stdout:
           "character": 60,
           "length": 1
         },
-        "symbol": "5193"
+        "symbol": "5196"
       },
       {
         "loc": {
@@ -2327,7 +2327,7 @@ stdout:
           "character": 64,
           "length": 1
         },
-        "symbol": "5194"
+        "symbol": "5197"
       },
       {
         "loc": {
@@ -2335,7 +2335,7 @@ stdout:
           "character": 68,
           "length": 4
         },
-        "symbol": "5184"
+        "symbol": "5187"
       },
       {
         "loc": {
@@ -2343,7 +2343,7 @@ stdout:
           "character": 75,
           "length": 5
         },
-        "symbol": "5183"
+        "symbol": "5186"
       },
       {
         "loc": {
@@ -2351,7 +2351,7 @@ stdout:
           "character": 83,
           "length": 3
         },
-        "symbol": "5185"
+        "symbol": "5188"
       },
       {
         "loc": {
@@ -2367,7 +2367,7 @@ stdout:
           "character": 13,
           "length": 1
         },
-        "symbol": "5399"
+        "symbol": "5402"
       },
       {
         "loc": {
@@ -2375,7 +2375,7 @@ stdout:
           "character": 21,
           "length": 13
         },
-        "symbol": "fn.4179"
+        "symbol": "fn.4189"
       },
       {
         "loc": {
@@ -2391,7 +2391,7 @@ stdout:
           "character": 12,
           "length": 2
         },
-        "symbol": "5400"
+        "symbol": "5403"
       },
       {
         "loc": {
@@ -2399,7 +2399,7 @@ stdout:
           "character": 21,
           "length": 3
         },
-        "symbol": "fn.2392"
+        "symbol": "fn.2396"
       },
       {
         "loc": {
@@ -2407,7 +2407,7 @@ stdout:
           "character": 12,
           "length": 1
         },
-        "symbol": "5401"
+        "symbol": "5404"
       },
       {
         "loc": {
@@ -2423,7 +2423,7 @@ stdout:
           "character": 16,
           "length": 1
         },
-        "symbol": "5398"
+        "symbol": "5401"
       },
       {
         "loc": {
@@ -2439,7 +2439,7 @@ stdout:
           "character": 16,
           "length": 1
         },
-        "symbol": "5401"
+        "symbol": "5404"
       },
       {
         "loc": {
@@ -2447,7 +2447,7 @@ stdout:
           "character": 12,
           "length": 3
         },
-        "symbol": "5402"
+        "symbol": "5405"
       },
       {
         "loc": {
@@ -2455,7 +2455,7 @@ stdout:
           "character": 17,
           "length": 3
         },
-        "symbol": "5402"
+        "symbol": "5405"
       },
       {
         "loc": {
@@ -2471,7 +2471,7 @@ stdout:
           "character": 18,
           "length": 1
         },
-        "symbol": "5405"
+        "symbol": "5408"
       },
       {
         "loc": {
@@ -2479,7 +2479,7 @@ stdout:
           "character": 13,
           "length": 1
         },
-        "symbol": "5403"
+        "symbol": "5406"
       },
       {
         "loc": {
@@ -2487,7 +2487,7 @@ stdout:
           "character": 13,
           "length": 1
         },
-        "symbol": "5404"
+        "symbol": "5407"
       },
       {
         "loc": {
@@ -2495,7 +2495,7 @@ stdout:
           "character": 17,
           "length": 3
         },
-        "symbol": "5402"
+        "symbol": "5405"
       },
       {
         "loc": {
@@ -2503,7 +2503,7 @@ stdout:
           "character": 13,
           "length": 1
         },
-        "symbol": "5405"
+        "symbol": "5408"
       },
       {
         "loc": {
@@ -2511,7 +2511,7 @@ stdout:
           "character": 16,
           "length": 4
         },
-        "symbol": "5406"
+        "symbol": "5409"
       },
       {
         "loc": {
@@ -2519,7 +2519,7 @@ stdout:
           "character": 16,
           "length": 4
         },
-        "symbol": "5406"
+        "symbol": "5409"
       },
       {
         "loc": {
@@ -2535,7 +2535,7 @@ stdout:
           "character": 18,
           "length": 4
         },
-        "symbol": "5406"
+        "symbol": "5409"
       },
       {
         "loc": {
@@ -2551,7 +2551,7 @@ stdout:
           "character": 14,
           "length": 1
         },
-        "symbol": "5407"
+        "symbol": "5410"
       },
       {
         "loc": {
@@ -2559,7 +2559,7 @@ stdout:
           "character": 18,
           "length": 5
         },
-        "symbol": "5183"
+        "symbol": "5186"
       },
       {
         "loc": {
@@ -2575,7 +2575,7 @@ stdout:
           "character": 14,
           "length": 1
         },
-        "symbol": "5407"
+        "symbol": "5410"
       },
       {
         "loc": {
@@ -2583,7 +2583,7 @@ stdout:
           "character": 17,
           "length": 1
         },
-        "symbol": "5408"
+        "symbol": "5411"
       },
       {
         "loc": {
@@ -2599,7 +2599,7 @@ stdout:
           "character": 8,
           "length": 5
         },
-        "symbol": "5196"
+        "symbol": "5199"
       },
       {
         "loc": {
@@ -2607,7 +2607,7 @@ stdout:
           "character": 9,
           "length": 5
         },
-        "symbol": "fn.2390"
+        "symbol": "fn.2394"
       },
       {
         "loc": {
@@ -2615,7 +2615,7 @@ stdout:
           "character": 8,
           "length": 5
         },
-        "symbol": "5196"
+        "symbol": "5199"
       },
       {
         "loc": {
@@ -2623,7 +2623,7 @@ stdout:
           "character": 9,
           "length": 6
         },
-        "symbol": "fn.2391"
+        "symbol": "fn.2395"
       },
       {
         "loc": {
@@ -2631,7 +2631,7 @@ stdout:
           "character": 8,
           "length": 5
         },
-        "symbol": "fn.2390"
+        "symbol": "fn.2394"
       },
       {
         "loc": {
@@ -2639,7 +2639,7 @@ stdout:
           "character": 4,
           "length": 3
         },
-        "symbol": "fn.2392"
+        "symbol": "fn.2396"
       },
       {
         "loc": {
@@ -2663,7 +2663,7 @@ stdout:
           "character": 22,
           "length": 5
         },
-        "symbol": "7391"
+        "symbol": "7394"
       },
       {
         "loc": {
@@ -2679,7 +2679,7 @@ stdout:
           "character": 6,
           "length": 13
         },
-        "symbol": "fn.4179"
+        "symbol": "fn.4189"
       },
       {
         "loc": {

--- a/tests/scripts/playground/auto/scopes_expected.txt
+++ b/tests/scripts/playground/auto/scopes_expected.txt
@@ -3184,38 +3184,38 @@ REF_COUNT D2                                                                    
 RETURNFUNC; Func[long RefCount(untyped)] Body End                               | 3155 resources/include/bindings/global.zh:964
 GC; Func[void GC()] Body Start                                                  | 3156 resources/include/bindings/global.zh:968
 RETURNFUNC; Func[void GC()] Body End                                            | 3157 resources/include/bindings/global.zh:968
-POP D2; Func[void sprite::Own(bitmap)] Body Start                               | 3158 resources/include/bindings/sprite.zh:372
-POP REFSPRITE                                                                   | 3159 resources/include/bindings/sprite.zh:372
-OBJ_OWN_BITMAP D2 0                                                             | 3160 resources/include/bindings/sprite.zh:372
-RETURNFUNC; Func[void sprite::Own(bitmap)] Body End                             | 3161 resources/include/bindings/sprite.zh:372
-POP D2; Func[void sprite::Own(paldata)] Body Start                              | 3162 resources/include/bindings/sprite.zh:380
-POP REFSPRITE                                                                   | 3163 resources/include/bindings/sprite.zh:380
-OBJ_OWN_PALDATA D2 0                                                            | 3164 resources/include/bindings/sprite.zh:380
-RETURNFUNC; Func[void sprite::Own(paldata)] Body End                            | 3165 resources/include/bindings/sprite.zh:380
-POP D2; Func[void sprite::Own(file)] Body Start                                 | 3166 resources/include/bindings/sprite.zh:388
-POP REFSPRITE                                                                   | 3167 resources/include/bindings/sprite.zh:388
-OBJ_OWN_FILE D2 0                                                               | 3168 resources/include/bindings/sprite.zh:388
-RETURNFUNC; Func[void sprite::Own(file)] Body End                               | 3169 resources/include/bindings/sprite.zh:388
-POP D2; Func[void sprite::Own(directory)] Body Start                            | 3170 resources/include/bindings/sprite.zh:396
-POP REFSPRITE                                                                   | 3171 resources/include/bindings/sprite.zh:396
-OBJ_OWN_DIR D2 0                                                                | 3172 resources/include/bindings/sprite.zh:396
-RETURNFUNC; Func[void sprite::Own(directory)] Body End                          | 3173 resources/include/bindings/sprite.zh:396
-POP D2; Func[void sprite::Own(stack)] Body Start                                | 3174 resources/include/bindings/sprite.zh:404
-POP REFSPRITE                                                                   | 3175 resources/include/bindings/sprite.zh:404
-OBJ_OWN_STACK D2 0                                                              | 3176 resources/include/bindings/sprite.zh:404
-RETURNFUNC; Func[void sprite::Own(stack)] Body End                              | 3177 resources/include/bindings/sprite.zh:404
-POP D2; Func[void sprite::Own(randgen)] Body Start                              | 3178 resources/include/bindings/sprite.zh:412
-POP REFSPRITE                                                                   | 3179 resources/include/bindings/sprite.zh:412
-OBJ_OWN_RNG D2 0                                                                | 3180 resources/include/bindings/sprite.zh:412
-RETURNFUNC; Func[void sprite::Own(randgen)] Body End                            | 3181 resources/include/bindings/sprite.zh:412
-POP D2; Func[void sprite::OwnArray(untyped)] Body Start                         | 3182 resources/include/bindings/sprite.zh:420
-POP REFSPRITE                                                                   | 3183 resources/include/bindings/sprite.zh:420
-OBJ_OWN_ARRAY D2 0                                                              | 3184 resources/include/bindings/sprite.zh:420
-RETURNFUNC; Func[void sprite::OwnArray(untyped)] Body End                       | 3185 resources/include/bindings/sprite.zh:420
-POP D2; Func[void sprite::OwnObject(untyped)] Body Start                        | 3186 resources/include/bindings/sprite.zh:428
-POP REFSPRITE                                                                   | 3187 resources/include/bindings/sprite.zh:428
-OBJ_OWN_CLASS D2 0                                                              | 3188 resources/include/bindings/sprite.zh:428
-RETURNFUNC; Func[void sprite::OwnObject(untyped)] Body End                      | 3189 resources/include/bindings/sprite.zh:428
+POP D2; Func[void sprite::Own(bitmap)] Body Start                               | 3158 resources/include/bindings/sprite.zh:378
+POP REFSPRITE                                                                   | 3159 resources/include/bindings/sprite.zh:378
+OBJ_OWN_BITMAP D2 0                                                             | 3160 resources/include/bindings/sprite.zh:378
+RETURNFUNC; Func[void sprite::Own(bitmap)] Body End                             | 3161 resources/include/bindings/sprite.zh:378
+POP D2; Func[void sprite::Own(paldata)] Body Start                              | 3162 resources/include/bindings/sprite.zh:386
+POP REFSPRITE                                                                   | 3163 resources/include/bindings/sprite.zh:386
+OBJ_OWN_PALDATA D2 0                                                            | 3164 resources/include/bindings/sprite.zh:386
+RETURNFUNC; Func[void sprite::Own(paldata)] Body End                            | 3165 resources/include/bindings/sprite.zh:386
+POP D2; Func[void sprite::Own(file)] Body Start                                 | 3166 resources/include/bindings/sprite.zh:394
+POP REFSPRITE                                                                   | 3167 resources/include/bindings/sprite.zh:394
+OBJ_OWN_FILE D2 0                                                               | 3168 resources/include/bindings/sprite.zh:394
+RETURNFUNC; Func[void sprite::Own(file)] Body End                               | 3169 resources/include/bindings/sprite.zh:394
+POP D2; Func[void sprite::Own(directory)] Body Start                            | 3170 resources/include/bindings/sprite.zh:402
+POP REFSPRITE                                                                   | 3171 resources/include/bindings/sprite.zh:402
+OBJ_OWN_DIR D2 0                                                                | 3172 resources/include/bindings/sprite.zh:402
+RETURNFUNC; Func[void sprite::Own(directory)] Body End                          | 3173 resources/include/bindings/sprite.zh:402
+POP D2; Func[void sprite::Own(stack)] Body Start                                | 3174 resources/include/bindings/sprite.zh:410
+POP REFSPRITE                                                                   | 3175 resources/include/bindings/sprite.zh:410
+OBJ_OWN_STACK D2 0                                                              | 3176 resources/include/bindings/sprite.zh:410
+RETURNFUNC; Func[void sprite::Own(stack)] Body End                              | 3177 resources/include/bindings/sprite.zh:410
+POP D2; Func[void sprite::Own(randgen)] Body Start                              | 3178 resources/include/bindings/sprite.zh:418
+POP REFSPRITE                                                                   | 3179 resources/include/bindings/sprite.zh:418
+OBJ_OWN_RNG D2 0                                                                | 3180 resources/include/bindings/sprite.zh:418
+RETURNFUNC; Func[void sprite::Own(randgen)] Body End                            | 3181 resources/include/bindings/sprite.zh:418
+POP D2; Func[void sprite::OwnArray(untyped)] Body Start                         | 3182 resources/include/bindings/sprite.zh:426
+POP REFSPRITE                                                                   | 3183 resources/include/bindings/sprite.zh:426
+OBJ_OWN_ARRAY D2 0                                                              | 3184 resources/include/bindings/sprite.zh:426
+RETURNFUNC; Func[void sprite::OwnArray(untyped)] Body End                       | 3185 resources/include/bindings/sprite.zh:426
+POP D2; Func[void sprite::OwnObject(untyped)] Body Start                        | 3186 resources/include/bindings/sprite.zh:434
+POP REFSPRITE                                                                   | 3187 resources/include/bindings/sprite.zh:434
+OBJ_OWN_CLASS D2 0                                                              | 3188 resources/include/bindings/sprite.zh:434
+RETURNFUNC; Func[void sprite::OwnObject(untyped)] Body End                      | 3189 resources/include/bindings/sprite.zh:434
 POP D1; Func[bitmap bitmap::bitmap(int, int)] Body Start                        | 3190 resources/include/bindings/bitmap.zh:9
 POP D0                                                                          | 3191 resources/include/bindings/bitmap.zh:9
 SETR D2 CREATEBITMAP                                                            | 3192 resources/include/bindings/bitmap.zh:9
@@ -3485,35 +3485,35 @@ RETURNFUNC; Func[void dmapdata::SetMusic(char32[])] Body End                    
 POP REFDROPSETDATA; Func[int dropsetdata::Choose()] Body Start                  | 3456 resources/include/bindings/dropsetdata.zh:31
 SETR D2 DROPSETCHOOSE                                                           | 3457 resources/include/bindings/dropsetdata.zh:31
 RETURNFUNC; Func[int dropsetdata::Choose()] Body End                            | 3458 resources/include/bindings/dropsetdata.zh:31
-POP D2; Func[void eweapon::Max(int)] Body Start                                 | 3459 resources/include/bindings/eweapon.zh:301
-POP REFEWPN                                                                     | 3460 resources/include/bindings/eweapon.zh:301
-SETR SPRITEMAXEWPN D2                                                           | 3461 resources/include/bindings/eweapon.zh:301
-RETURNFUNC; Func[void eweapon::Max(int)] Body End                               | 3462 resources/include/bindings/eweapon.zh:301
-POP D2; Func[bool eweapon::isValid()] Body Start                                | 3463 resources/include/bindings/eweapon.zh:309
-ISVALIDEWPN D2                                                                  | 3464 resources/include/bindings/eweapon.zh:309
-RETURNFUNC; Func[bool eweapon::isValid()] Body End                              | 3465 resources/include/bindings/eweapon.zh:309
-POP D2; Func[void eweapon::UseSprite(int)] Body Start                           | 3466 resources/include/bindings/eweapon.zh:319
-POP D3                                                                          | 3467 resources/include/bindings/eweapon.zh:319
-SETR REFEWPN D3                                                                 | 3468 resources/include/bindings/eweapon.zh:319
-EWPNUSESPRITER D2                                                               | 3469 resources/include/bindings/eweapon.zh:319
-RETURNFUNC; Func[void eweapon::UseSprite(int)] Body End                         | 3470 resources/include/bindings/eweapon.zh:319
-POP D2; Func[void eweapon::Explode(int)] Body Start                             | 3471 resources/include/bindings/eweapon.zh:327
-POP REFEWPN                                                                     | 3472 resources/include/bindings/eweapon.zh:327
-EWEAPONEXPLODER D2                                                              | 3473 resources/include/bindings/eweapon.zh:327
-RETURNFUNC; Func[void eweapon::Explode(int)] Body End                           | 3474 resources/include/bindings/eweapon.zh:327
-POP REFEWPN; Func[void eweapon::Remove()] Body Start                            | 3475 resources/include/bindings/eweapon.zh:334
-EWPNDEL                                                                         | 3476 resources/include/bindings/eweapon.zh:334
-RETURNFUNC; Func[void eweapon::Remove()] Body End                               | 3477 resources/include/bindings/eweapon.zh:334
-POP D2; Func[bool eweapon::Switch(int)] Body Start                              | 3478 resources/include/bindings/eweapon.zh:344
-POP REFEWPN                                                                     | 3479 resources/include/bindings/eweapon.zh:344
-SWITCHEW D2                                                                     | 3480 resources/include/bindings/eweapon.zh:344
-RETURNFUNC; Func[bool eweapon::Switch(int)] Body End                            | 3481 resources/include/bindings/eweapon.zh:344
-POP D2; Func[void eweapon::MakeAngular()] Body Start                            | 3482 resources/include/bindings/eweapon.zh:352
-EWPNMAKEANGULAR D2                                                              | 3483 resources/include/bindings/eweapon.zh:352
-RETURNFUNC; Func[void eweapon::MakeAngular()] Body End                          | 3484 resources/include/bindings/eweapon.zh:352
-POP D2; Func[void eweapon::MakeDirectional()] Body Start                        | 3485 resources/include/bindings/eweapon.zh:360
-EWPNMAKEDIRECTIONAL D2                                                          | 3486 resources/include/bindings/eweapon.zh:360
-RETURNFUNC; Func[void eweapon::MakeDirectional()] Body End                      | 3487 resources/include/bindings/eweapon.zh:360
+POP D2; Func[void eweapon::Max(int)] Body Start                                 | 3459 resources/include/bindings/eweapon.zh:307
+POP REFEWPN                                                                     | 3460 resources/include/bindings/eweapon.zh:307
+SETR SPRITEMAXEWPN D2                                                           | 3461 resources/include/bindings/eweapon.zh:307
+RETURNFUNC; Func[void eweapon::Max(int)] Body End                               | 3462 resources/include/bindings/eweapon.zh:307
+POP D2; Func[bool eweapon::isValid()] Body Start                                | 3463 resources/include/bindings/eweapon.zh:315
+ISVALIDEWPN D2                                                                  | 3464 resources/include/bindings/eweapon.zh:315
+RETURNFUNC; Func[bool eweapon::isValid()] Body End                              | 3465 resources/include/bindings/eweapon.zh:315
+POP D2; Func[void eweapon::UseSprite(int)] Body Start                           | 3466 resources/include/bindings/eweapon.zh:325
+POP D3                                                                          | 3467 resources/include/bindings/eweapon.zh:325
+SETR REFEWPN D3                                                                 | 3468 resources/include/bindings/eweapon.zh:325
+EWPNUSESPRITER D2                                                               | 3469 resources/include/bindings/eweapon.zh:325
+RETURNFUNC; Func[void eweapon::UseSprite(int)] Body End                         | 3470 resources/include/bindings/eweapon.zh:325
+POP D2; Func[void eweapon::Explode(int)] Body Start                             | 3471 resources/include/bindings/eweapon.zh:333
+POP REFEWPN                                                                     | 3472 resources/include/bindings/eweapon.zh:333
+EWEAPONEXPLODER D2                                                              | 3473 resources/include/bindings/eweapon.zh:333
+RETURNFUNC; Func[void eweapon::Explode(int)] Body End                           | 3474 resources/include/bindings/eweapon.zh:333
+POP REFEWPN; Func[void eweapon::Remove()] Body Start                            | 3475 resources/include/bindings/eweapon.zh:340
+EWPNDEL                                                                         | 3476 resources/include/bindings/eweapon.zh:340
+RETURNFUNC; Func[void eweapon::Remove()] Body End                               | 3477 resources/include/bindings/eweapon.zh:340
+POP D2; Func[bool eweapon::Switch(int)] Body Start                              | 3478 resources/include/bindings/eweapon.zh:350
+POP REFEWPN                                                                     | 3479 resources/include/bindings/eweapon.zh:350
+SWITCHEW D2                                                                     | 3480 resources/include/bindings/eweapon.zh:350
+RETURNFUNC; Func[bool eweapon::Switch(int)] Body End                            | 3481 resources/include/bindings/eweapon.zh:350
+POP D2; Func[void eweapon::MakeAngular()] Body Start                            | 3482 resources/include/bindings/eweapon.zh:358
+EWPNMAKEANGULAR D2                                                              | 3483 resources/include/bindings/eweapon.zh:358
+RETURNFUNC; Func[void eweapon::MakeAngular()] Body End                          | 3484 resources/include/bindings/eweapon.zh:358
+POP D2; Func[void eweapon::MakeDirectional()] Body Start                        | 3485 resources/include/bindings/eweapon.zh:366
+EWPNMAKEDIRECTIONAL D2                                                          | 3486 resources/include/bindings/eweapon.zh:366
+RETURNFUNC; Func[void eweapon::MakeDirectional()] Body End                      | 3487 resources/include/bindings/eweapon.zh:366
 POP D3; Func[file file::file(char32[], char32[])] Body Start                    | 3488 resources/include/bindings/file.zh:37
 POP D2                                                                          | 3489 resources/include/bindings/file.zh:37
 SETV REFFILE 0                                                                  | 3490 resources/include/bindings/file.zh:37
@@ -3742,35 +3742,35 @@ POP D2; Func[bool itemsprite::Switch(int)] Body Start                           
 POP REFITEM                                                                     | 3713 resources/include/bindings/itemsprite.zh:171
 SWITCHITM D2                                                                    | 3714 resources/include/bindings/itemsprite.zh:171
 RETURNFUNC; Func[bool itemsprite::Switch(int)] Body End                         | 3715 resources/include/bindings/itemsprite.zh:171
-POP D2; Func[void lweapon::Max(int)] Body Start                                 | 3716 resources/include/bindings/lweapon.zh:341
-POP REFLWPN                                                                     | 3717 resources/include/bindings/lweapon.zh:341
-SETR SPRITEMAXLWPN D2                                                           | 3718 resources/include/bindings/lweapon.zh:341
-RETURNFUNC; Func[void lweapon::Max(int)] Body End                               | 3719 resources/include/bindings/lweapon.zh:341
-POP D2; Func[bool lweapon::isValid()] Body Start                                | 3720 resources/include/bindings/lweapon.zh:349
-ISVALIDLWPN D2                                                                  | 3721 resources/include/bindings/lweapon.zh:349
-RETURNFUNC; Func[bool lweapon::isValid()] Body End                              | 3722 resources/include/bindings/lweapon.zh:349
-POP D2; Func[void lweapon::UseSprite(int)] Body Start                           | 3723 resources/include/bindings/lweapon.zh:359
-POP D3                                                                          | 3724 resources/include/bindings/lweapon.zh:359
-SETR REFLWPN D3                                                                 | 3725 resources/include/bindings/lweapon.zh:359
-LWPNUSESPRITER D2                                                               | 3726 resources/include/bindings/lweapon.zh:359
-RETURNFUNC; Func[void lweapon::UseSprite(int)] Body End                         | 3727 resources/include/bindings/lweapon.zh:359
-POP D2; Func[void lweapon::Explode(int)] Body Start                             | 3728 resources/include/bindings/lweapon.zh:367
-POP REFLWPN                                                                     | 3729 resources/include/bindings/lweapon.zh:367
-LWEAPONEXPLODER D2                                                              | 3730 resources/include/bindings/lweapon.zh:367
-RETURNFUNC; Func[void lweapon::Explode(int)] Body End                           | 3731 resources/include/bindings/lweapon.zh:367
-POP REFLWPN; Func[void lweapon::Remove()] Body Start                            | 3732 resources/include/bindings/lweapon.zh:374
-LWPNDEL                                                                         | 3733 resources/include/bindings/lweapon.zh:374
-RETURNFUNC; Func[void lweapon::Remove()] Body End                               | 3734 resources/include/bindings/lweapon.zh:374
-POP D2; Func[bool lweapon::Switch(int)] Body Start                              | 3735 resources/include/bindings/lweapon.zh:384
-POP REFLWPN                                                                     | 3736 resources/include/bindings/lweapon.zh:384
-SWITCHLW D2                                                                     | 3737 resources/include/bindings/lweapon.zh:384
-RETURNFUNC; Func[bool lweapon::Switch(int)] Body End                            | 3738 resources/include/bindings/lweapon.zh:384
-POP D2; Func[bool lweapon::MakeAngular()] Body Start                            | 3739 resources/include/bindings/lweapon.zh:392
-LWPNMAKEANGULAR D2                                                              | 3740 resources/include/bindings/lweapon.zh:392
-RETURNFUNC; Func[bool lweapon::MakeAngular()] Body End                          | 3741 resources/include/bindings/lweapon.zh:392
-POP D2; Func[bool lweapon::MakeDirectional()] Body Start                        | 3742 resources/include/bindings/lweapon.zh:400
-LWPNMAKEDIRECTIONAL D2                                                          | 3743 resources/include/bindings/lweapon.zh:400
-RETURNFUNC; Func[bool lweapon::MakeDirectional()] Body End                      | 3744 resources/include/bindings/lweapon.zh:400
+POP D2; Func[void lweapon::Max(int)] Body Start                                 | 3716 resources/include/bindings/lweapon.zh:347
+POP REFLWPN                                                                     | 3717 resources/include/bindings/lweapon.zh:347
+SETR SPRITEMAXLWPN D2                                                           | 3718 resources/include/bindings/lweapon.zh:347
+RETURNFUNC; Func[void lweapon::Max(int)] Body End                               | 3719 resources/include/bindings/lweapon.zh:347
+POP D2; Func[bool lweapon::isValid()] Body Start                                | 3720 resources/include/bindings/lweapon.zh:355
+ISVALIDLWPN D2                                                                  | 3721 resources/include/bindings/lweapon.zh:355
+RETURNFUNC; Func[bool lweapon::isValid()] Body End                              | 3722 resources/include/bindings/lweapon.zh:355
+POP D2; Func[void lweapon::UseSprite(int)] Body Start                           | 3723 resources/include/bindings/lweapon.zh:365
+POP D3                                                                          | 3724 resources/include/bindings/lweapon.zh:365
+SETR REFLWPN D3                                                                 | 3725 resources/include/bindings/lweapon.zh:365
+LWPNUSESPRITER D2                                                               | 3726 resources/include/bindings/lweapon.zh:365
+RETURNFUNC; Func[void lweapon::UseSprite(int)] Body End                         | 3727 resources/include/bindings/lweapon.zh:365
+POP D2; Func[void lweapon::Explode(int)] Body Start                             | 3728 resources/include/bindings/lweapon.zh:373
+POP REFLWPN                                                                     | 3729 resources/include/bindings/lweapon.zh:373
+LWEAPONEXPLODER D2                                                              | 3730 resources/include/bindings/lweapon.zh:373
+RETURNFUNC; Func[void lweapon::Explode(int)] Body End                           | 3731 resources/include/bindings/lweapon.zh:373
+POP REFLWPN; Func[void lweapon::Remove()] Body Start                            | 3732 resources/include/bindings/lweapon.zh:380
+LWPNDEL                                                                         | 3733 resources/include/bindings/lweapon.zh:380
+RETURNFUNC; Func[void lweapon::Remove()] Body End                               | 3734 resources/include/bindings/lweapon.zh:380
+POP D2; Func[bool lweapon::Switch(int)] Body Start                              | 3735 resources/include/bindings/lweapon.zh:390
+POP REFLWPN                                                                     | 3736 resources/include/bindings/lweapon.zh:390
+SWITCHLW D2                                                                     | 3737 resources/include/bindings/lweapon.zh:390
+RETURNFUNC; Func[bool lweapon::Switch(int)] Body End                            | 3738 resources/include/bindings/lweapon.zh:390
+POP D2; Func[bool lweapon::MakeAngular()] Body Start                            | 3739 resources/include/bindings/lweapon.zh:398
+LWPNMAKEANGULAR D2                                                              | 3740 resources/include/bindings/lweapon.zh:398
+RETURNFUNC; Func[bool lweapon::MakeAngular()] Body End                          | 3741 resources/include/bindings/lweapon.zh:398
+POP D2; Func[bool lweapon::MakeDirectional()] Body Start                        | 3742 resources/include/bindings/lweapon.zh:406
+LWPNMAKEDIRECTIONAL D2                                                          | 3743 resources/include/bindings/lweapon.zh:406
+RETURNFUNC; Func[bool lweapon::MakeDirectional()] Body End                      | 3744 resources/include/bindings/lweapon.zh:406
 POP D1; Func[bool mapdata::isSolid(int, int)] Body Start                        | 3745 resources/include/bindings/mapdata.zh:893
 POP D0                                                                          | 3746 resources/include/bindings/mapdata.zh:893
 POP REFMAPDATA                                                                  | 3747 resources/include/bindings/mapdata.zh:893
@@ -5311,6 +5311,7 @@ debug data:
       - int HitYOffset @ Reg[SPRITE_HIT_OFFSET_Y]
       - int HitZHeight @ Reg[SPRITE_HIT_ZHEIGHT]
       - int Jump @ Reg[SPRITE_JUMP]
+      - int LightOffset @ Reg[SPRITE_LIGHT_OFFSET]
       - int LightRadius @ Reg[SPRITE_LIGHT_RADIUS]
       - int LightShape @ Reg[SPRITE_LIGHT_SHAPE]
       - untyped[] Misc @ Reg[SPRITE_MISCD]
@@ -6773,6 +6774,7 @@ debug data:
       - bool Behind @ Reg[EWPNBEHIND]
       - int BounceAdd @ Reg[EWPN_BOUNCE_ADD]
       - int BounceMult @ Reg[EWPN_BOUNCE_MULT]
+      - int[] BurnLightOffset @ Reg[EWPNBURNLIGHTOFFSET]
       - int[] BurnLightRadius @ Reg[EWPNBURNLIGHTRADIUS]
       - bool CollDetection @ Reg[EWPNCOLLDET]
       - int Damage @ Reg[EWPNPOWER] <HIDDEN>
@@ -9271,6 +9273,7 @@ debug data:
       - bool Behind @ Reg[LWPNBEHIND]
       - int BounceAdd @ Reg[LWPN_BOUNCE_ADD]
       - int BounceMult @ Reg[LWPN_BOUNCE_MULT]
+      - int[] BurnLightOffset @ Reg[LWPNBURNLIGHTOFFSET]
       - int[] BurnLightRadius @ Reg[LWPNBURNLIGHTRADIUS]
       - bool CollDetection @ Reg[LWPNCOLLDET]
       - int Damage @ Reg[LWPNPOWER] <HIDDEN>


### PR DESCRIPTION
Anything that casts light in new darkrooms can now have an offset applied. Offsets can be positive or negative, with positive moving the source of the light that many pixels in the direction the light is "facing". Offsets perpendicular to the facing direction are not currently supported.