### PR TITLE
docs: fix typo succesive -> successive

### DIFF
--- a/resources/docs/zscript.txt
+++ b/resources/docs/zscript.txt
@@ -2814,7 +2814,7 @@ void DrawString( 	int layer, int x, int y,
 					SETRENDERTARGET
 
 	/**
-	* Sets the target bitmap for all succesive drawing commands.
+	* Sets the target bitmap for all successive drawing commands.
 	* These can be directly to the screen or any one of the available off-screen bitmaps,
 	* which are generally categorized as -1(screen) or 0-bitmapNumber(off-screen).
 	*


### PR DESCRIPTION
Corrects the misspelling `succesive` -> `successive` in `resources/docs/zscript.txt`.

Documentation only, no behaviour change.