### PR TITLE
fix!: crash on program exiting during a failed test

### DIFF
--- a/src/base/zapp.cpp
+++ b/src/base/zapp.cpp
@@ -104,19 +104,19 @@ void common_main_setup(App id, int argc_, char **argv_)
 	if (used_switch(argc, argv, "-version"))
 	{
 		printf("version %s\n", getVersionString());
-		exit(0);
+		zapp_exit(0);
 	}
 
 	if (used_switch(argc, argv, "-channel"))
 	{
 		printf("channel %s\n", getReleaseChannel());
-		exit(0);
+		zapp_exit(0);
 	}
 
 	if (used_switch(argc, argv, "-repo"))
 	{
 		printf("repo %s\n", getRepo());
-		exit(0);
+		zapp_exit(0);
 	}
 
 	bool disable_chdir = std::getenv("ZC_DISABLE_OSX_CHDIR") != nullptr || std::getenv("ZC_DISABLE_CHDIR") != nullptr;
@@ -240,7 +240,7 @@ int32_t zapp_check_switch(const char *s, std::vector<const char*> arg_names)
 		if (bad_args)
 		{
 			printf("%s\n", fmt::format("expected switch {} to have {} args: {}", s, num_args, fmt::join(arg_names, ", ")).c_str());
-			exit(1);
+			zapp_exit(1);
 		}
 	}
 
@@ -375,4 +375,10 @@ bool is_exiting()
 void set_is_exiting()
 {
 	g_is_exiting = true;
+}
+
+void zapp_exit(int code)
+{
+	set_is_exiting();
+	exit(code);
 }

--- a/src/base/zapp.h
+++ b/src/base/zapp.h
@@ -42,5 +42,6 @@ void zapp_reporting_set_tag(const char* key, int value);
 
 bool is_exiting();
 void set_is_exiting();
+void zapp_exit(int code);
 
 #endif

--- a/src/launcher/launcher.cpp
+++ b/src/launcher/launcher.cpp
@@ -71,7 +71,7 @@ int32_t main(int32_t argc, char* argv[])
 		printf("%s\n", output.c_str());
 		set_is_exiting();
 		allegro_exit();
-		exit(success ? 0 : 1);
+		zapp_exit(success ? 0 : 1);
 	}
 
 	if (!render_timer_start())

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -328,7 +328,7 @@ int32_t main(int32_t argc, char **argv)
 		else
 			printf("tests failed\n");
 
-		exit(success ? 0 : 1);
+		zapp_exit(success ? 0 : 1);
 	}
 
 	if (used_switch(argc, argv, "-print-zasm-commands"))
@@ -491,11 +491,11 @@ int32_t main(int32_t argc, char **argv)
 	{
 		auto root(ZScript::parseFile(script_path));
 		if (zscript_error_out)
-			exit(1);
+			zapp_exit(1);
 		if (!root.get())
 			log_error(ZScript::CompileError::CantOpenSource(NULL));
 		fmt::println("ok");
-		exit(0);
+		zapp_exit(0);
 	}
 
 	bool do_json_output = used_switch(argc, argv, "-json") > 0;
@@ -531,7 +531,7 @@ int32_t main(int32_t argc, char **argv)
 	if (result && !result->docs.empty())
 	{
 		printf("%s\n", result->docs.c_str());
-		exit(0);
+		zapp_exit(0);
 	}
 
 	if(linked)

--- a/src/zc/commands.cpp
+++ b/src/zc/commands.cpp
@@ -19,7 +19,7 @@ void do_load_and_quit_command(const char* quest_path, bool jit_precompile)
 	byte skip_flags[] = {0, 0, 0, 0};
 	int ret = loadquest(quest_path,&QHeader,&QMisc,tunes+ZC_MIDI_COUNT,false,skip_flags,true,false,0xFF);
 	if (ret)
-		exit(ret);
+		zapp_exit(ret);
 
 	strcpy(qstpath, quest_path);
 	printf("Hash: %s\n", QHeader.hash().c_str());
@@ -28,8 +28,7 @@ void do_load_and_quit_command(const char* quest_path, bool jit_precompile)
 		jit_set_enabled(true);
 	zasm_pipeline_init(true);
 
-	set_is_exiting();
-	exit(0);
+	zapp_exit(0);
 }
 
 void do_extract_zasm_command(const char* quest_path)
