### PR TITLE
fix(zc)!: recent added water/pit attributes conflicting

### DIFF
--- a/src/dialog/comboeditor.cpp
+++ b/src/dialog/comboeditor.cpp
@@ -920,11 +920,11 @@ void ComboEditorDialog::loadComboType()
 			h_flag[3] = "Solid areas of the combo are treated as non-solid Shallow Liquid combo";
 			l_attribute[0] = "Drown Damage:";
 			h_attribute[0] = "The amount of damage dealt when drowning, in HP points. If negative, drowning will heal the Hero.";
-			l_attribute[1] = "Inv. Frames";
-			h_attribute[1] = "The duration, in frames, the player will be invincible after drowning."
+			l_attribute[3] = "Inv. Frames";
+			h_attribute[3] = "The duration, in frames, the player will be invincible after drowning."
 				" If 0, the default of 48 will be used instead. If < 0, 0 will be used instead.";
-			l_attribute[2] = "Stun Frames";
-			h_attribute[2] = "The duration, in frames, the player will be stunned after drowning.";
+			l_attribute[4] = "Stun Frames";
+			h_attribute[4] = "The duration, in frames, the player will be stunned after drowning.";
 			l_attribute[8] = "Flipper Level:";
 			h_attribute[8] = "The minimum level flippers required to swim in the water. Flippers of lower level will have no effect.";
 			l_attribute[12] = "Drown SFX:";
@@ -1740,12 +1740,12 @@ void ComboEditorDialog::loadComboType()
 			h_flag[4] = "Don't suck in the Hero at all";
 			l_attribute[0] = "Damage:";
 			h_attribute[0] = "The amount of damage, in HP, to take when falling. Negative values heal.";
-			l_attribute[1] = "Inv. Frames";
-			h_attribute[1] = "The duration, in frames, the player will be invincible after falling."
+			l_attribute[3] = "Inv. Frames";
+			h_attribute[3] = "The duration, in frames, the player will be invincible after falling."
 				" If 0, the default will be used instead (48 if damage >0, 0 otherwise)."
 				" If < 0, 0 will be used instead.";
-			l_attribute[2] = "Stun Frames";
-			h_attribute[2] = "The duration, in frames, the player will be stunned after falling.";
+			l_attribute[4] = "Stun Frames";
+			h_attribute[4] = "The duration, in frames, the player will be stunned after falling.";
 			l_attribute[8] = "Fall SFX:";
 			h_attribute[8] = "The SFX to play when falling";
 			if(FL(cflag1)) //Warp enabled

--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -9702,8 +9702,8 @@ heroanimate_skip_liftwpn:;
 			if (watercmb.type == cWATER)
 			{
 				damage = watercmb.c_attributes[0].getTrunc();
-				inv_timer = watercmb.c_attributes[1].getTrunc();
-				stun_timer = watercmb.c_attributes[2].getTrunc();
+				inv_timer = watercmb.c_attributes[3].getTrunc();
+				stun_timer = watercmb.c_attributes[4].getTrunc();
 				if (!inv_timer)
 					inv_timer = 48;
 			}
@@ -14338,8 +14338,8 @@ bool HeroClass::pitfall()
 				dmg = cmb->c_attributes[0].getTrunc();
 				dmg_perc = cmb->usrflags&cflag3;
 				warp = cmb->usrflags&cflag1;
-				inv_timer = cmb->c_attributes[1].getTrunc();
-				stun_timer = cmb->c_attributes[2].getTrunc();
+				inv_timer = cmb->c_attributes[3].getTrunc();
+				stun_timer = cmb->c_attributes[4].getTrunc();
 			}
 			if (cheat_superman && dmg > 0)
 				dmg = 0;


### PR DESCRIPTION
The water hp mod was using the same attribute, so the new inv/stun timer attributes have been moved to different attribute numbers