### PR TITLE
fix(zc): coyote time jumps eating an 'extra jump'

### DIFF
--- a/src/zc/hero.cpp
+++ b/src/zc/hero.cpp
@@ -11207,7 +11207,8 @@ bool HeroClass::do_jump(int32_t jumpid, bool passive)
 	
 	if(!standing)
 	{
-		++extra_jump_count;
+		if (!coyotejump)
+			++extra_jump_count;
 		fall = 0;
 		fakefall = 0;
 		if(hoverclk > 0)


### PR DESCRIPTION
roc items with both coyote time and 'extra jumps' would lose one 'extra jump' when executing a coyote time jump.