### PR TITLE
fix(zc): softlock with `No Scrolling Screen While Carrying` qr in nes dungeons

### DIFF
--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -10286,6 +10286,9 @@ heroanimate_skip_liftwpn:;
 			}
 		}
 		
+		if (walk && lift_wpn && get_qr(qr_NO_SCROLL_WHILE_CARRYING))
+			walk = false; // prevent softlock at screen edge
+		
 		if(walk)
 		{
 			hclk=0;


### PR DESCRIPTION
qr wasn't preventing the "suck" of bombed doors and walk-through walls from trying to scroll this resulted in softlocking the player because they were being permanently sucked into the scroll but the scroll was being prevented by the carried object.