@@ -37,7 +36,7 @@ void do_extract_zasm_command(const char* quest_path)
 	byte skip_flags[] = {0, 0, 0, 0};
 	int ret = loadquest(quest_path,&QHeader,&QMisc,tunes+ZC_MIDI_COUNT,false,skip_flags,false,false,0xFF);
 	if (ret)
-		exit(ret);
+		zapp_exit(ret);
 
 	DEBUG_PRINT_TO_FILE = true;
 	strcpy(qstpath, quest_path);
@@ -64,8 +63,7 @@ void do_extract_zasm_command(const char* quest_path)
 		}
 	}
 
-	set_is_exiting();
-	exit(0);
+	zapp_exit(0);
 }
 
 void zplayer_handle_commands()
@@ -98,19 +96,16 @@ void zplayer_handle_commands()
 		else
 			printf("tests failed\n");
 
-		set_is_exiting();
-		exit(success ? 0 : 1);
+		zapp_exit(success ? 0 : 1);
 	}
 
 	if (zapp_check_switch("-upload-replays"))
 	{
 #ifdef HAS_CURL
 		replay_upload();
-		set_is_exiting();
-		exit(0);
+		zapp_exit(0);
 #else
-		set_is_exiting();
-		exit(1);
+		zapp_exit(1);
 #endif
 	}
 
@@ -130,8 +125,7 @@ void zplayer_handle_commands()
 	{
 		std::string path = zapp_get_arg_string(test_opt_zasm_arg + 1);
 		zasm_optimize_run_for_file(path);
-		set_is_exiting();
-		exit(0);
+		zapp_exit(0);
 	}
 
 	int load_and_quit_arg = zapp_check_switch("-load-and-quit", {"qst"});
@@ -168,8 +162,7 @@ void zplayer_handle_commands()
 		if (auto r = saves_create_slot(new_game); !r)
 			Z_error_fatal("failed to create save file: %s\n", r.error().c_str());
 
-		set_is_exiting();
-		exit(0);
+		zapp_exit(0);
 	}
 
 	if (zapp_check_switch("-no_console"))

--- a/src/zc/zc_sys.cpp
+++ b/src/zc/zc_sys.cpp
@@ -161,7 +161,7 @@ void zc_exit(int code)
 	Z_message("ZQuest Classic docs: https://docs.zquestclassic.com\n");
 
 	allegro_exit();
-	exit(code);
+	zapp_exit(code);
 }
 
 bool flash_reduction_enabled(bool check_qr)

--- a/src/zq/zquest.cpp
+++ b/src/zq/zquest.cpp
@@ -19889,7 +19889,7 @@ int32_t main(int32_t argc,char **argv)
 			if (onNew() == D_CLOSE)
 			{
 				Z_message("User canceled creating new quest, closing.\n");
-				exit(0);
+				zapp_exit(0);
 			}
 
 			//otherwise the blank quest gets the name of the last loaded quest... not good! -DD
@@ -20054,7 +20054,7 @@ void zq_exit(int code)
 	
 	quit_game();
 	allegro_exit();
-	exit(code);
+	zapp_exit(code);
 }
 
 void init_bitmap(BITMAP** bmp, int32_t w, int32_t h)

--- a/src/zupdater/zupdater.cpp
+++ b/src/zupdater/zupdater.cpp
@@ -61,7 +61,7 @@ std::ofstream out("updater.log", std::ios::binary);
 
 	out << "[fatal] " << msg.c_str() << '\n';
 	out.close();
-	exit(1);
+	zapp_exit(1);
 }
 
 [[noreturn]] static void done(std::string msg)
@@ -73,7 +73,7 @@ std::ofstream out("updater.log", std::ios::binary);
 
 	out << "[done] " << msg.c_str() << '\n';
 	out.close();
-	exit(0);
+	zapp_exit(0);
 }
 
 static bool prompt(std::string msg)
@@ -311,7 +311,7 @@ int32_t main(int32_t argc, char* argv[])
 	{
 		printf("tag_name %s\n", new_version.c_str());
 		printf("asset_url %s\n", asset_url.c_str());
-		exit(0);
+		zapp_exit(0);
 	}
 
 	if (current_version == new_version)


### PR DESCRIPTION
end changelog

some calls to `exit()` did not set `set_is_exiting()` first, causing a crash accessing `all_sprites` post-delete in `~sprite()` (as a comment already placed there describes) new helper `zapp_exit()` wraps `exit()` to ensure `set_is_exiting()` is called first.