### PR TITLE
fix(zc)!: Roc's 'Release Decay' of 0 doing nothing

### DIFF
--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -8292,7 +8292,10 @@ heroanimate_skip_liftwpn:;
 			if (last_rocs.flags & item_flag6)
 			{
 				int32_t jump_loss = last_rocs.misc6 / 100;
-				fall = zc_min(0_zf, fall + jump_loss);
+				if (jump_loss) // lose this much
+					fall = zc_min(0_zf, fall + jump_loss);
+				else // lose entire jump
+					fall = 0;
 			}
 			if (fall >= 0)
 				try_hover();


### PR DESCRIPTION
It now properly kills your entire jump, as the help text stated it did.