### PR TITLE
feat(zscript): @ExportInitD0 - @ExportInitD7

### DIFF
--- a/docs-www/source/zscript/lang/scripts.rst
+++ b/docs-www/source/zscript/lang/scripts.rst
@@ -28,6 +28,8 @@ Scripts are capable of being targetted with a number of :ref:`annotations<annota
 
 For `String` values, the number in parentheses is the maximum length, in characters.
 
+These annotations take a single value:
+
 .. table::
 	:widths: auto
 	
@@ -44,20 +46,20 @@ For `String` values, the number in parentheses is the maximum length, in charact
 	+-----------------------------------------+-----------------+-----------------------------------------------+
 	| `@FlagHelp0` - `@FlagHelp15`            | String (65535)  | Sets help text in the Combo / Item editors.   |
 	+-----------------------------------------+-----------------+-----------------------------------------------+
-	| `@Attribyte0` - `@Attribyte8`           | String (256)    | Sets labels in the Combo editor.              |
+	| `@Attribyte0` - `@Attribyte7`           | String (256)    | Sets labels in the Combo editor.              |
 	+-----------------------------------------+-----------------+-----------------------------------------------+
-	| `@AttribyteHelp0` - `@AttribyteHelp8`   | String (65535)  | Sets help text in the Combo editor.           |
+	| `@AttribyteHelp0` - `@AttribyteHelp7`   | String (65535)  | Sets help text in the Combo editor.           |
 	+-----------------------------------------+-----------------+-----------------------------------------------+
-	| `@Attrishort0` - `@Attrishort8`         | String (256)    | Sets labels in the Combo editor.              |
+	| `@Attrishort0` - `@Attrishort7`         | String (256)    | Sets labels in the Combo editor.              |
 	+-----------------------------------------+-----------------+-----------------------------------------------+
-	| `@AttrishortHelp0` - `@AttrishortHelp8` | String (65535)  | Sets help text in the Combo editor.           |
+	| `@AttrishortHelp0` - `@AttrishortHelp7` | String (65535)  | Sets help text in the Combo editor.           |
 	+-----------------------------------------+-----------------+-----------------------------------------------+
-	| `@InitD0` - `@InitD8`                   | String (256)    | Sets labels for the `void run` parameters.    |
+	| `@InitD0` - `@InitD7`                   | String (256)    | Sets labels for the `void run` parameters.    |
 	|                                         |                 | Defaults to the parameter names.              |
 	+-----------------------------------------+-----------------+-----------------------------------------------+
-	| `@InitDHelp0` - `@InitDHelp8`           | String (65535)  | Sets help text for the `void run` parameters. |
+	| `@InitDHelp0` - `@InitDHelp7`           | String (65535)  | Sets help text for the `void run` parameters. |
 	+-----------------------------------------+-----------------+-----------------------------------------------+
-	| `@InitDType0` - `@InitDType8`           | "D", "H", "LD", | Sets the input field type of the textbox for  |
+	| `@InitDType0` - `@InitDType7`           | "D", "H", "LD", | Sets the input field type of the textbox for  |
 	|                                         | "LH", "B", "-1" | inputting the `void run` parameters. Default  |
 	|                                         |                 | based on `void run` parameter type, as:       |
 	|                                         |                 |                                               |
@@ -83,3 +85,26 @@ For `String` values, the number in parentheses is the maximum length, in charact
 	|                                         |                 | value if this annotation is not provided.     |
 	+-----------------------------------------+-----------------+-----------------------------------------------+
 
+These annotations take a varying amount of values.
+A value in [square brackets] indicates an 'optional' value.
+
+.. table::
+	:widths: auto
+	
+	+-----------------------------------------+-----------------------------------------------+-----------------------------------------------+
+	| Annotation Name                         | Values                                        | Purpose                                       |
+	+=========================================+===============================================+===============================================+
+	| `@ExportInitD0` - `@ExportInitD7`       | | Name: String (256)                          | Sets the labels, helptext, and input field    |
+	|                                         | | Help Text: [String (65535)]                 | type of the textbox for the specified         |
+	|                                         | | Type: ["D", "H", "LD", "LH", "B", "-1"]     | `void run` parameters.                        |
+	|                                         |                                               |                                               |
+	|                                         |                                               | Name defaults to the variable name, help text |
+	|                                         |                                               | defaults to blank, and type defaults based on |
+	|                                         |                                               | variable type, as:                            |
+	|                                         |                                               |                                               |
+	|                                         |                                               | | `int`, `float`, `untyped` -> "D"            |
+	|                                         |                                               | | `long` -> "LD"                              |
+	|                                         |                                               | | `bool` -> "B"                               |
+	|                                         |                                               | | `rgb` -> "LH"                               |
+	|                                         |                                               | | else -> "-1"                                |
+	+-----------------------------------------+-----------------------------------------------+-----------------------------------------------+

--- a/src/parser/AST.cpp
+++ b/src/parser/AST.cpp
@@ -663,14 +663,8 @@ void ASTStringList::execute(ASTVisitor& visitor, void* param)
 
 // ASTAnnotation
 
-ASTAnnotation::ASTAnnotation(ASTString* key, ASTString* strval, LocationData const& location)
-	: AST(location), key(key), strval(strval), intval()
-{}
-ASTAnnotation::ASTAnnotation(ASTString* key, ASTFloat* intval, LocationData const& location)
-	: AST(location), key(key), strval(), intval(intval)
-{}
-ASTAnnotation::ASTAnnotation(ASTString* key, LocationData const& location)
-	: AST(location), key(key), strval(), intval()
+ASTAnnotation::ASTAnnotation(LocationData const& location)
+	: AST(location), key(), params()
 {}
 
 void ASTAnnotation::execute(ASTVisitor&, void*)

--- a/src/parser/AST.h
+++ b/src/parser/AST.h
@@ -402,20 +402,28 @@ namespace ZScript
 		owning_vector<ASTString> strings;
 	};
 
+	struct AnnotationParam
+	{
+		AnnotationParam(ASTString* ptr)
+			: is_string(true), strval(ptr), intval()
+		{}
+		AnnotationParam(ASTFloat* ptr)
+			: is_string(false), strval(), intval(ptr)
+		{}
+		bool is_string;
+		owning_ptr<ASTString> strval;
+		owning_ptr<ASTFloat> intval;
+	};
 	class ASTAnnotation : public AST
 	{
 	public:
-		ASTAnnotation(ASTString* key, ASTString* strval,
-		          LocationData const& location = LOC_NONE);
-		ASTAnnotation(ASTString* key, ASTFloat* intval,
-		          LocationData const& location = LOC_NONE);
-		ASTAnnotation(ASTString* key, LocationData const& location = LOC_NONE);
+		ASTAnnotation(LocationData const& location = LOC_NONE);
 		ASTAnnotation* clone() const {return new ASTAnnotation(*this);}
 		
 		void execute(ASTVisitor& visitor, void* param = NULL);
 		
-		owning_ptr<ASTString> key, strval;
-		owning_ptr<ASTFloat> intval;
+		owning_ptr<ASTString> key;
+		vector<AnnotationParam> params;
 	};
 	
 	class ASTAnnotationList : public AST

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -18,8 +18,9 @@
 #include "zsyssimple.h"
 #include "parser/ParserHelper.h"
 #include "base/util.h"
+#include "base/headers.h"
+#include <fmt/ranges.h>
 
-using std::string;
 using std::ostringstream;
 using namespace ZScript;
 
@@ -52,7 +53,7 @@ void trunc_str(std::string& str, size_t sz, std::string const& header, int32_t r
 	}
 }
 
-enum
+enum AnnotationParamType
 {
 	ANNTY_NONE,
 	ANNTY_STR,
@@ -64,91 +65,223 @@ static string annot_tys[ANNTY_MAX] = {"Empty", "String", "Number"};
 int annot_row, annot_col;
 string annot_err_txt;
 static const string annot_err_header = "ERROR: Bad Annotation Value";
+struct AnnotParamData
+{
+	string strval, val, unescaped_val;
+	zfix intval;
+	AnnotationParamType type;
+};
 struct AnnotData
 {
-	string key, strval;
-	string val, unescaped_val;
-	zfix intval;
-	uint type;
+	string key;
+	vector<AnnotParamData> params;
 	YYLTYPE location;
 };
-void annot_errstr(string const& message, YYLTYPE const& loc)
+static void annot_errstr(string const& message, YYLTYPE const& loc)
 {
 	zconsole_error(message.c_str());
 	zparser_error_out(message, ZScript::LocationData(loc));
 }
-void annot_trunc_str(string& str, size_t size)
+static void annot_trunc_str(string& str, size_t size)
 {
 	trunc_str(str, size, annot_err_header, annot_row, annot_col, annot_err_txt.c_str());
 }
-bool annot_type_check(uint expected, AnnotData const& data)
+
+
+static optional<int8_t> annot_param_check_swaptype(AnnotData& data, size_t param_idx)
 {
-	if(expected == data.type)
-		return true;
-	annot_errstr("ERROR: Bad Annotation Value: @"+data.key
-		+" expects a "+annot_tys[expected]+", not a "+annot_tys[data.type], data.location);
-	return false;
+	auto& pdata = data.params[param_idx];
+	assert(pdata.type == ANNTY_STR);
+	if (pdata.val == "-1")
+		return -1;
+	util::upperstr(pdata.val);
+	if (pdata.val.size() == 2 && pdata.val[0] == 'L')
+	{
+		switch(pdata.val[1])
+		{
+			case 'D': return nswapLDEC;
+			case 'H': return nswapLHEX;
+		}
+	}
+	else if (pdata.val.size() == 1)
+	{
+		switch (pdata.val[0])
+		{
+			case 'D': return nswapDEC;
+			case 'H': return nswapHEX;
+			case 'B': return nswapBOOL;
+		}
+	}
+	
+	annot_errstr(
+		fmt::format("ERROR: Bad Annotation Value: '@{}' parameter {} must be"
+			" exactly 'D','H','LD','LH','B', or '-1' NOT '{}'.",
+			data.key, param_idx, pdata.strval), data.location);
+	return nullopt;
 }
-void annot_incompatible(string const& key1, string const& key2, YYLTYPE const& loc)
+static bool annot_sig_check(AnnotData const& data, vector<vector<AnnotationParamType>> signature)
 {
-	annot_errstr(fmt::format("ERROR: Annotation '@{}' not compatible with '@{}'", key1, key2), loc);
+	size_t max = signature.size();
+	size_t min = max;
+	for (int idx = int(signature.size()-1); idx >= 0; --idx)
+	{
+		auto& sigvec = signature[idx];
+		if (util::contains(sigvec, ANNTY_NONE)) // optional
+		{
+			assert(min == idx+1); // can't have a required after an optional!
+			--min;
+			util::remove_if_exists(sigvec, ANNTY_NONE);
+		}
+		assert(!sigvec.empty());
+	}
+	
+	auto sz = data.params.size();
+	
+	// check param count
+	{
+		string err_word;
+		size_t err_sz;
+		if (max == min)
+		{
+			if (sz != min)
+			{
+				err_word = "exactly";
+				err_sz = min;
+			}
+		}
+		else
+		{
+			assert(min < max);
+			if (sz < min)
+			{
+				err_word = "at least";
+				err_sz = min;
+			}
+			else if (sz > max)
+			{
+				err_word = "at most";
+				err_sz = max;
+			}
+		}
+		
+		if (!err_word.empty())
+		{
+			annot_errstr(fmt::format("ERROR: Bad Annotation Value: @{} expects"
+				" {} {} parameter{}, not {} parameter{}!", data.key, err_word,
+				err_sz, err_sz == 1 ? "" : "s",
+				sz, sz == 1 ? "" : "s"), data.location);
+			return false;
+		}
+	}
+	// check param types
+	{
+		for (size_t idx = 0; idx < sz; ++idx)
+		{
+			auto& pdata = data.params[idx];
+			auto& sigvec = signature[idx];
+			if (util::contains(sigvec, pdata.type))
+				continue;
+			string s;
+			if (sigvec.size() == 1)
+				s = fmt::format("type '{}'", annot_tys[sigvec[0]]);
+			else
+			{
+				vector<string> tynames;
+				for (auto ty : sigvec)
+					tynames.push_back(annot_tys[ty]);
+				s = fmt::format("one of types '{}'", fmt::join(tynames, ", "));
+			}
+			annot_errstr(fmt::format("ERROR: Bad Annotation Value: @{} expects parameter {} to be {}, not type '{}'",
+				data.key, idx, s, annot_tys[pdata.type]), data.location);
+			return false;
+		}
+	}
+	return true;
 }
-void handle_annotations(ASTAnnotationList* list, std::function<bool(AnnotData&)> fn)
+static bool annot_sig_check_1(AnnotationParamType expected, AnnotData const& data)
+{
+	return annot_sig_check(data, {{expected}});
+}
+
+static void handle_annotations(ASTAnnotationList* list, std::function<bool(AnnotData&, map<string, std::set<string>>&)> fn)
 {
 	owning_vector<ASTAnnotation>& set = list->set;
 	annot_row = list->location.first_line;
 	annot_col = list->location.first_column;
-	std::set<std::string> used_keys;
+	std::set<string> used_keys;
+	map<string, std::set<string>> excl_keys;
 	for(size_t q = 0; q < set.size(); ++q)
 	{
 		ASTAnnotation* a = set[q];
 		AnnotData data = AnnotData();
 		data.key = a->key->getValue();
-		data.type = ANNTY_NONE;
-		data.strval = "";
-		data.intval = 0;
-		if(a->strval)
+		for (auto& param : a->params)
 		{
-			data.type = ANNTY_STR;
-			data.strval = a->strval->getValue();
+			auto& pdata = data.params.emplace_back();
+			
+			pdata.strval = "";
+			pdata.intval = 0;
+			if(param.is_string)
+			{
+				pdata.type = ANNTY_STR;
+				pdata.strval = param.strval->getValue();
+			}
+			else if(param.intval)
+			{
+				pdata.type = ANNTY_INT;
+				pdata.intval = zslongToFix(param.intval->getValue());
+			}
+			else assert(false);
+			
+			pdata.val = "";
+			pdata.unescaped_val = "";
+			switch (pdata.type)
+			{
+				case ANNTY_STR:
+					pdata.val = pdata.strval;
+					pdata.unescaped_val = util::disallow_escapes(util::escape_characters(pdata.strval));
+					break;
+				case ANNTY_INT:
+					pdata.val = pdata.unescaped_val = pdata.intval.str();
+					break;
+			}
 		}
-		else if(a->intval)
+		ostringstream oss;
+		oss << "@" << data.key << "(";
+		for (size_t q = 0; q < data.params.size(); ++q)
 		{
-			data.type = ANNTY_INT;
-			data.intval = zslongToFix(a->intval->getValue());
+			if (q)
+				oss << ", ";
+			oss << data.params[q].val;
 		}
-		
-		data.val = "";
-		data.unescaped_val = "";
-		switch(data.type)
-		{
-			case ANNTY_STR:
-				data.val = data.strval;
-				data.unescaped_val = util::disallow_escapes(util::escape_characters(data.strval));
-				break;
-			case ANNTY_INT:
-				data.val = data.unescaped_val = data.intval.str();
-				break;
-		}
-		annot_err_txt = "@" + data.key + "(" + data.val + ")";
+		oss << ")";
+		annot_err_txt = oss.str();
 
 		data.location.first_line = a->location.first_line;
 		data.location.first_column = a->location.first_column;
 		data.location.last_line = a->location.last_line;
 		data.location.last_column = a->location.last_column;
 		
-		if(used_keys.contains(data.key))
+		if (used_keys.contains(data.key))
 		{
 			annot_errstr("ERROR: Duplicate Annotation Key: @"+data.key+" was already set.", data.location);
 			continue;
 		}
-		if(!fn(data))
+		if (excl_keys.contains(data.key))
+		{
+			vector<string> bad_keys;
+			for (auto& bad_key : excl_keys[data.key])
+				bad_keys.push_back(fmt::format("'@{}'", bad_key));
+			annot_errstr(fmt::format("ERROR: Annotation '@{}' not compatible with '@{}'", data.key, fmt::join(bad_keys, ", ")), data.location);
+			continue;
+		}
+		if(!fn(data, excl_keys))
 			annot_errstr("ERROR: Bad Annotation Key: '"+data.key+"'", data.location);
 	}
 	delete list;
 }
 
-ASTExpr* handle_statement_expr(ASTExpr* expr)
+static ASTExpr* handle_statement_expr(ASTExpr* expr)
 {
 	if(ASTExprIncrement* increm = dynamic_cast<ASTExprIncrement*>(expr))
 	{
@@ -1050,22 +1183,25 @@ Annotated_Script :
 	Annotation_List Script {
 		ASTAnnotationList* list = (ASTAnnotationList*)$1;
 		ASTScript* script = (ASTScript*)$2;
-		handle_annotations(list, [&](AnnotData& data)
+		handle_annotations(list, [&](AnnotData& data, map<string, std::set<string>>& excl_keys)
 		{
+			AnnotParamData* p1 = nullptr;
+			if (data.params.size() > 0)
+				p1 = &data.params[0];
 			auto& key = data.key;
 			if(key == "Author")
 			{
-				if(annot_type_check(ANNTY_STR, data))
+				if(annot_sig_check_1(ANNTY_STR, data))
 				{
-					annot_trunc_str(data.unescaped_val, 255);
-					script->metadata.author = data.unescaped_val;
+					annot_trunc_str(p1->unescaped_val, 255);
+					script->metadata.author = p1->unescaped_val;
 				}
 				return true;
 			}
 			else if(key == "InitScript")
 			{
-				if(annot_type_check(ANNTY_INT, data))
-					script->init_weight = data.intval.getZLong();
+				if(annot_sig_check_1(ANNTY_INT, data))
+					script->init_weight = p1->intval.getZLong();
 				return true;
 			}
 			else if((key.size() == 5 || key.size() == 6) && !key.compare(0,4,"Flag"))
@@ -1075,10 +1211,10 @@ Annotated_Script :
 					c = (c*10)+key[5]-'0';
 				if(c < 16)
 				{
-					if(annot_type_check(ANNTY_STR, data))
+					if(annot_sig_check_1(ANNTY_STR, data))
 					{
-						annot_trunc_str(data.unescaped_val, 255);
-						script->metadata.usrflags[c] = data.unescaped_val;
+						annot_trunc_str(p1->unescaped_val, 255);
+						script->metadata.usrflags[c] = p1->unescaped_val;
 					}
 					return true;
 				}
@@ -1090,10 +1226,10 @@ Annotated_Script :
 					c = (c*10)+key[9]-'0';
 				if(c < 16)
 				{
-					if(annot_type_check(ANNTY_STR, data))
+					if(annot_sig_check_1(ANNTY_STR, data))
 					{
-						annot_trunc_str(data.val, 65535);
-						script->metadata.usrflags_help[c] = data.val;
+						annot_trunc_str(p1->val, 65535);
+						script->metadata.usrflags_help[c] = p1->val;
 					}
 					return true;
 				}
@@ -1103,11 +1239,12 @@ Annotated_Script :
 				byte c = key[5]-'0';
 				if(c < 8)
 				{
-					if(annot_type_check(ANNTY_STR, data))
+					if(annot_sig_check_1(ANNTY_STR, data))
 					{
-						annot_trunc_str(data.unescaped_val, 255);
-						script->metadata.initd[c] = data.unescaped_val;
+						annot_trunc_str(p1->unescaped_val, 255);
+						script->metadata.initd[c] = p1->unescaped_val;
 					}
+					excl_keys[fmt::format("ExportInitD{}", c)].insert(key);
 					return true;
 				}
 			}
@@ -1118,34 +1255,12 @@ Annotated_Script :
 				{
 					if(c < 8)
 					{
-						if(annot_type_check(ANNTY_STR, data))
+						if(annot_sig_check_1(ANNTY_STR, data))
 						{
-							int8_t v = -1;
-							util::upperstr(data.val);
-							if(data.val.size() == 2 && data.val[0] == 'L')
-							{
-								switch(data.val[1])
-								{
-									case 'D': v = nswapLDEC; break;
-									case 'H': v = nswapLHEX; break;
-								}
-							}
-							else if(data.val.size() == 1)
-							{
-								switch(data.val[0])
-								{
-									case 'D': v = nswapDEC; break;
-									case 'H': v = nswapHEX; break;
-									case 'B': v = nswapBOOL; break;
-								}
-							}
-							if(unsigned(v) < nswapMAX)
-								script->metadata.initd_type[c] = v;
-							else if(data.val == "-1")
-								script->metadata.initd_type[c] = -1;
-							else annot_errstr("ERROR: Bad Annotation Value: '@" + key + "' must be"
-									" exactly 'D','H','LD','LH','B', or '-1' NOT '" + data.strval + "'.", data.location);
+							if (auto v = annot_param_check_swaptype(data, 0))
+								script->metadata.initd_type[c] = *v;
 						}
+						excl_keys[fmt::format("ExportInitD{}", c)].insert(key);
 						return true;
 					}
 				}
@@ -1153,11 +1268,12 @@ Annotated_Script :
 				{
 					if(c < 8)
 					{
-						if(annot_type_check(ANNTY_STR, data))
+						if(annot_sig_check_1(ANNTY_STR, data))
 						{
-							annot_trunc_str(data.val, 65535);
-							script->metadata.initd_help[c] = data.val;
+							annot_trunc_str(p1->val, 65535);
+							script->metadata.initd_help[c] = p1->val;
 						}
+						excl_keys[fmt::format("ExportInitD{}", c)].insert(key);
 						return true;
 					}
 				}
@@ -1165,10 +1281,10 @@ Annotated_Script :
 				{
 					if(c < 10) // 1 digit number
 					{
-						if(annot_type_check(ANNTY_STR, data))
+						if(annot_sig_check_1(ANNTY_STR, data))
 						{
-							annot_trunc_str(data.unescaped_val, 255);
-							script->metadata.attributes[c] = data.unescaped_val;
+							annot_trunc_str(p1->unescaped_val, 255);
+							script->metadata.attributes[c] = p1->unescaped_val;
 						}
 						return true;
 					}
@@ -1177,10 +1293,10 @@ Annotated_Script :
 				{
 					if(c < 8)
 					{
-						if(annot_type_check(ANNTY_STR, data))
+						if(annot_sig_check_1(ANNTY_STR, data))
 						{
-							annot_trunc_str(data.unescaped_val, 255);
-							script->metadata.attributes[8+c] = data.unescaped_val;
+							annot_trunc_str(p1->unescaped_val, 255);
+							script->metadata.attributes[8+c] = p1->unescaped_val;
 						}
 						return true;
 					}
@@ -1195,10 +1311,10 @@ Annotated_Script :
 						byte c = atoi(key.c_str()+9);
 						if (c < NUM_ZMETA_ATTRIBUTES)
 						{
-							if(annot_type_check(ANNTY_STR, data))
+							if(annot_sig_check_1(ANNTY_STR, data))
 							{
-								annot_trunc_str(data.unescaped_val, 255);
-								script->metadata.attributes[c] = data.unescaped_val;
+								annot_trunc_str(p1->unescaped_val, 255);
+								script->metadata.attributes[c] = p1->unescaped_val;
 							}
 							return true;
 						}
@@ -1209,11 +1325,53 @@ Annotated_Script :
 					byte c = key[10]-'0';
 					if(c < 8)
 					{
-						if(annot_type_check(ANNTY_STR, data))
+						if(annot_sig_check_1(ANNTY_STR, data))
 						{
-							annot_trunc_str(data.unescaped_val, 255);
-							script->metadata.attributes[16+c] = data.unescaped_val;
+							annot_trunc_str(p1->unescaped_val, 255);
+							script->metadata.attributes[16+c] = p1->unescaped_val;
 						}
+						return true;
+					}
+				}
+			}
+			else if(key.size() == 12)
+			{
+				if(!key.compare(0,11,"ExportInitD"))
+				{
+					byte c = key[11]-'0';
+					if (c < 8)
+					{
+						if (annot_sig_check(data,
+							{
+								{ANNTY_STR},
+								{ANNTY_NONE, ANNTY_STR},
+								{ANNTY_NONE, ANNTY_STR}
+							}))
+						{
+							auto sz = data.params.size();
+							if (sz >= 3)
+							{
+								if (auto v = annot_param_check_swaptype(data, 2))
+									script->metadata.initd_type[c] = *v;
+							}
+							
+							if (sz >= 2)
+							{
+								auto& param = data.params[1];
+								annot_trunc_str(param.val, 65535);
+								script->metadata.initd_help[c] = param.val;
+							}
+							
+							// if (sz >= 1)
+							{
+								auto& param = data.params[0];
+								annot_trunc_str(param.unescaped_val, 255);
+								script->metadata.initd[c] = param.unescaped_val;
+							}
+						}
+						excl_keys[fmt::format("InitD{}", c)].insert(key);
+						excl_keys[fmt::format("InitDHelp{}", c)].insert(key);
+						excl_keys[fmt::format("InitDType{}", c)].insert(key);
 						return true;
 					}
 				}
@@ -1225,10 +1383,10 @@ Annotated_Script :
 					byte c = key[13]-'0';
 					if(c < 10) // 1 digit number
 					{
-						if(annot_type_check(ANNTY_STR, data))
+						if(annot_sig_check_1(ANNTY_STR, data))
 						{
-							annot_trunc_str(data.val, 65535);
-							script->metadata.attributes_help[c] = data.val;
+							annot_trunc_str(p1->val, 65535);
+							script->metadata.attributes_help[c] = p1->val;
 						}
 						return true;
 					}
@@ -1238,10 +1396,10 @@ Annotated_Script :
 					byte c = key[13]-'0';
 					if(c < 8)
 					{
-						if(annot_type_check(ANNTY_STR, data))
+						if(annot_sig_check_1(ANNTY_STR, data))
 						{
-							annot_trunc_str(data.val, 65535);
-							script->metadata.attributes_help[8+c] = data.val;
+							annot_trunc_str(p1->val, 65535);
+							script->metadata.attributes_help[8+c] = p1->val;
 						}
 						return true;
 					}
@@ -1256,10 +1414,10 @@ Annotated_Script :
 						byte c = atoi(key.c_str()+13);
 						if(c < NUM_ZMETA_ATTRIBUTES)
 						{
-							if(annot_type_check(ANNTY_STR, data))
+							if(annot_sig_check_1(ANNTY_STR, data))
 							{
-								annot_trunc_str(data.val, 65535);
-								script->metadata.attributes_help[c] = data.val;
+								annot_trunc_str(p1->val, 65535);
+								script->metadata.attributes_help[c] = p1->val;
 							}
 							return true;
 						}
@@ -1270,10 +1428,10 @@ Annotated_Script :
 					byte c = key[14]-'0';
 					if(c < 8)
 					{
-						if(annot_type_check(ANNTY_STR, data))
+						if(annot_sig_check_1(ANNTY_STR, data))
 						{
-							annot_trunc_str(data.val, 65535);
-							script->metadata.attributes_help[16+c] = data.val;
+							annot_trunc_str(p1->val, 65535);
+							script->metadata.attributes_help[16+c] = p1->val;
 						}
 						return true;
 					}
@@ -1362,43 +1520,61 @@ Annotation_List :
 	;
 
 Annotation :
-	HANDLE IDENTIFIER LPAREN QuotedString RPAREN {
+	HANDLE IDENTIFIER LPAREN AnnotArgList RPAREN {
 		ASTString* key = (ASTString*)$2;
-		ASTString* val = (ASTString*)$4;
-		ASTAnnotation* a = new ASTAnnotation(key, val, @$);
-		a->doc_comment = std::move(key->doc_comment);
-		$$ = a;}
-	| HANDLE IDENTIFIER LPAREN NUMBER RPAREN {
-		ASTString* key = (ASTString*)$2;
-		ASTFloat* val = (ASTFloat*)$4;
-		ASTAnnotation* a = new ASTAnnotation(key, val, @$);
-		a->doc_comment = std::move(key->doc_comment);
-		$$ = a;}
-	| HANDLE IDENTIFIER LPAREN LONGNUMBER RPAREN {
-		ASTString* key = (ASTString*)$2;
-		ASTFloat* val = (ASTFloat*)$4;
-		ASTAnnotation* a = new ASTAnnotation(key, val, @$);
-		a->doc_comment = std::move(key->doc_comment);
-		$$ = a;}
-	| HANDLE IDENTIFIER LPAREN MINUS NUMBER RPAREN {
-		ASTString* key = (ASTString*)$2;
-		ASTFloat* val = (ASTFloat*)$5;
-		val->negative = !val->negative;
-		ASTAnnotation* a = new ASTAnnotation(key, val, @$);
-		a->doc_comment = std::move(key->doc_comment);
-		$$ = a;}
-	| HANDLE IDENTIFIER LPAREN MINUS LONGNUMBER RPAREN {
-		ASTString* key = (ASTString*)$2;
-		ASTFloat* val = (ASTFloat*)$5;
-		val->negative = !val->negative;
-		ASTAnnotation* a = new ASTAnnotation(key, val, @$);
+		ASTAnnotation* a = (ASTAnnotation*)$4;
+		a->key = key;
+		a->location = @$;
 		a->doc_comment = std::move(key->doc_comment);
 		$$ = a;}
 	| HANDLE IDENTIFIER LPAREN RPAREN {
 		ASTString* key = (ASTString*)$2;
-		ASTAnnotation* a = new ASTAnnotation(key, @$);
+		ASTAnnotation* a = new ASTAnnotation(@$);
+		a->key = key;
 		a->doc_comment = std::move(key->doc_comment);
 		$$ = a;}
+	;
+
+AnnotArgList :
+	AnnotArgList COMMA AnnotFloat {
+		ASTAnnotation* a = (ASTAnnotation*)$1;
+		a->params.emplace_back((ASTFloat*)$3);
+		$$ = a;
+	}
+	| AnnotArgList COMMA AnnotStr {
+		ASTAnnotation* a = (ASTAnnotation*)$1;
+		a->params.emplace_back((ASTString*)$3);
+		$$ = a;
+	}
+	| AnnotFloat {
+		ASTAnnotation* a = new ASTAnnotation(@$);
+		a->params.emplace_back((ASTFloat*)$1);
+		$$ = a;
+	}
+	| AnnotStr {
+		ASTAnnotation* a = new ASTAnnotation(@$);
+		a->params.emplace_back((ASTString*)$1);
+		$$ = a;
+	}
+	;
+
+AnnotFloat :
+	NUMBER {$$ = $1;}
+	| LONGNUMBER {$$ = $1;}
+	| MINUS NUMBER {
+		ASTFloat* val = (ASTFloat*)$2;
+		val->negative = !val->negative;
+		$$ = val;
+	}
+	| MINUS LONGNUMBER {
+		ASTFloat* val = (ASTFloat*)$2;
+		val->negative = !val->negative;
+		$$ = val;
+	}
+	;
+
+AnnotStr :
+	QuotedString {$$ = $1;}
 	;
 
 ////////////////////////////////////////////////////////////////
@@ -1695,21 +1871,24 @@ Annotated_Loop :
 	Annotation_List Statement_Loop {
 		ASTAnnotationList* list = (ASTAnnotationList*)$1;
 		ASTStmtRangeLoop* loop = (ASTStmtRangeLoop*)$2;
-		handle_annotations(list, [&](AnnotData& data)
+		handle_annotations(list, [&](AnnotData& data, map<string, std::set<string>>&)
 		{
+			AnnotParamData* p1 = nullptr;
+			if (data.params.size() > 0)
+				p1 = &data.params[0];
 			auto& key = data.key;
 			if(key == "AlwaysRunEndpoint")
 			{
-				if(annot_type_check(ANNTY_STR, data))
+				if(annot_sig_check_1(ANNTY_STR, data))
 				{
-					if(data.strval == "off")
+					if(p1->strval == "off")
 						loop->overflow = ASTStmtRangeLoop::OVERFLOW_ALLOW;
-					else if(data.strval == "int")
+					else if(p1->strval == "int")
 						loop->overflow = ASTStmtRangeLoop::OVERFLOW_INT;
-					else if(data.strval == "long" || data.strval == "float")
+					else if(p1->strval == "long" || p1->strval == "float")
 						loop->overflow = ASTStmtRangeLoop::OVERFLOW_LONG;
 					else annot_errstr(annot_err_header+": '@"+key+"' must be"
-							" exactly 'off','int','float', or 'long', NOT '" + data.strval + "'.", data.location);
+							" exactly 'off','int','float', or 'long', NOT '" + p1->strval + "'.", data.location);
 				}
 				return true;
 			}
@@ -1885,28 +2064,29 @@ Annotated_Enum:
 		{
 			if (!list->doc_comment.empty()) en->doc_comment = std::move(list->doc_comment);
 		}
-		handle_annotations(list, [&](AnnotData& data)
+		handle_annotations(list, [&](AnnotData& data, map<string, std::set<string>>& excl_keys)
 		{
+			AnnotParamData* p1 = nullptr;
+			if (data.params.size() > 0)
+				p1 = &data.params[0];
 			auto& key = data.key;
 			if(key == "Increment")
 			{
-				if(en->getBitMode() != ASTDataEnum::BIT_NONE)
-					annot_incompatible("Increment", "Bitflags", data.location);
-				else if(annot_type_check(ANNTY_INT, data))
-					en->increment_val = data.intval;
+				if(annot_sig_check_1(ANNTY_INT, data))
+					en->increment_val = p1->intval;
+				excl_keys["Bitflags"].insert(key);
 				return true;
 			}
 			else if(key == "Bitflags")
 			{
-				if(en->increment_val)
-					annot_incompatible("Bitflags", "Increment", data.location);
-				else if(annot_type_check(ANNTY_STR, data))
+				if(annot_sig_check_1(ANNTY_STR, data))
 				{
-					if(data.strval == "int")
+					if(p1->strval == "int")
 						en->setBitMode(ASTDataEnum::BIT_INT);
-					else if(data.strval == "long")
+					else if(p1->strval == "long")
 						en->setBitMode(ASTDataEnum::BIT_LONG);
 				}
+				excl_keys["Increment"].insert(key);
 				return true;
 			}
 			return false;

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -91,7 +91,7 @@ static void annot_trunc_str(string& str, size_t size)
 static optional<int8_t> annot_param_check_swaptype(AnnotData& data, size_t param_idx)
 {
 	auto& pdata = data.params[param_idx];
-	assert(pdata.type == ANNTY_STR);
+	CHECK(pdata.type == ANNTY_STR);
 	if (pdata.val == "-1")
 		return -1;
 	util::upperstr(pdata.val);
@@ -128,11 +128,11 @@ static bool annot_sig_check(AnnotData const& data, vector<vector<AnnotationParam
 		auto& sigvec = signature[idx];
 		if (util::contains(sigvec, ANNTY_NONE)) // optional
 		{
-			assert(min == idx+1); // can't have a required after an optional!
+			CHECK(min == idx+1); // can't have a required after an optional!
 			--min;
 			util::remove_if_exists(sigvec, ANNTY_NONE);
 		}
-		assert(!sigvec.empty());
+		CHECK(!sigvec.empty());
 	}
 	
 	auto sz = data.params.size();
@@ -151,7 +151,7 @@ static bool annot_sig_check(AnnotData const& data, vector<vector<AnnotationParam
 		}
 		else
 		{
-			assert(min < max);
+			CHECK(min < max);
 			if (sz < min)
 			{
 				err_word = "at least";
@@ -231,7 +231,7 @@ static void handle_annotations(ASTAnnotationList* list, std::function<bool(Annot
 				pdata.type = ANNTY_INT;
 				pdata.intval = zslongToFix(param.intval->getValue());
 			}
-			else assert(false);
+			else CHECK(false);
 			
 			pdata.val = "";
 			pdata.unescaped_val = "";
@@ -272,7 +272,7 @@ static void handle_annotations(ASTAnnotationList* list, std::function<bool(Annot
 			vector<string> bad_keys;
 			for (auto& bad_key : excl_keys[data.key])
 				bad_keys.push_back(fmt::format("'@{}'", bad_key));
-			annot_errstr(fmt::format("ERROR: Annotation '@{}' not compatible with '@{}'", data.key, fmt::join(bad_keys, ", ")), data.location);
+			annot_errstr(fmt::format("ERROR: Annotation '@{}' not compatible with {}", data.key, fmt::join(bad_keys, ", ")), data.location);
 			continue;
 		}
 		if(!fn(data, excl_keys))
@@ -1362,7 +1362,7 @@ Annotated_Script :
 								script->metadata.initd_help[c] = param.val;
 							}
 							
-							// if (sz >= 1)
+							if (sz >= 1)
 							{
 								auto& param = data.params[0];
 								annot_trunc_str(param.unescaped_val, 255);

--- a/tests/scripts/errors/errors_8_expected.txt
+++ b/tests/scripts/errors/errors_8_expected.txt
@@ -2,7 +2,7 @@ stderr:
 
 Compiling 'errors_8.zs'
 Pass 1: Parsing
-ERROR: Bad Annotation Value: @Author expects a String, not a Number
+ERROR: Bad Annotation Value: @Author expects parameter 0 to be type 'String', not type 'Number'
 
 
 13    
@@ -32,7 +32,7 @@ stdout:
         }
       },
       "severity": 1,
-      "message": "ERROR: Bad Annotation Value: @Author expects a String, not a Number"
+      "message": "ERROR: Bad Annotation Value: @Author expects parameter 0 to be type 'String', not type 'Number'"
     }
   ]
 }

--- a/tests/scripts/errors/errors_annotations.zs
+++ b/tests/scripts/errors/errors_annotations.zs
@@ -6,7 +6,20 @@ void badAnnotation()
     }
 }
 
-@Authors("asd")
+@Authors("asd"),
+@Author(1),
+@ExportInitD0(2),
+@ExportInitD1("Foo", 3),
+@ExportInitD2("Bar", "Error", 4),
+@ExportInitD3("FooBar", 5, 6),
+@ExportInitD4(7, 8, 9),
+@ExportInitD5(),
+@ExportInitD6(1, 2, 3, 4, 5, 6, 7),
+@ExportInitD7("Error", "Test", "Some Random Value"),
+@Author(),
+@InitD0("Overlap"),
+@ExportInitD0("Overlap"),
+@ExportInitD8("Doesn't Exist")
 ffc script BadAnnotatedScript
 {
 	void run(){}

--- a/tests/scripts/errors/errors_annotations_expected.txt
+++ b/tests/scripts/errors/errors_annotations_expected.txt
@@ -16,8 +16,116 @@ ERROR: Bad Annotation Key: 'Authors'
 
  7    }
  8    
- 9    @Authors("asd")
+ 9    @Authors("asd"),
       ^~~~~~~~~~~~~~~
+
+
+ERROR: Bad Annotation Value: @Author expects parameter 0 to be type 'String', not type 'Number'
+
+
+ 8    
+ 9    @Authors("asd"),
+10    @Author(1),
+      ^~~~~~~~~~
+
+
+ERROR: Bad Annotation Value: @ExportInitD0 expects parameter 0 to be type 'String', not type 'Number'
+
+
+ 9    @Authors("asd"),
+10    @Author(1),
+11    @ExportInitD0(2),
+      ^~~~~~~~~~~~~~~~
+
+
+ERROR: Bad Annotation Value: @ExportInitD1 expects parameter 1 to be type 'String', not type 'Number'
+
+
+10    @Author(1),
+11    @ExportInitD0(2),
+12    @ExportInitD1("Foo", 3),
+      ^~~~~~~~~~~~~~~~~~~~~~~
+
+
+ERROR: Bad Annotation Value: @ExportInitD2 expects parameter 2 to be type 'String', not type 'Number'
+
+
+11    @ExportInitD0(2),
+12    @ExportInitD1("Foo", 3),
+13    @ExportInitD2("Bar", "Error", 4),
+      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+ERROR: Bad Annotation Value: @ExportInitD3 expects parameter 1 to be type 'String', not type 'Number'
+
+
+12    @ExportInitD1("Foo", 3),
+13    @ExportInitD2("Bar", "Error", 4),
+14    @ExportInitD3("FooBar", 5, 6),
+      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+ERROR: Bad Annotation Value: @ExportInitD4 expects parameter 0 to be type 'String', not type 'Number'
+
+
+13    @ExportInitD2("Bar", "Error", 4),
+14    @ExportInitD3("FooBar", 5, 6),
+15    @ExportInitD4(7, 8, 9),
+      ^~~~~~~~~~~~~~~~~~~~~~
+
+
+ERROR: Bad Annotation Value: @ExportInitD5 expects at least 1 parameter, not 0 parameters!
+
+
+14    @ExportInitD3("FooBar", 5, 6),
+15    @ExportInitD4(7, 8, 9),
+16    @ExportInitD5(),
+      ^~~~~~~~~~~~~~~
+
+
+ERROR: Bad Annotation Value: @ExportInitD6 expects at most 3 parameters, not 7 parameters!
+
+
+15    @ExportInitD4(7, 8, 9),
+16    @ExportInitD5(),
+17    @ExportInitD6(1, 2, 3, 4, 5, 6, 7),
+      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+ERROR: Bad Annotation Value: '@ExportInitD7' parameter 2 must be exactly 'D','H','LD','LH','B', or '-1' NOT 'Some Random Value'.
+
+
+16    @ExportInitD5(),
+17    @ExportInitD6(1, 2, 3, 4, 5, 6, 7),
+18    @ExportInitD7("Error", "Test", "Some Random Value"),
+      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+ERROR: Bad Annotation Value: @Author expects exactly 1 parameter, not 0 parameters!
+
+
+17    @ExportInitD6(1, 2, 3, 4, 5, 6, 7),
+18    @ExportInitD7("Error", "Test", "Some Random Value"),
+19    @Author(),
+      ^~~~~~~~~
+
+
+ERROR: Annotation '@InitD0' not compatible with '@ExportInitD0'
+
+
+18    @ExportInitD7("Error", "Test", "Some Random Value"),
+19    @Author(),
+20    @InitD0("Overlap"),
+      ^~~~~~~~~~~~~~~~~~
+
+
+ERROR: Bad Annotation Key: 'ExportInitD8'
+
+
+20    @InitD0("Overlap"),
+21    @ExportInitD0("Overlap"),
+22    @ExportInitD8("Doesn't Exist")
+      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
 Failure!
@@ -56,6 +164,174 @@ stdout:
       },
       "severity": 1,
       "message": "ERROR: Bad Annotation Key: 'Authors'"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 0
+        },
+        "end": {
+          "line": 9,
+          "character": 10
+        }
+      },
+      "severity": 1,
+      "message": "ERROR: Bad Annotation Value: @Author expects parameter 0 to be type 'String', not type 'Number'"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 0
+        },
+        "end": {
+          "line": 10,
+          "character": 16
+        }
+      },
+      "severity": 1,
+      "message": "ERROR: Bad Annotation Value: @ExportInitD0 expects parameter 0 to be type 'String', not type 'Number'"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 11,
+          "character": 0
+        },
+        "end": {
+          "line": 11,
+          "character": 23
+        }
+      },
+      "severity": 1,
+      "message": "ERROR: Bad Annotation Value: @ExportInitD1 expects parameter 1 to be type 'String', not type 'Number'"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 0
+        },
+        "end": {
+          "line": 12,
+          "character": 32
+        }
+      },
+      "severity": 1,
+      "message": "ERROR: Bad Annotation Value: @ExportInitD2 expects parameter 2 to be type 'String', not type 'Number'"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 0
+        },
+        "end": {
+          "line": 13,
+          "character": 29
+        }
+      },
+      "severity": 1,
+      "message": "ERROR: Bad Annotation Value: @ExportInitD3 expects parameter 1 to be type 'String', not type 'Number'"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 14,
+          "character": 0
+        },
+        "end": {
+          "line": 14,
+          "character": 22
+        }
+      },
+      "severity": 1,
+      "message": "ERROR: Bad Annotation Value: @ExportInitD4 expects parameter 0 to be type 'String', not type 'Number'"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 0
+        },
+        "end": {
+          "line": 15,
+          "character": 15
+        }
+      },
+      "severity": 1,
+      "message": "ERROR: Bad Annotation Value: @ExportInitD5 expects at least 1 parameter, not 0 parameters!"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 16,
+          "character": 0
+        },
+        "end": {
+          "line": 16,
+          "character": 34
+        }
+      },
+      "severity": 1,
+      "message": "ERROR: Bad Annotation Value: @ExportInitD6 expects at most 3 parameters, not 7 parameters!"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 0
+        },
+        "end": {
+          "line": 17,
+          "character": 51
+        }
+      },
+      "severity": 1,
+      "message": "ERROR: Bad Annotation Value: '@ExportInitD7' parameter 2 must be exactly 'D','H','LD','LH','B', or '-1' NOT 'Some Random Value'."
+    },
+    {
+      "range": {
+        "start": {
+          "line": 18,
+          "character": 0
+        },
+        "end": {
+          "line": 18,
+          "character": 9
+        }
+      },
+      "severity": 1,
+      "message": "ERROR: Bad Annotation Value: @Author expects exactly 1 parameter, not 0 parameters!"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 19,
+          "character": 0
+        },
+        "end": {
+          "line": 19,
+          "character": 18
+        }
+      },
+      "severity": 1,
+      "message": "ERROR: Annotation '@InitD0' not compatible with '@ExportInitD0'"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 21,
+          "character": 0
+        },
+        "end": {
+          "line": 21,
+          "character": 30
+        }
+      },
+      "severity": 1,
+      "message": "ERROR: Bad Annotation Key: 'ExportInitD8'"
     }
   ]
 }

--- a/tests/scripts/misc/annotations.zs
+++ b/tests/scripts/misc/annotations.zs
@@ -1,0 +1,10 @@
+
+@ExportInitD0("Speed", "In pixels/frame"),
+@ExportInitD1("Delay", "In frames"),
+@ExportInitD2("Secrets?", "Trigger secrets or not?", "B"),
+@ExportInitD3("Screen", "Other screen to interact with", "H")
+ffc script foo
+{
+	void run(int a, int b, int c, int d)
+	{}
+}

--- a/tests/scripts/misc/annotations_expected.txt
+++ b/tests/scripts/misc/annotations_expected.txt
@@ -1,0 +1,38 @@
+stderr:
+
+Compiling 'annotations.zs'
+Pass 1: Parsing
+Pass 2: Preprocessing
+Pass 3: Registration
+Pass 4: Analyzing Code
+Pass 5: Checking code paths
+Pass 6: Generating object code
+Pass 7: Assembling
+Success!
+Compile finished with exit code '0' (success)
+
+stdout:
+
+{
+  "success": true,
+  "diagnostics": [],
+  "metadata": {
+    "currentFileSymbols": 2,
+    "symbols": 2,
+    "identifiers": 2,
+    "elided": true
+  }
+}
+
+zasm:
+
+QUIT; void run() Body
+PUSHR D0; void run(int, int, int, int) Params
+PUSHR D1
+PUSHR D2
+PUSHR D3
+PUSHR REFFFC; void run(int, int, int, int) Body Start
+SETR D4 SP2
+NOP
+POPARGS D5 0.0005
+RETURNFUNC; void run(int, int, int, int) Body End


### PR DESCRIPTION
Using multiple annotations for one thing is a bit bulky. With this new annotation, specify all the information about an InitD at once! ex. `@ExportInitD0("Speed", "Movement Speed in px/frame")` to specify a name + helptext. A 3rd parameter can be supplied to specify the field type. This combines `@InitD0()`, `@InitDHelp0()`, and `@InitDType0()` into a single annotation.

end changelog

This refactors the annotation code to handle different numbers of parameters, instead of being limited to only exactly 0 or 1 parameter.