### PR TITLE
fix: continue hearts being improperly bounded

### DIFF
--- a/src/dialog/init_data.cpp
+++ b/src/dialog/init_data.cpp
@@ -381,7 +381,7 @@ std::shared_ptr<GUI::Widget> InitDataDialog::view()
 							fitParent = true,
 							onValChangedFunc = [&](GUI::TextField::type,std::string_view,int32_t val)
 							{
-								local_zinit.counter[crLIFE] = val*HEART_FACTOR;
+								local_zinit.counter[crLIFE] = std::min(65535, val*HEART_FACTOR);
 							}
 						),
 						TextField(maxLength = 5, type = GUI::TextField::type::INT_DECIMAL,
@@ -389,7 +389,7 @@ std::shared_ptr<GUI::Widget> InitDataDialog::view()
 							fitParent = true,
 							onValChangedFunc = [&](GUI::TextField::type,std::string_view,int32_t val)
 							{
-								local_zinit.mcounter[crLIFE] = val*HEART_FACTOR;
+								local_zinit.mcounter[crLIFE] = std::min(65535, val*HEART_FACTOR);
 							}
 						),
 						TextField(maxLength = 5, type = GUI::TextField::type::INT_DECIMAL,
@@ -397,7 +397,7 @@ std::shared_ptr<GUI::Widget> InitDataDialog::view()
 							fitParent = true,
 							onValChangedFunc = [&](GUI::TextField::type,std::string_view,int32_t val)
 							{
-								local_zinit.cont_heart = val*HEART_FACTOR2;
+								local_zinit.cont_heart = std::min(65535, val*HEART_FACTOR2);
 							}
 						),
 						Button(text = "HP Per Heart", colSpan = 2, maxheight = 1.5_em, fitParent = true,

--- a/src/gamedata.cpp
+++ b/src/gamedata.cpp
@@ -720,12 +720,12 @@ void gamedata::set_hcp_per_hc(byte val)
     set_generic(val, 4);
 }
 
-byte gamedata::get_cont_hearts()
+word gamedata::get_cont_hearts()
 {
     return get_generic(5);
 }
 
-void gamedata::set_cont_hearts(byte val)
+void gamedata::set_cont_hearts(word val)
 {
     set_generic(val, 5);
 }

--- a/src/gamedata.h
+++ b/src/gamedata.h
@@ -248,8 +248,8 @@ public:
 	byte get_hcp_per_hc();
 	void set_hcp_per_hc(byte val);
 	
-	byte get_cont_hearts();
-	void set_cont_hearts(byte val);
+	word get_cont_hearts();
+	void set_cont_hearts(word val);
 	
 	bool get_cont_percent();
 	void set_cont_percent(bool ispercent);


### PR DESCRIPTION
This lead to high continue heart values wrapping around to lower values. Regressed in `acb7c84`.