### PR TITLE
fix: Switchhook Block combo attributes overlapping

### DIFF
--- a/src/dialog/comboeditor.cpp
+++ b/src/dialog/comboeditor.cpp
@@ -1969,13 +1969,13 @@ void ComboEditorDialog::loadComboType()
 					h_flag[4] = "Drop a specific item instead of an item from a dropset";
 					if(FL(cflag5))
 					{
-						l_attribute[10] = "Item:";
-						h_attribute[10] = "The item ID to drop";
+						l_attribute[11] = "Item:";
+						h_attribute[11] = "The item ID to drop";
 					}
 					else
 					{
-						l_attribute[10] = "Dropset:";
-						h_attribute[10] = "The dropset to select a drop item from";
+						l_attribute[11] = "Dropset:";
+						h_attribute[11] = "The dropset to select a drop item from";
 					}
 				}
 			}

--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -8952,7 +8952,7 @@ heroanimate_skip_liftwpn:;
 													int32_t thedropset = -1;
 													if(cmb.usrflags&cflag4) //drop item
 													{
-														auto id = cmb.c_attributes[10].getTrunc();
+														auto id = cmb.c_attributes[11].getTrunc();
 														if(cmb.usrflags&cflag5)
 															it = id;
 														else


### PR DESCRIPTION
The 'Item/Dropset' attribute was in the same spot as the 'Break SFX' attribute! The 'Item/Dropset' attribute has been moved to fix this. If you were using 'Item/Dropset' before, you'll want to update your Switchhook Block combos.