### PR TITLE
fix(zc): enemies that "ignore solidity" not working below them in sideview

### DIFF
--- a/src/zc/guys.cpp
+++ b/src/zc/guys.cpp
@@ -1623,6 +1623,8 @@ bool enemy::m_walkflag(int32_t dx,int32_t dy,int32_t special, int32_t dir, int32
 
 bool enemy::isOnSideviewPlatform()
 {
+	if ((moveflags & move_ignore_solidity) && (moveflags & move_new_movement))
+		return false;
 	int32_t usewid = (SIZEflags&OVERRIDE_HIT_WIDTH) ? hit_width : 16;
 	int32_t usehei = (SIZEflags&OVERRIDE_HIT_HEIGHT) ? hit_height : 16;
 	if(!get_qr(qr_BROKEN_SIDEVIEW_SPRITE_JUMP)&&fall<0)


### PR DESCRIPTION
The code for "is the enemy standing on a solid" was using entirely different code that didn't check this flag. Now it checks it, if "Use 'Scripted Movement' for engine movement" is also checked.